### PR TITLE
Break and Continue

### DIFF
--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -17,11 +17,6 @@ constexpr auto DIV         = std::string_view{"/"};
 constexpr auto MOD         = std::string_view{"%"};
 constexpr auto DUP         = std::string_view{"dup"};
 constexpr auto PRINT_FRAME = std::string_view{"frame"};
-constexpr auto DO          = std::string_view{"do"};
-constexpr auto WHILE       = std::string_view{"while"};
-constexpr auto IF          = std::string_view{"if"};
-constexpr auto ELSE        = std::string_view{"else"};
-constexpr auto END         = std::string_view{"end"};
 constexpr auto EQ          = std::string_view{"=="};
 constexpr auto NE          = std::string_view{"!="};
 constexpr auto LT          = std::string_view{"<"};
@@ -31,6 +26,17 @@ constexpr auto GE          = std::string_view{">="};
 constexpr auto OR          = std::string_view{"or"};
 constexpr auto AND         = std::string_view{"and"};
 constexpr auto INPUT       = std::string_view{"input"};
+
+// Control Flow
+constexpr auto IF          = std::string_view{"if"};
+constexpr auto ELSE        = std::string_view{"else"};
+
+constexpr auto WHILE       = std::string_view{"while"};
+constexpr auto BREAK       = std::string_view{"break"};
+constexpr auto CONTINUE    = std::string_view{"continue"};
+
+constexpr auto DO          = std::string_view{"do"};
+constexpr auto END         = std::string_view{"end"};
 
 auto parse_file(const std::string& file) -> std::vector<anzu::op>;
 


### PR DESCRIPTION
* Add `break` and `continue` keywords to use in while loops. These are implemented with `op_block_jump` under the hood.
* The tricky part here was having `break` and `continue` wrapped in `if` statements, as they would get collected up when parsing an `if` block. To fix this, `parse_if_statement` returns the op codes that it doesn't process and they get added back to the control flow stack. This can be made more efficient in the future.