### PR TITLE
More Operations

### DIFF
--- a/program.anzu
+++ b/program.anzu
@@ -1,6 +1,6 @@
+0 -> x
 
-
-20 while dup 10 >= do
-    dup .
-    1 -
+while x 10 < do
+    x .
+    x 1 + -> x
 end

--- a/program.anzu
+++ b/program.anzu
@@ -13,16 +13,3 @@
 end
 
 count .
-
-// Project Euler #1 Using OR operator, index stored in heap
-0 -> count
-0 -> index
-
-while index 1000 < do
-    if index 3 % 0 == index 5 % 0 == or do
-        index count + -> count
-    end
-    index 1 + -> index
-end
-
-count .

--- a/program.anzu
+++ b/program.anzu
@@ -1,6 +1,6 @@
 
 
-0 while dup 10 < do
+20 while dup 10 >= do
     dup .
-    1 +
+    1 -
 end

--- a/program.anzu
+++ b/program.anzu
@@ -1,3 +1,4 @@
+// Program for Project Euler #1
 0 -> count
 
 0 while dup 1000 < do

--- a/program.anzu
+++ b/program.anzu
@@ -1,5 +1,6 @@
 
 
-0 while dup 10 != do
-    dup . 1 +
+0 while dup 10 < do
+    dup .
+    1 +
 end

--- a/program.anzu
+++ b/program.anzu
@@ -1,6 +1,14 @@
-0 -> x
+0 -> count
 
-while x 10 < do
-    x .
-    x 1 + -> x
+0 while dup 1000 < do
+    if dup 3 % 0 == do
+        dup count + -> count
+    else
+        if dup 5 % 0 == do
+            dup count + -> count
+        end 
+    end
+    1 +
 end
+
+count .

--- a/program.anzu
+++ b/program.anzu
@@ -1,4 +1,4 @@
-// Program for Project Euler #1
+// Project Euler #1 No OR operator, index stored in stack
 0 -> count
 
 0 while dup 1000 < do
@@ -10,6 +10,19 @@
         end 
     end
     1 +
+end
+
+count .
+
+// Project Euler #1 Using OR operator, index stored in heap
+0 -> count
+0 -> index
+
+while index 1000 < do
+    if index 3 % 0 == index 5 % 0 == or do
+        index count + -> count
+    end
+    index 1 + -> index
 end
 
 count .

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -13,6 +13,8 @@
 #include <fstream>
 #include <sstream>
 
+namespace {
+
 bool is_literal(const std::string& token)
 {
     return token == "false"
@@ -41,6 +43,8 @@ std::string next(std::vector<std::string>::iterator& it)
     return *it;
 }
 
+}
+
 constexpr auto OP_STORE       = std::string_view{"->"};
 constexpr auto OP_DUMP        = std::string_view{"."};
 constexpr auto OP_POP         = std::string_view{"pop"};
@@ -64,6 +68,7 @@ constexpr auto OP_GT          = std::string_view{">"};
 constexpr auto OP_GE          = std::string_view{">="};
 constexpr auto OP_OR          = std::string_view{"or"};
 constexpr auto OP_AND         = std::string_view{"and"};
