### PR TITLE
Unmerge If and While Op Codes

### DIFF
--- a/program.anzu
+++ b/program.anzu
@@ -1,14 +1,11 @@
 // Project Euler #1 No OR operator, index stored in stack
 0 -> count
-input -> max
 
-0 while dup max < do
+0 while dup 1000 < do
     if dup 3 % 0 == do
         dup count + -> count
-    else
-        if dup 5 % 0 == do
-            dup count + -> count
-        end 
+    elif dup 5 % 0 == do
+        dup count + -> count
     end
     1 +
 end

--- a/program.anzu
+++ b/program.anzu
@@ -1,7 +1,8 @@
 // Project Euler #1 No OR operator, index stored in stack
 0 -> count
+input -> max
 
-0 while dup 1000 < do
+0 while dup max < do
     if dup 3 % 0 == do
         dup count + -> count
     else

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -9,7 +9,7 @@
 void run_program(const std::vector<anzu::op>& program)
 {
     anzu::stack_frame frame;
-    while (frame.ptr() < program.size()) {
+    while (frame.ptr() < std::ssize(program)) {
         std::visit([&](auto&& o) { o.apply(frame); }, program[frame.ptr()]);
     }
 }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -13,20 +13,20 @@ namespace anzu {
 namespace lexer {
 namespace {
 
-std::string next(std::vector<std::string>::iterator& it)
+inline std::string next(std::vector<std::string>::iterator& it)
 {
     return *(++it);
 }
 
 template <typename... Args>
-void exit_bad(std::string_view format, Args&&... args)
+inline void exit_bad(std::string_view format, Args&&... args)
 {
     fmt::print(format, std::forward<Args>(args)...);
     std::exit(1);
 }
 
 template <typename T>
-T pop_top(std::stack<T>& stack)
+inline T pop_top(std::stack<T>& stack)
 {
     T ret = stack.top();
     stack.pop();

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -25,136 +25,74 @@ void exit_bad(std::string_view format, Args&&... args)
     std::exit(1);
 }
 
-auto drop_front_back(int front, int back)
+template <typename T>
+T pop_top(std::stack<T>& stack)
 {
-    namespace sv = std::views;
-    return sv::drop(front) | sv::reverse | sv::drop(back) | sv::reverse;
-}
-
-void process_if_block(std::vector<anzu::op>& program, std::stack<std::ptrdiff_t>& block)
-{
-    /*
-    // We need to first strip out and breaks and continues to pass them back as they
-    // are not part of this block.
-    std::vector<std::ptrdiff_t> block;
-    std::vector<std::ptrdiff_t> ret;
-    for (auto ptr : block_raw) {
-        if (auto* op = std::get_if<anzu::op_block_jump>(&program[ptr])) {
-            if (op->type == "BREAK" || op->type == "CONTINUE") {
-                ret.push_back(ptr);
-            } else {
-                block.push_back(ptr);
-            }
-        } else {
-            block.push_back(ptr);
-        }
-    }
-
-    std::ptrdiff_t end_op_ptr = block[0];
-
-    if (block.size() == 3) { // if -> do -> end
-        std::ptrdiff_t do_op_ptr   = block[1];
-
-        auto* do_op = std::get_if<anzu::op_block_jump_if_false>(&program[do_op_ptr]);
-        if (!do_op) { exit_bad("invalid block at index {}\n", do_op_ptr); }
-        do_op->jump = end_op_ptr + 1;
-    }
-    else if (block.size() == 4) { // if -> do -> else -> end
-        std::ptrdiff_t do_op_ptr   = block[2];
-        std::ptrdiff_t else_op_ptr = block[1];
-
-        auto* do_op = std::get_if<anzu::op_block_jump_if_false>(&program[do_op_ptr]);
-        if (!do_op) { exit_bad("invalid block at index {}\n", do_op_ptr); }
-        do_op->jump = else_op_ptr + 1;
-
-        auto* else_op = std::get_if<anzu::op_block_jump>(&program[else_op_ptr]);
-        if (!else_op) { exit_bad("invalid block at index {}\n", else_op_ptr); }
-        else_op->jump = end_op_ptr + 1;
-    }
-    else {
-        fmt::print("invalid if-statement\n");
-        std::exit(1);
-    }
-
-    auto* end_op = std::get_if<anzu::op_block_end>(&program[end_op_ptr]);
-    if (!end_op) { exit_bad("invalid block at index {}\n", end_op_ptr); }
-    end_op->jump = end_op_ptr + 1;
-
+    T ret = stack.top();
+    stack.pop();
     return ret;
-    */
 }
 
-void process_while_block(std::vector<anzu::op>& program, std::stack<std::ptrdiff_t>& block)
+void process_if_block(std::vector<anzu::op>& program, std::stack<std::ptrdiff_t>& stmt_stack)
 {
-/*
-    if (block.size() >= 3) { // while -> do -> [ break -> continue -> ...] -> end
-        std::ptrdiff_t while_op_ptr = block.back();
-        std::ptrdiff_t do_op_ptr    = block.at(block.size() - 2);
-        std::ptrdiff_t end_op_ptr   = block.front();
+    std::deque<std::ptrdiff_t> block;
+    while (!std::get_if<anzu::op_if>(&program[stmt_stack.top()])) {
+        block.push_front(pop_top(stmt_stack)); // do/else/elif/end
+    }
 
-        auto* end_op = std::get_if<anzu::op_block_end>(&program[end_op_ptr]);
-        if (!end_op) { exit_bad("invalid end at index {}\n", end_op_ptr); }
-        end_op->jump = while_op_ptr;
+    auto begin_ptr = pop_top(stmt_stack); // if
+    auto end_ptr = block.back();
 
-        auto* do_op = std::get_if<anzu::op_block_jump_if_false>(&program[do_op_ptr]);
-        if (!do_op) { exit_bad("invalid do at index {}\n", do_op_ptr); }
-        do_op->jump = end_op_ptr + 1;
+    for (std::size_t i = 0; i != block.size(); ++i) {
+        std::ptrdiff_t ptr = block[i];
 
-        for (std::ptrdiff_t ptr : block | drop_front_back(1, 2)) {
-            auto* jump_op = std::get_if<anzu::op_block_jump>(&program[ptr]);
-            if (!jump_op) { exit_bad("invalid jump at index {}\n", end_op_ptr); }
-            if (jump_op->type == "BREAK") {
-                jump_op->jump = end_op_ptr + 1;
-            }
-            else if (jump_op->type == "CONTINUE") {
-                jump_op->jump = while_op_ptr;
-            }
-            else {
-                exit_bad("invalid jump type in while loop: {}\n", jump_op->type);
-            }
+        if (auto* op = std::get_if<anzu::op_do>(&program[ptr])) {
+            std::ptrdiff_t next_ptr = block[i+1]; // end or else
+            op->jump = next_ptr + 1;
+        }
+        else if (auto* op = std::get_if<anzu::op_elif>(&program[ptr])) {
+            op->jump = end_ptr;
+        }
+        else if (auto* op = std::get_if<anzu::op_else>(&program[ptr])) {
+            op->jump = end_ptr;
+        }
+        else if (auto* op = std::get_if<anzu::op_end_if>(&program[ptr])) {
+            // pass
+        }
+        else {
+            exit_bad("unexepected op in if-statement\n");
         }
     }
-    else {
-        fmt::print("invalid while-statement {}\n", block.size());
-        std::exit(1);
-    }
-*/
 }
 
-/*
-void process_control_block(
-    std::vector<anzu::op>& program,
-    std::stack<std::ptrdiff_t>& control_flow)
+void process_while_block(std::vector<anzu::op>& program, std::stack<std::ptrdiff_t>& stmt_stack)
 {
-    std::vector<std::ptrdiff_t> block;
-    while (!control_flow.empty() && !std::get_if<anzu::op_block_begin>(&program[control_flow.top()])) {
-        block.push_back(control_flow.top());
-        control_flow.pop();
+    std::deque<std::ptrdiff_t> block;
+    while (!std::get_if<anzu::op_while>(&program[stmt_stack.top()])) {
+        block.push_front(pop_top(stmt_stack)); // do/break/continue/end
     }
 
-    // Pop the block_start too
-    block.push_back(control_flow.top());
-    control_flow.pop();
+    auto begin_ptr = pop_top(stmt_stack); // while
+    auto end_ptr = block.back();
 
-    std::ptrdiff_t begin_ptr = block.back();
-    auto* begin = std::get_if<anzu::op_block_begin>(&program[begin_ptr]);
-    //auto after_end_ptr = std::size(program);
-
-    if (begin->type == "IF") {
-        auto remaining = process_if_block(program, block);
-        for (auto ptr : remaining) {
-            control_flow.push(ptr);
+    for (std::ptrdiff_t ptr : block) {
+        if (auto* op = std::get_if<anzu::op_do>(&program[ptr])) {
+            op->jump = end_ptr + 1;
+        }
+        else if (auto* op = std::get_if<anzu::op_break>(&program[ptr])) {
+            op->jump = end_ptr + 1;
+        }
+        else if (auto* op = std::get_if<anzu::op_continue>(&program[ptr])) {
+            op->jump = begin_ptr;
+        }
+        else if (auto* op = std::get_if<anzu::op_end_while>(&program[ptr])) {
+            op->jump = begin_ptr;
+        }
+        else {
+            exit_bad("unexepected op in while-statement\n");
         }
     }
-    else if (begin->type == "WHILE") {
-        process_while_block(program, block);
-    }
-    else {
-        fmt::print("unknown OP_BLOCK_BEGIN: '{}'", begin->type);
-        std::exit(1);
-    }
 }
-*/
 
 }
 
@@ -222,6 +160,10 @@ auto parse_file(const std::string& file) -> std::vector<anzu::op>
             if_stack.push(std::ssize(program));
             blocks.push("IF");
             program.push_back(anzu::op_if{});
+        }
+        else if (token == ELIF) {
+            if_stack.push(std::ssize(program));
+            program.push_back(anzu::op_elif{});
         }
         else if (token == ELSE) {
             if_stack.push(std::ssize(program));

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -29,6 +29,7 @@ constexpr auto INPUT       = std::string_view{"input"};
 
 // Control Flow
 constexpr auto IF          = std::string_view{"if"};
+constexpr auto ELIF        = std::string_view{"elif"};
 constexpr auto ELSE        = std::string_view{"else"};
 
 constexpr auto WHILE       = std::string_view{"while"};

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -271,6 +271,11 @@ void op_end_if::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
+void op_elif::apply(anzu::stack_frame& frame) const
+{
+    frame.ptr() = jump;
+}
+
 void op_else::apply(anzu::stack_frame& frame) const
 {
     frame.ptr() = jump;

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -279,7 +279,6 @@ void op_and::apply(anzu::stack_frame& frame) const
 
 void op_input::apply(anzu::stack_frame& frame) const
 {
-    frame.pop();
     fmt::print("Input: ");
     std::string in;
     std::cin >> in;
@@ -289,6 +288,55 @@ void op_input::apply(anzu::stack_frame& frame) const
     }
     frame.push(anzu::parse_literal(in));
     frame.ptr() += 1;
+}
+
+void op_if::apply(anzu::stack_frame& frame) const
+{
+    frame.ptr() += 1;
+}
+
+void op_end_if::apply(anzu::stack_frame& frame) const
+{
+    frame.ptr() += 1;
+}
+
+void op_else::apply(anzu::stack_frame& frame) const
+{
+    frame.ptr() = jump;
+}
+
+void op_while::apply(anzu::stack_frame& frame) const
+{
+    frame.ptr() += 1;
+}
+
+void op_end_while::apply(anzu::stack_frame& frame) const
+{
+    frame.ptr() = jump;
+}
+
+void op_break::apply(anzu::stack_frame& frame) const
+{
+    frame.ptr() = jump;
+}
+
+void op_continue::apply(anzu::stack_frame& frame) const
+{
+    frame.ptr() = jump;
+}
+
+void op_do::apply(anzu::stack_frame& frame) const
+{
+    auto condition = std::visit(overloaded {
+        [](int v) { return v != 0; },
+        [](bool v) { return v; }
+    }, frame.pop());
+
+    if (condition) {
+        frame.ptr() += 1;
+    } else {
+        frame.ptr() = jump;
+    }
 }
 
 }

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -128,35 +128,6 @@ void op_print_frame::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_block_begin::apply(anzu::stack_frame& frame) const
-{
-    frame.ptr() += 1;
-}
-
-void op_block_end::apply(anzu::stack_frame& frame) const
-{
-    frame.ptr() = jump;
-}
-
-void op_block_jump_if_false::apply(anzu::stack_frame& frame) const
-{
-    auto condition = std::visit(overloaded {
-        [](int v) { return v != 0; },
-        [](bool v) { return v; }
-    }, frame.pop());
-
-    if (condition) {
-        frame.ptr() += 1;
-    } else {
-        frame.ptr() = jump;
-    }
-}
-
-void op_block_jump::apply(anzu::stack_frame& frame) const
-{
-    frame.ptr() = jump;
-}
-
 void op_eq::apply(anzu::stack_frame& frame) const
 {
     auto b = frame.pop();

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -171,6 +171,64 @@ struct op_input
     void apply(anzu::stack_frame& frame) const;
 };
 
+struct op_if
+{
+    void print() const { fmt::print("OP_IF\n"); }
+    void apply(anzu::stack_frame& frame) const;
+};
+
+struct op_end_if
+{
+    void print() const { fmt::print("OP_END_IF\n"); }
+    void apply(anzu::stack_frame& frame) const;
+};
+
+struct op_else
+{
+    std::ptrdiff_t jump;
+
+    void print() const { fmt::print("OP_ELSE (to {})\n", jump); }
+    void apply(anzu::stack_frame& frame) const;
+};
+
+struct op_while
+{
+    void print() const { fmt::print("OP_WHILE\n"); }
+    void apply(anzu::stack_frame& frame) const;
+};
+
+struct op_end_while
+{
+    std::ptrdiff_t jump;
+
+    void print() const { fmt::print("OP_END_WHILE (to {})\n", jump); }
+    void apply(anzu::stack_frame& frame) const;
+};
+
+struct op_break
+{
+    std::ptrdiff_t jump;
+
+    void print() const { fmt::print("OP_BREAK (to {})\n", jump); }
+    void apply(anzu::stack_frame& frame) const;
+};
+
+struct op_continue
+{
+    std::ptrdiff_t jump;
+
+    void print() const { fmt::print("OP_CONTINUE (to {})\n", jump); }
+    void apply(anzu::stack_frame& frame) const;
+};
+
+struct op_do
+{
+    std::ptrdiff_t jump;
+
+    void print() const { fmt::print("OP_DO (to {} if false)\n", jump); }
+    void apply(anzu::stack_frame& frame) const;
+};
+
 using op = std::variant<
     op_store,
     op_dump,
@@ -196,7 +254,17 @@ using op = std::variant<
     op_ge,
     op_or,
     op_and,
-    op_input
+    op_input,
+
+    // Control Flow
+    op_if,
+    op_end_if,
+    op_else,
+    op_while,
+    op_end_while,
+    op_break,
+    op_continue,
+    op_do
 >;
 
 }

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -84,39 +84,6 @@ struct op_print_frame
     void apply(anzu::stack_frame& frame) const;
 };
 