+constexpr auto OP_INPUT       = std::string_view{"input"};
 
 std::vector<anzu::op> load_program(const std::string& file)
 {
@@ -245,6 +250,9 @@ std::vector<anzu::op> load_program(const std::string& file)
         else if (token == OP_AND) {
             program.push_back(anzu::op_and{});
         }
+        else if (token == OP_INPUT) {
+            program.push_back(anzu::op_input{});
+        }
         else if (is_literal(token)) {
             program.push_back(anzu::op_push_const{
                 .value=parse_literal(token)
@@ -285,8 +293,14 @@ int main(int argc, char** argv)
     fmt::print("Running file {}\n", file);
     auto program = load_program(file);
     
-    run_program(program);
-    //for (const auto& op : program) { std::visit([](auto&& o) { o.print(); }, op); }
+    //run_program(program);
+    int lineno = 0;
+    for (const auto& op : program) {
+        std::visit([&](auto&& o) {
+            fmt::print("{:>4} - ", lineno++);
+            o.print();
+        }, op);
+    }
 
     return 0;
 }

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -282,24 +282,47 @@ void run_program(const std::vector<anzu::op>& program)
     }
 }
 
-int main(int argc, char** argv)
+void print_program(const std::vector<anzu::op>& program)
 {
-    if (argc != 2) {
-        fmt::print("Print usage\n");
-        return 0;
-    }
-
-    auto file = std::string{argv[1]};
-    fmt::print("Running file {}\n", file);
-    auto program = load_program(file);
-    
-    //run_program(program);
     int lineno = 0;
     for (const auto& op : program) {
         std::visit([&](auto&& o) {
             fmt::print("{:>4} - ", lineno++);
             o.print();
         }, op);
+    }
+}
+
+void print_usage()
+{
+    fmt::print("usage: anzu.exe (run|print) <program_file>\n\n");
+    fmt::print("The Anzu Programming Language\n\n");
+    fmt::print("run:   executes the program\n");
+    fmt::print("print: prints the program as a series of op codes\n");
+}
+
+int main(int argc, char** argv)
+{
+    if (argc != 3) {
+        print_usage();
+        return 1;
+    }
+
+    const auto mode = std::string{argv[1]};
+    const auto file = std::string{argv[2]};
+
+    fmt::print("Loading file {}\n", file);
+    const auto program = load_program(file);
+    
+    if (mode == "print") {
+        print_program(program);
+    }
+    else if (mode == "run") {
+        run_program(program);
+    }
+    else {
+        print_usage();
+        return 1;
     }
 
     return 0;

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -297,8 +297,9 @@ void print_usage()
 {
     fmt::print("usage: anzu.exe (run|print) <program_file>\n\n");
     fmt::print("The Anzu Programming Language\n\n");
-    fmt::print("run:   executes the program\n");
-    fmt::print("print: prints the program as a series of op codes\n");
+    fmt::print("options:\n");
+    fmt::print("    run   - executes the program\n");
+    fmt::print("    print - displays the program bytecode\n");
 }
 
 int main(int argc, char** argv)

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -62,6 +62,8 @@ constexpr auto OP_LT          = std::string_view{"<"};
 constexpr auto OP_LE          = std::string_view{"<="};
 constexpr auto OP_GT          = std::string_view{">"};
 constexpr auto OP_GE          = std::string_view{">="};
+constexpr auto OP_OR          = std::string_view{"or"};
+constexpr auto OP_AND         = std::string_view{"and"};
 
 std::vector<anzu::op> load_program(const std::string& file)
 {
@@ -236,6 +238,12 @@ std::vector<anzu::op> load_program(const std::string& file)
         }
         else if (token == OP_GE) {
             program.push_back(anzu::op_ge{});
+        }
+        else if (token == OP_OR) {
+            program.push_back(anzu::op_or{});
+        }
+        else if (token == OP_AND) {
+            program.push_back(anzu::op_and{});
         }
         else if (is_literal(token)) {
             program.push_back(anzu::op_push_const{

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -312,7 +312,7 @@ int main(int argc, char** argv)
     const auto mode = std::string{argv[1]};
     const auto file = std::string{argv[2]};
 
-    fmt::print("Loading file {}\n", file);
+    fmt::print("loading file '{}'\n", file);
     const auto program = load_program(file);
     
     if (mode == "print") {
@@ -322,6 +322,7 @@ int main(int argc, char** argv)
         run_program(program);
     }
     else {
+        fmt::print("unknown mode: '{}'\n", mode);
         print_usage();
         return 1;
     }

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -40,14 +40,14 @@ std::string next(std::vector<std::string>::iterator& it)
     return *it;
 }
 
-constexpr auto OP_STORE_NEW   = std::string_view{"->"};
+constexpr auto OP_STORE       = std::string_view{"->"};
 constexpr auto OP_DUMP        = std::string_view{"."};
-constexpr auto OP_STORE       = std::string_view{"let"};
 constexpr auto OP_POP         = std::string_view{"pop"};
 constexpr auto OP_ADD         = std::string_view{"+"};
 constexpr auto OP_SUB         = std::string_view{"-"};
 constexpr auto OP_MUL         = std::string_view{"*"};
 constexpr auto OP_DIV         = std::string_view{"/"};
+constexpr auto OP_MOD         = std::string_view{"%"};
 constexpr auto OP_DUP         = std::string_view{"dup"};
 constexpr auto OP_PRINT_FRAME = std::string_view{"frame"};
 constexpr auto OP_DO          = std::string_view{"do"};
@@ -80,7 +80,7 @@ std::vector<anzu::op> load_program(const std::string& file)
     while (it != tokens.end()) {
         const auto& token = *it;
 
-        if (token == OP_STORE_NEW) {
+        if (token == OP_STORE) {
             program.push_back(anzu::op_store{
                 .name=next(it)
             });
@@ -90,21 +90,6 @@ std::vector<anzu::op> load_program(const std::string& file)
         }
         else if (token == OP_POP) {
             program.push_back(anzu::op_pop{});
-        }
-        else if (token == OP_STORE) {
-            auto name = next(it);
-            auto val = next(it);
-            if (is_literal(val)) {
-                program.push_back(anzu::op_store_const{
-                    .name=name,
-                    .value=parse_literal(val)
-                });
-            } else {
-                program.push_back(anzu::op_store_var{
-                    .name=name,
-                    .source=val
-                });
-            }
         }
         else if (token == OP_ADD) {
             program.push_back(anzu::op_add{});
@@ -117,6 +102,9 @@ std::vector<anzu::op> load_program(const std::string& file)
         }
         else if (token == OP_DIV) {
             program.push_back(anzu::op_div{});
+        }
+        else if (token == OP_MOD) {
+            program.push_back(anzu::op_mod{});
         }
         else if (token == OP_DUP) {
             program.push_back(anzu::op_dup{});

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -40,6 +40,7 @@ std::string next(std::vector<std::string>::iterator& it)
     return *it;
 }
 
+constexpr auto OP_STORE_NEW   = std::string_view{"->"};
 constexpr auto OP_DUMP        = std::string_view{"."};
 constexpr auto OP_STORE       = std::string_view{"let"};
 constexpr auto OP_POP         = std::string_view{"pop"};
@@ -79,7 +80,12 @@ std::vector<anzu::op> load_program(const std::string& file)
     while (it != tokens.end()) {
         const auto& token = *it;
 
-        if (token == OP_DUMP) {
+        if (token == OP_STORE_NEW) {
+            program.push_back(anzu::op_store{
+                .name=next(it)
+            });
+        }
+        else if (token == OP_DUMP) {
             program.push_back(anzu::op_dump{});
         }
         else if (token == OP_POP) {

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -11,6 +11,7 @@
 #include <tuple>
 #include <utility>
 #include <fstream>
+#include <sstream>
 
 bool is_literal(const std::string& token)
 {
@@ -64,10 +65,18 @@ constexpr auto OP_GE          = std::string_view{">="};
 
 std::vector<anzu::op> load_program(const std::string& file)
 {
-    std::ifstream stream{file};
+    // Loop over the lines in the program, and then split each line into tokens.
+    // If a '//' comment symbol is hit, the rest of the line is ignored.
     std::vector<std::string> tokens;
-    for (const auto& token : std::ranges::istream_view<std::string>(stream)) {
-        tokens.push_back(token);
+    std::ifstream file_stream{file};
+    std::string line;
+    while (std::getline(file_stream, line)) {
+        std::istringstream line_stream{line};
+        for (const auto& token : std::ranges::istream_view<std::string>(line_stream)
+                               | std::views::take_while([](auto&& tok) { return tok != "//"; }))
+        {
+            tokens.push_back(token);
+        }
     }
 
     std::vector<anzu::op> program;

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -45,6 +45,8 @@ constexpr auto OP_STORE       = std::string_view{"let"};
 constexpr auto OP_POP         = std::string_view{"pop"};
 constexpr auto OP_ADD         = std::string_view{"+"};
 constexpr auto OP_SUB         = std::string_view{"-"};
+constexpr auto OP_MUL         = std::string_view{"*"};
+constexpr auto OP_DIV         = std::string_view{"/"};
 constexpr auto OP_DUP         = std::string_view{"dup"};
 constexpr auto OP_PRINT_FRAME = std::string_view{"frame"};
 constexpr auto OP_DO          = std::string_view{"do"};
@@ -103,6 +105,12 @@ std::vector<anzu::op> load_program(const std::string& file)
         }
         else if (token == OP_SUB) {
             program.push_back(anzu::op_sub{});
+        }
+        else if (token == OP_MUL) {
+            program.push_back(anzu::op_mul{});
+        }
+        else if (token == OP_DIV) {
+            program.push_back(anzu::op_div{});
         }
         else if (token == OP_DUP) {
             program.push_back(anzu::op_dup{});

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -40,20 +40,21 @@ std::string next(std::vector<std::string>::iterator& it)
     return *it;
 }
 
-constexpr auto OP_DUMP         = std::string_view{"."};
-constexpr auto OP_STORE        = std::string_view{"let"};
-constexpr auto OP_POP          = std::string_view{"pop"};
-constexpr auto OP_ADD          = std::string_view{"+"};
-constexpr auto OP_SUB          = std::string_view{"-"};
-constexpr auto OP_DUP          = std::string_view{"dup"};
-constexpr auto OP_PRINT_FRAME  = std::string_view{"frame"};
-constexpr auto OP_DO           = std::string_view{"do"};
-constexpr auto OP_WHILE        = std::string_view{"while"};
-constexpr auto OP_IF           = std::string_view{"if"};
-constexpr auto OP_ELSE         = std::string_view{"else"};
-constexpr auto OP_END          = std::string_view{"end"};
-constexpr auto OP_EQUALS       = std::string_view{"=="};
-constexpr auto OP_NOT_EQUALS   = std::string_view{"!="};
+constexpr auto OP_DUMP        = std::string_view{"."};
+constexpr auto OP_STORE       = std::string_view{"let"};
+constexpr auto OP_POP         = std::string_view{"pop"};
+constexpr auto OP_ADD         = std::string_view{"+"};
+constexpr auto OP_SUB         = std::string_view{"-"};
+constexpr auto OP_DUP         = std::string_view{"dup"};
+constexpr auto OP_PRINT_FRAME = std::string_view{"frame"};
+constexpr auto OP_DO          = std::string_view{"do"};
+constexpr auto OP_WHILE       = std::string_view{"while"};
+constexpr auto OP_IF          = std::string_view{"if"};
+constexpr auto OP_ELSE        = std::string_view{"else"};
+constexpr auto OP_END         = std::string_view{"end"};
+constexpr auto OP_EQ          = std::string_view{"=="};
+constexpr auto OP_NE          = std::string_view{"!="};
+constexpr auto OP_LT          = std::string_view{"<"};
 
 std::vector<anzu::op> load_program(const std::string& file)
 {
@@ -204,11 +205,14 @@ std::vector<anzu::op> load_program(const std::string& file)
                 std::exit(1);
             }
         }
-        else if (token == OP_EQUALS) {
-            program.push_back(anzu::op_equals{});
+        else if (token == OP_EQ) {
+            program.push_back(anzu::op_eq{});
         }
-        else if (token == OP_NOT_EQUALS) {
-            program.push_back(anzu::op_not_equals{});
+        else if (token == OP_NE) {
+            program.push_back(anzu::op_ne{});
+        }
+        else if (token == OP_LT) {
+            program.push_back(anzu::op_lt{});
         }
         else if (is_literal(token)) {
             program.push_back(anzu::op_push_const{

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -55,6 +55,9 @@ constexpr auto OP_END         = std::string_view{"end"};
 constexpr auto OP_EQ          = std::string_view{"=="};
 constexpr auto OP_NE          = std::string_view{"!="};
 constexpr auto OP_LT          = std::string_view{"<"};
+constexpr auto OP_LE          = std::string_view{"<="};
+constexpr auto OP_GT          = std::string_view{">"};
+constexpr auto OP_GE          = std::string_view{">="};
 
 std::vector<anzu::op> load_program(const std::string& file)
 {
@@ -213,6 +216,15 @@ std::vector<anzu::op> load_program(const std::string& file)
         }
         else if (token == OP_LT) {
             program.push_back(anzu::op_lt{});
+        }
+        else if (token == OP_LE) {
+            program.push_back(anzu::op_le{});
+        }
+        else if (token == OP_GT) {
+            program.push_back(anzu::op_gt{});
+        }
+        else if (token == OP_GE) {
+            program.push_back(anzu::op_ge{});
         }
         else if (is_literal(token)) {
             program.push_back(anzu::op_push_const{

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -4,6 +4,12 @@ namespace anzu {
 
 template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 
+int op_store::apply(anzu::stack_frame& frame) const
+{
+    frame.load(name, frame.pop());
+    return 1;
+}
+
 int op_dump::apply(anzu::stack_frame& frame) const
 {
     anzu::print_value(frame.pop());

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -157,4 +157,49 @@ int op_lt::apply(anzu::stack_frame& frame) const
     return 1;
 }
 
+int op_le::apply(anzu::stack_frame& frame) const
+{
+    auto b = frame.pop();
+    auto a = frame.pop();
+    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
+        if constexpr (std::is_same_v<A, B>) {
+            frame.push(a <= b);
+        } else {
+            fmt::print("Can only compare values of the same type\n");
+            std::exit(1);
+        }
+    }, a, b);
+    return 1;
+}
+
+int op_gt::apply(anzu::stack_frame& frame) const
+{
+    auto b = frame.pop();
+    auto a = frame.pop();
+    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
+        if constexpr (std::is_same_v<A, B>) {
+            frame.push(a > b);
+        } else {
+            fmt::print("Can only compare values of the same type\n");
+            std::exit(1);
+        }
+    }, a, b);
+    return 1;
+}
+
+int op_ge::apply(anzu::stack_frame& frame) const
+{
+    auto b = frame.pop();
+    auto a = frame.pop();
+    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
+        if constexpr (std::is_same_v<A, B>) {
+            frame.push(a >= b);
+        } else {
+            fmt::print("Can only compare values of the same type\n");
+            std::exit(1);
+        }
+    }, a, b);
+    return 1;
+}
+
 }

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -1,8 +1,37 @@
 #include "op_codes.hpp"
 
+#include <iostream>
+#include <string>
+
 namespace anzu {
+namespace {
+
+// Move these elsewhere
+bool is_literal(const std::string& token)
+{
+    return token == "false"
+        || token == "true"
+        || token.find_first_not_of("0123456789") == std::string::npos;
+}
+
+anzu::stack_frame::type parse_literal(const std::string& token)
+{
+    if (token == "true") {
+        return true;
+    }
+    if (token == "false") {
+        return false;
+    }
+    if (token.find_first_not_of("0123456789") == std::string::npos) {
+        return std::stoi(token);
+    }
+    fmt::print("[Fatal] Could not parse constant: {}\n", token);
+    std::exit(1);
+}
 
 template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+
+}
 
 int op_store::apply(anzu::stack_frame& frame) const
 {
@@ -268,6 +297,20 @@ int op_and::apply(anzu::stack_frame& frame) const
             std::exit(1);
         }
     }, a, b);
+    return 1;
+}
+
+int op_input::apply(anzu::stack_frame& frame) const
+{
+    frame.pop();
+    fmt::print("Input: ");
+    std::string in;
+    std::cin >> in;
+    if (!is_literal(in)) {
+        fmt::print("[BAD INPUT]\n");
+        std::exit(1);
+    }
+    frame.push(parse_literal(in));
     return 1;
 }
 

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -29,21 +29,9 @@ int op_push_const::apply(anzu::stack_frame& frame) const
     return 1;
 }
 
-int op_store_const::apply(anzu::stack_frame& frame) const
-{
-    frame.load(name, value);
-    return 1;
-}
-
 int op_push_var::apply(anzu::stack_frame& frame) const
 {
     frame.push(frame.fetch(name));
-    return 1;
-}
-
-int op_store_var::apply(anzu::stack_frame& frame) const
-{
-    frame.load(name, frame.fetch(source));
     return 1;
 }
 
@@ -99,6 +87,21 @@ int op_div::apply(anzu::stack_frame& frame) const
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
         if constexpr (std::is_same_v<A, int> && std::is_same_v<B, int>) {
             frame.push(a / b);
+        } else {
+            fmt::print("Can only sub integers\n");
+            std::exit(1);
+        }
+    }, a, b);
+    return 1;
+}
+
+int op_mod::apply(anzu::stack_frame& frame) const
+{
+    auto b = frame.pop();
+    auto a = frame.pop();
+    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
+        if constexpr (std::is_same_v<A, int> && std::is_same_v<B, int>) {
+            frame.push(a % b);
         } else {
             fmt::print("Can only sub integers\n");
             std::exit(1);

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -71,6 +71,36 @@ int op_sub::apply(anzu::stack_frame& frame) const
     return 1;
 }
 
+int op_mul::apply(anzu::stack_frame& frame) const
+{
+    auto b = frame.pop();
+    auto a = frame.pop();
+    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
+        if constexpr (std::is_same_v<A, int> && std::is_same_v<B, int>) {
+            frame.push(a * b);
+        } else {
+            fmt::print("Can only add integers\n");
+            std::exit(1);
+        }
+    }, a, b);
+    return 1;
+}
+
+int op_div::apply(anzu::stack_frame& frame) const
+{
+    auto b = frame.pop();
+    auto a = frame.pop();
+    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
+        if constexpr (std::is_same_v<A, int> && std::is_same_v<B, int>) {
+            frame.push(a / b);
+        } else {
+            fmt::print("Can only sub integers\n");
+            std::exit(1);
+        }
+    }, a, b);
+    return 1;
+}
+
 int op_dup::apply(anzu::stack_frame& frame) const
 {
     frame.push(frame.peek());

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -112,7 +112,7 @@ int op_end::apply(anzu::stack_frame& frame) const
     return jump;
 }
 
-int op_equals::apply(anzu::stack_frame& frame) const
+int op_eq::apply(anzu::stack_frame& frame) const
 {
     auto b = frame.pop();
     auto a = frame.pop();
@@ -127,13 +127,28 @@ int op_equals::apply(anzu::stack_frame& frame) const
     return 1;
 }
 
-int op_not_equals::apply(anzu::stack_frame& frame) const
+int op_ne::apply(anzu::stack_frame& frame) const
 {
     auto b = frame.pop();
     auto a = frame.pop();
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
         if constexpr (std::is_same_v<A, B>) {
             frame.push(a != b);
+        } else {
+            fmt::print("Can only compare values of the same type\n");
+            std::exit(1);
+        }
+    }, a, b);
+    return 1;
+}
+
+int op_lt::apply(anzu::stack_frame& frame) const
+{
+    auto b = frame.pop();
+    auto a = frame.pop();
+    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
+        if constexpr (std::is_same_v<A, B>) {
+            frame.push(a < b);
         } else {
             fmt::print("Can only compare values of the same type\n");
             std::exit(1);

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -241,4 +241,34 @@ int op_ge::apply(anzu::stack_frame& frame) const
     return 1;
 }
 
+int op_or::apply(anzu::stack_frame& frame) const
+{
+    auto b = frame.pop();
+    auto a = frame.pop();
+    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
+        if constexpr (std::is_same_v<A, bool> && std::is_same_v<B, bool>) {
+            frame.push(a || b);
+        } else {
+            fmt::print("Logical OR can only be used on bools\n");
+            std::exit(1);
+        }
+    }, a, b);
+    return 1;
+}
+
+int op_and::apply(anzu::stack_frame& frame) const
+{
+    auto b = frame.pop();
+    auto a = frame.pop();
+    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
+        if constexpr (std::is_same_v<A, bool> && std::is_same_v<B, bool>) {
+            frame.push(a && b);
+        } else {
+            fmt::print("Logical AND can only be used on bools\n");
+            std::exit(1);
+        }
+    }, a, b);
+    return 1;
+}
+
 }

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -171,6 +171,12 @@ struct op_and
     int apply(anzu::stack_frame& frame) const;
 };
 
+struct op_input
+{
+    void print() const { fmt::print("OP_INPUT\n"); }
+    int apply(anzu::stack_frame& frame) const;
+};
+
 using op = std::variant<
     op_store,
     op_dump,
@@ -196,7 +202,8 @@ using op = std::variant<
     op_gt,
     op_ge,
     op_or,
-    op_and
+    op_and,
+    op_input
 >;
 
 }

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -136,6 +136,24 @@ struct op_lt
     int apply(anzu::stack_frame& frame) const;
 };
 
+struct op_le
+{
+    void print() const { fmt::print("OP_LE\n"); }
+    int apply(anzu::stack_frame& frame) const;
+};
+
+struct op_gt
+{
+    void print() const { fmt::print("OP_GT\n"); }
+    int apply(anzu::stack_frame& frame) const;
+};
+
+struct op_ge
+{
+    void print() const { fmt::print("OP_GE\n"); }
+    int apply(anzu::stack_frame& frame) const;
+};
+
 using op = std::variant<
     op_dump,
     op_pop,
@@ -154,7 +172,8 @@ using op = std::variant<
     op_end,
     op_eq,
     op_ne,
-    op_lt
+    op_lt,
+    op_le
 >;
 
 }

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -159,6 +159,18 @@ struct op_ge
     int apply(anzu::stack_frame& frame) const;
 };
 