-struct op_block_begin
-{
-    std::string type;
-
-    void print() const { fmt::print("OP_BLOCK_BEGIN ({})\n", type); }
-    void apply(anzu::stack_frame& frame) const;
-};
-
-struct op_block_end
-{
-    std::ptrdiff_t jump = -1;
-
-    void print() const { fmt::print("OP_BLOCK_END (to {})\n", jump); }
-    void apply(anzu::stack_frame& frame) const;
-};
-
-struct op_block_jump_if_false
-{
-    std::ptrdiff_t jump = -1;
-
-    void print() const { fmt::print("OP_BLOCK_JUMP_IF_FALSE (to {})\n", jump); }
-    void apply(anzu::stack_frame& frame) const;
-};
-
-struct op_block_jump
-{
-    std::string    type;
-    std::ptrdiff_t jump = -1;
-
-    void print() const { fmt::print("OP_BLOCK_JUMP ({}) (to {})\n", type, jump); }
-    void apply(anzu::stack_frame& frame) const;
-};
-
 struct op_eq
 {
     void print() const { fmt::print("OP_EQ\n"); }
@@ -242,10 +209,6 @@ using op = std::variant<
     op_mod,
     op_dup,
     op_print_frame,
-    op_block_begin,
-    op_block_end,
-    op_block_jump_if_false,
-    op_block_jump,
     op_eq,
     op_ne,
     op_lt,

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -6,6 +6,9 @@
 
 namespace anzu {
 
+constexpr auto PRINT_JUMP          = std::string_view{"{:<25} JUMP -> {}\n"};
+constexpr auto PRINT_JUMP_IF_FALSE = std::string_view{"{:<25} JUMP -> {} (IF FALSE)\n"};
+
 struct op_store
 {
     std::string name;
@@ -150,11 +153,19 @@ struct op_end_if
     void apply(anzu::stack_frame& frame) const;
 };
 
+struct op_elif
+{
+    std::ptrdiff_t jump = -1;
+
+    void print() const { fmt::print(PRINT_JUMP, "OP_ELIF", jump); }
+    void apply(anzu::stack_frame& frame) const;
+};
+
 struct op_else
 {
     std::ptrdiff_t jump = -1;
 
-    void print() const { fmt::print("OP_ELSE (to {})\n", jump); }
+    void print() const { fmt::print(PRINT_JUMP, "OP_ELSE", jump); }
     void apply(anzu::stack_frame& frame) const;
 };
 
@@ -168,7 +179,7 @@ struct op_end_while
 {
     std::ptrdiff_t jump = -1;
 
-    void print() const { fmt::print("OP_END_WHILE (to {})\n", jump); }
+    void print() const { fmt::print(PRINT_JUMP, "OP_END_WHILE", jump); }
     void apply(anzu::stack_frame& frame) const;
 };
 
@@ -176,7 +187,7 @@ struct op_break
 {
     std::ptrdiff_t jump = -1;
 
-    void print() const { fmt::print("OP_BREAK (to {})\n", jump); }
+    void print() const { fmt::print(PRINT_JUMP, "OP_BREAK", jump); }
     void apply(anzu::stack_frame& frame) const;
 };
 
@@ -184,7 +195,7 @@ struct op_continue
 {
     std::ptrdiff_t jump = -1;
 
-    void print() const { fmt::print("OP_CONTINUE (to {})\n", jump); }
+    void print() const { fmt::print(PRINT_JUMP, "OP_CONTINUE", jump); }
     void apply(anzu::stack_frame& frame) const;
 };
 
@@ -192,7 +203,7 @@ struct op_do
 {
     std::ptrdiff_t jump = -1;
 
-    void print() const { fmt::print("OP_DO (to {} if false)\n", jump); }
+    void print() const { fmt::print(PRINT_JUMP_IF_FALSE, "OP_DO", jump); }
     void apply(anzu::stack_frame& frame) const;
 };
 
@@ -222,6 +233,7 @@ using op = std::variant<
     // Control Flow
     op_if,
     op_end_if,
+    op_elif,
     op_else,
     op_while,
     op_end_while,

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -94,7 +94,7 @@ struct op_block_begin
 
 struct op_block_end
 {
-    std::ptrdiff_t jump;
+    std::ptrdiff_t jump = -1;
 
     void print() const { fmt::print("OP_BLOCK_END (to {})\n", jump); }
     void apply(anzu::stack_frame& frame) const;
@@ -102,7 +102,7 @@ struct op_block_end
 
 struct op_block_jump_if_false
 {
-    std::ptrdiff_t jump;
+    std::ptrdiff_t jump = -1;
 
     void print() const { fmt::print("OP_BLOCK_JUMP_IF_FALSE (to {})\n", jump); }
     void apply(anzu::stack_frame& frame) const;
@@ -111,7 +111,7 @@ struct op_block_jump_if_false
 struct op_block_jump
 {
     std::string    type;
-    std::ptrdiff_t jump;
+    std::ptrdiff_t jump = -1;
 
     void print() const { fmt::print("OP_BLOCK_JUMP ({}) (to {})\n", type, jump); }
     void apply(anzu::stack_frame& frame) const;
@@ -185,7 +185,7 @@ struct op_end_if
 
 struct op_else
 {
-    std::ptrdiff_t jump;
+    std::ptrdiff_t jump = -1;
 
     void print() const { fmt::print("OP_ELSE (to {})\n", jump); }
     void apply(anzu::stack_frame& frame) const;
@@ -199,7 +199,7 @@ struct op_while
 
 struct op_end_while
 {
-    std::ptrdiff_t jump;
+    std::ptrdiff_t jump = -1;
 
     void print() const { fmt::print("OP_END_WHILE (to {})\n", jump); }
     void apply(anzu::stack_frame& frame) const;
@@ -207,7 +207,7 @@ struct op_end_while
 
 struct op_break
 {
-    std::ptrdiff_t jump;
+    std::ptrdiff_t jump = -1;
 
     void print() const { fmt::print("OP_BREAK (to {})\n", jump); }
     void apply(anzu::stack_frame& frame) const;
@@ -215,7 +215,7 @@ struct op_break
 
 struct op_continue
 {
-    std::ptrdiff_t jump;
+    std::ptrdiff_t jump = -1;
 
     void print() const { fmt::print("OP_CONTINUE (to {})\n", jump); }
     void apply(anzu::stack_frame& frame) const;
@@ -223,7 +223,7 @@ struct op_continue
 
 struct op_do
 {
-    std::ptrdiff_t jump;
+    std::ptrdiff_t jump = -1;
 
     void print() const { fmt::print("OP_DO (to {} if false)\n", jump); }
     void apply(anzu::stack_frame& frame) const;


### PR DESCRIPTION
* Replacing the control op codes with `jump` and `jump_if_false` didn't actually help simplify anything, since `break` and `continue` could be nested inside if statements, which broke the model (which I fixed with hacks but didn't like).
* The solution I've gone with is handling if and while blocks separately. There is now and `if_stack` and `while_stack` which stores pointers to their corresponding constructs. There is also a stack that just stores "IF" and "WHILE" so then when we hit a `do` or `end` (which are still shared), the lexer can do different logic. Under the hood there is `op_end_while` and `op_end_if`, but only one `op_do` as it does the same thing in both cases.
* Added `elif`, which was trivial with the new implementation.