+struct op_or
+{
+    void print() const { fmt::print("OP_OR\n"); }
+    int apply(anzu::stack_frame& frame) const;
+};
+
+struct op_and
+{
+    void print() const { fmt::print("OP_AND\n"); }
+    int apply(anzu::stack_frame& frame) const;
+};
+
 using op = std::variant<
     op_store,
     op_dump,
@@ -182,7 +194,9 @@ using op = std::variant<
     op_lt,
     op_le,
     op_gt,
-    op_ge
+    op_ge,
+    op_or,
+    op_and
 >;
 
 }

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -70,6 +70,18 @@ struct op_sub
     int apply(anzu::stack_frame& frame) const;
 };
 
+struct op_mul
+{
+    void print() const { fmt::print("OP_MUL\n"); }
+    int apply(anzu::stack_frame& frame) const;
+};
+
+struct op_div
+{
+    void print() const { fmt::print("OP_DIV\n"); }
+    int apply(anzu::stack_frame& frame) const;
+};
+
 struct op_dup
 {
     void print() const { fmt::print("OP_DUP\n"); }
@@ -163,6 +175,8 @@ using op = std::variant<
     op_store_var,
     op_add,
     op_sub,
+    op_mul,
+    op_div,
     op_dup,
     op_print_frame,
     op_while,
@@ -173,7 +187,9 @@ using op = std::variant<
     op_eq,
     op_ne,
     op_lt,
-    op_le
+    op_le,
+    op_gt,
+    op_ge
 >;
 
 }

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -6,6 +6,14 @@
 
 namespace anzu {
 
+struct op_store
+{
+    std::string name;
+
+    void print() const { fmt::print("OP_STORE({})\n", name); }
+    int apply(anzu::stack_frame& frame) const;
+};
+
 struct op_dump
 {
     void print() const { fmt::print("OP_DUMP\n"); }
@@ -167,6 +175,7 @@ struct op_ge
 };
 
 using op = std::variant<
+    op_store,
     op_dump,
     op_pop,
     op_push_const,

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -37,32 +37,11 @@ struct op_push_const
     int apply(anzu::stack_frame& frame) const;
 };
 
-struct op_store_const
-{
-    std::string name;
-    anzu::stack_frame::type value;
-
-    void print() const {
-        fmt::print("OP_STORE_CONST({}, ", name);
-        anzu::print_value(value);
-        fmt::print(")\n"); }
-    int apply(anzu::stack_frame& frame) const;
-};
-
 struct op_push_var
 {
     std::string name;
 
     void print() const { fmt::print("OP_PUSH_VAR({})\n", name); }
-    int apply(anzu::stack_frame& frame) const;
-};
-
-struct op_store_var
-{
-    std::string name;
-    std::string source; 
-
-    void print() const { fmt::print("OP_STORE_VAR({}, {})\n", name, source); }
     int apply(anzu::stack_frame& frame) const;
 };
 
@@ -87,6 +66,12 @@ struct op_mul
 struct op_div
 {
     void print() const { fmt::print("OP_DIV\n"); }
+    int apply(anzu::stack_frame& frame) const;
+};
+
+struct op_mod
+{
+    void print() const { fmt::print("OP_MOD\n"); }
     int apply(anzu::stack_frame& frame) const;
 };
 
@@ -179,13 +164,12 @@ using op = std::variant<
     op_dump,
     op_pop,
     op_push_const,
-    op_store_const,
     op_push_var,
-    op_store_var,
     op_add,
     op_sub,
     op_mul,
     op_div,
+    op_mod,
     op_dup,
     op_print_frame,
     op_while,

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -118,15 +118,21 @@ struct op_end
     int apply(anzu::stack_frame& frame) const;
 };
 
-struct op_equals
+struct op_eq
 {
-    void print() const { fmt::print("OP_EQUALS\n"); }
+    void print() const { fmt::print("OP_EQ\n"); }
     int apply(anzu::stack_frame& frame) const;
 };
 
-struct op_not_equals
+struct op_ne
 {
-    void print() const { fmt::print("OP_NOT_EQUALS\n"); }
+    void print() const { fmt::print("OP_NE\n"); }
+    int apply(anzu::stack_frame& frame) const;
+};
+
+struct op_lt
+{
+    void print() const { fmt::print("OP_LT\n"); }
     int apply(anzu::stack_frame& frame) const;
 };
 
@@ -146,8 +152,9 @@ using op = std::variant<
     op_do,
     op_else,
     op_end,
-    op_equals,
-    op_not_equals
+    op_eq,
+    op_ne,
+    op_lt
 >;
 
 }

--- a/src/stack_frame.cpp
+++ b/src/stack_frame.cpp
@@ -30,7 +30,7 @@ auto stack_frame::empty() const -> bool
 auto stack_frame::fetch(const std::string& token) const -> type
 {
     if (!d_symbols.contains(token)) {
-        fmt::print("Error: Unknown int");
+        fmt::print("Error: Unknown value '{}'", token);
         std::exit(1);
     }
     return d_symbols.at(token);


### PR DESCRIPTION
* Add multiplication '*', division '/', and modulo '%' for integers.
* Add 'and', 'or', '<', '<=', '>', '>=' for booleans.
* Remove `let <name> <value>` as it doesn't work well for storing new calculations, and also requires separate logic for storing literals vs other symbols. Instead, replace with a "store" operator `-> <name>` which takes the value on top of the stack and stores in the given name. 'let x 5` is equivalent to `5 -> x`.
* Add ability to have comments with `//`.
* Add `input` keyword for reading literals from stdin. (Currently parses either ints and bools, will eventually just return a string when supported and users will need to cast to others).
* Enhanced the interpreter to allow for either running a program or printing the bytecode.