### PR TITLE
Functions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["run", "${workspaceFolder}/program.anzu"],
+            "args": ["run", "${workspaceFolder}/recursion.anzu"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/euler.anzu
+++ b/euler.anzu
@@ -1,4 +1,4 @@
-// Project Euler #1 No OR operator, index stored in stack
+// project euler #1, sum of multiple of 3 and 5 below 1000
 
 0 -> count
 
@@ -8,7 +8,7 @@
     elif dup 5 % 0 == do
         dup count + -> count
     end
-    1 +
+    1 + 
 end
+
 count .
-    

--- a/program.anzu
+++ b/program.anzu
@@ -1,13 +1,8 @@
 // Project Euler #1 No OR operator, index stored in stack
-0 -> count
 
-0 while dup 1000 < do
-    if dup 3 % 0 == do
-        dup count + -> count
-    elif dup 5 % 0 == do
-        dup count + -> count
-    end
-    1 +
+function double 1
+    dup + return
 end
 
-count .
+2 double .
+3 double .

--- a/program.anzu
+++ b/program.anzu
@@ -1,8 +1,14 @@
 // Project Euler #1 No OR operator, index stored in stack
 
-function double 1
-    dup + return
-end
+0 -> count
 
-2 double .
-3 double .
+0 while dup 1000 < do
+    if dup 3 % 0 == do
+        dup count + -> count
+    elif dup 5 % 0 == do
+        dup count + -> count
+    end
+    1 +
+end
+count .
+    

--- a/recursion.anzu
+++ b/recursion.anzu
@@ -12,7 +12,7 @@ function fibb 1
     end
 end
 
-0 while dup 20 < do
+0 while dup 10 < do
     dup fibb .
     1 + 
 end

--- a/recursion.anzu
+++ b/recursion.anzu
@@ -1,0 +1,18 @@
+// fibbonacci to demonstrate functions and recursion
+
+function fibb 1
+    if dup 0 == do
+        0 return
+    elif dup 1 == do
+        1 return
+    else
+        dup 1 - -> a
+        dup 2 - -> b
+        a fibb b fibb + return
+    end
+end
+
+0 while dup 20 < do
+    dup fibb .
+    1 + 
+end

--- a/recursion.anzu
+++ b/recursion.anzu
@@ -1,15 +1,15 @@
 // fibbonacci to demonstrate functions and recursion
 
-function fibb 1
+function fibb 1 1
     if dup 0 == do
         0 return
     elif dup 1 == do
         1 return
-    else
-        dup 1 - -> a
-        dup 2 - -> b
-        a fibb b fibb + return
     end
+    
+    dup 1 - -> a
+    dup 2 - -> b
+    a fibb b fibb + return
 end
 
 0 while dup 10 < do

--- a/recursion.anzu
+++ b/recursion.anzu
@@ -6,7 +6,7 @@ function fibb 1 1
     elif dup 1 == do
         1 return
     end
-    
+
     dup 1 - -> a
     dup 2 - -> b
     a fibb b fibb + return

--- a/recursion.anzu
+++ b/recursion.anzu
@@ -16,3 +16,9 @@ end
     dup fibb .
     1 + 
 end
+
+function print 2 0
+    . .
+end
+
+1 2 print

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -8,9 +8,11 @@
 
 void run_program(const std::vector<anzu::op>& program)
 {
-    anzu::stack_frame frame;
-    while (frame.ptr() < std::ssize(program)) {
-        program[frame.ptr()].apply(frame);
+    anzu::context ctx;
+    ctx.push({});
+
+    while (ctx.top().ptr() < std::ssize(program)) {
+        program[ctx.top().ptr()].apply(ctx);
     }
 }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -99,6 +99,12 @@ void process_while_block(std::vector<anzu::op>& program, std::stack<std::ptrdiff
 
 }
 
+struct function_def
+{
+    int            argc;
+    std::ptrdiff_t ptr;
+};
+
 auto parse_file(const std::string& file) -> std::vector<anzu::op>
 {
     // Loop over the lines in the program, and then split each line into tokens.
@@ -121,7 +127,13 @@ auto parse_file(const std::string& file) -> std::vector<anzu::op>
     // 'if', 'do' and 'else' so the jumps can be set up correctly.
     std::stack<std::ptrdiff_t> if_stack;
     std::stack<std::ptrdiff_t> while_stack;
-    std::stack<std::string>    blocks;
+    std::stack<std::ptrdiff_t> function_stack;
+
+    // Pointers into function definitions.
+    std::unordered_map<std::string, function_def> functions;
+
+    // Keeps a stack of if/else/function blocks to handle 'end' and 'do' keywords
+    std::stack<std::string> blocks;
 
     auto it = tokens.begin();
     while (it != tokens.end()) {
@@ -209,6 +221,12 @@ auto parse_file(const std::string& file) -> std::vector<anzu::op>
                 program.emplace_back(anzu::op_end_while{});
                 process_while_block(program, while_stack);
             }
+            else if (blocks.top() == "FUNCTION") {
+                std::ptrdiff_t begin_ptr = function_stack.top();
+                function_stack.pop();
+                program[begin_ptr].get_if<anzu::op_function>()->jump = std::ssize(program) + 1;
+                program.emplace_back(anzu::op_function_end{});
+            }
             else {
                 fmt::print("bad 'end', is not in a control flow block\n");
                 std::exit(1);
@@ -242,9 +260,30 @@ auto parse_file(const std::string& file) -> std::vector<anzu::op>
         else if (token == INPUT) {
             program.emplace_back(anzu::op_input{});
         }
+        else if (token == FUNCTION) {
+            blocks.push("FUNCTION");
+
+            std::string name = next(it);
+            function_def def = {
+                .argc=anzu::parse_int(next(it)),
+                .ptr=std::ssize(program) + 1
+            };
+            functions.emplace(name, def);
+            function_stack.push(std::ssize(program));
+            program.emplace_back(anzu::op_function{});
+        }
+        else if (token == RETURN) {
+            program.emplace_back(anzu::op_return{});
+        }
         else if (anzu::is_literal(token)) {
             program.emplace_back(anzu::op_push_const{
                 .value=anzu::parse_literal(token)
+            });
+        }
+        else if (functions.contains(token)) {
+            auto [argc, ptr] = functions[token];
+            program.emplace_back(anzu::op_function_call{
+                .name=token, .argc=argc, .jump=ptr
             });
         }
         else {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -52,12 +52,12 @@ void process_if_block(std::vector<anzu::op>& program, std::stack<std::ptrdiff_t>
             data->jump = next_ptr + 1;
         }
         else if (auto* data = op.get_if<anzu::op_elif>()) {
-            data->jump = end_ptr;
+            data->jump = end_ptr + 1;
         }
         else if (auto* data = op.get_if<anzu::op_else>()) {
-            data->jump = end_ptr;
+            data->jump = end_ptr + 1;
         }
-        else if (auto* data = op.get_if<anzu::op_end_if>()) {
+        else if (auto* data = op.get_if<anzu::op_if_end>()) {
             // pass
         }
         else {
@@ -88,7 +88,7 @@ void process_while_block(std::vector<anzu::op>& program, std::stack<std::ptrdiff
         else if (auto* data = op.get_if<anzu::op_continue>()) {
             data->jump = begin_ptr;
         }
-        else if (auto* data = op.get_if<anzu::op_end_while>()) {
+        else if (auto* data = op.get_if<anzu::op_while_end>()) {
             data->jump = begin_ptr;
         }
         else {
@@ -213,12 +213,12 @@ auto parse_file(const std::string& file) -> std::vector<anzu::op>
         else if (token == END) {
             if (blocks.top() == "IF") {
                 if_stack.push(std::ssize(program));
-                program.emplace_back(anzu::op_end_if{});
+                program.emplace_back(anzu::op_if_end{});
                 process_if_block(program, if_stack);
             }
             else if (blocks.top() == "WHILE") {
                 while_stack.push(std::ssize(program));
-                program.emplace_back(anzu::op_end_while{});
+                program.emplace_back(anzu::op_while_end{});
                 process_while_block(program, while_stack);
             }
             else if (blocks.top() == "FUNCTION") {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -128,7 +128,7 @@ auto parse_file(const std::string& file) -> std::vector<anzu::op>
     // 'if', 'do' and 'else' so the jumps can be set up correctly.
     std::stack<std::ptrdiff_t> if_stack;
     std::stack<std::ptrdiff_t> while_stack;
-    std::stack<std::ptrdiff_t> function_stack;
+    std::stack<function_def> function_stack;
 
     // Pointers into function definitions.
     std::unordered_map<std::string, function_def> functions;
@@ -223,10 +223,10 @@ auto parse_file(const std::string& file) -> std::vector<anzu::op>
                 process_while_block(program, while_stack);
             }
             else if (blocks.top() == "FUNCTION") {
-                std::ptrdiff_t begin_ptr = function_stack.top();
+                auto def = function_stack.top();
                 function_stack.pop();
-                program[begin_ptr].get_if<anzu::op_function>()->jump = std::ssize(program) + 1;
-                program.emplace_back(anzu::op_function_end{});
+                program[def.ptr].get_if<anzu::op_function>()->jump = std::ssize(program) + 1;
+                program.emplace_back(anzu::op_function_end{ .retc=def.retc });
             }
             else {
                 fmt::print("bad 'end', is not in a control flow block\n");
@@ -268,16 +268,15 @@ auto parse_file(const std::string& file) -> std::vector<anzu::op>
             function_def def = {
                 .argc=anzu::parse_int(next(it)),
                 .retc=anzu::parse_int(next(it)),
-                .ptr=std::ssize(program) + 1
+                .ptr=std::ssize(program)
             };
             functions.emplace(name, def);
-            function_stack.push(std::ssize(program));
+            function_stack.push(def);
             program.emplace_back(anzu::op_function{ .name=name });
         }
         else if (token == RETURN) {
-            auto f_name = program[function_stack.top()].get_if<anzu::op_function>()->name;
-            const auto& f_data = functions.at(f_name);
-            program.emplace_back(anzu::op_return{ .retc=f_data.retc });
+            const auto& def = function_stack.top();
+            program.emplace_back(anzu::op_return{ .retc=def.retc });
         }
         else if (anzu::is_literal(token)) {
             program.emplace_back(anzu::op_push_const{
@@ -287,7 +286,7 @@ auto parse_file(const std::string& file) -> std::vector<anzu::op>
         else if (functions.contains(token)) {
             auto [argc, retc, ptr] = functions[token];
             program.emplace_back(anzu::op_function_call{
-                .name=token, .argc=argc, .jump=ptr
+                .name=token, .argc=argc, .jump=ptr + 1
             });
         }
         else {

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -39,6 +39,10 @@ constexpr auto CONTINUE    = std::string_view{"continue"};
 constexpr auto DO          = std::string_view{"do"};
 constexpr auto END         = std::string_view{"end"};
 
+// Functions
+constexpr auto FUNCTION    = std::string_view{"function"};
+constexpr auto RETURN      = std::string_view{"return"};
+
 auto parse_file(const std::string& file) -> std::vector<anzu::op>;
 
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -19,6 +19,13 @@ anzu::object parse_literal(const std::string& token)
     if (token == "false") {
         return false;
     }
+    return parse_int(token);
+    fmt::print("[Fatal] Could not parse constant: {}\n", token);
+    std::exit(1);
+}
+
+int parse_int(const std::string& token)
+{
     if (token.find_first_not_of("0123456789") == std::string::npos) {
         return std::stoi(token);
     }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -10,6 +10,8 @@ using object = std::variant<int, bool>;
 bool is_literal(const std::string& token);
 anzu::object parse_literal(const std::string& token);
 
+int parse_int(const std::string& token);
+
 }
 
 template <> struct fmt::formatter<anzu::object> {

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -356,15 +356,8 @@ void op_function_call::apply(anzu::context& ctx) const
     prev.ptr() += 1;   // The position in the program where it will resume
 
     // Move the required number of arguments over to the new frame
-    std::stack<anzu::object> tmp;
-    for (int i = 0; i != argc; ++i) {
-        tmp.push(prev.pop());
-    }
-    for (int i = 0; i != argc; ++i) {
-        curr.push(tmp.top());
-        tmp.pop();
-    }
-
+    for (int i = 0; i != argc; ++i) { curr.push(prev.top(argc - 1 - i)); }
+    for (int i = 0; i != argc; ++i) { prev.pop(); }
 }
 
 void op_return::apply(anzu::context& ctx) const

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -352,8 +352,8 @@ void op_function_call::apply(anzu::context& ctx) const
     auto& curr = ctx.push({}); // New frame
     auto& prev = ctx.top(1);   // One under the top
 
-    // The position in the program where it will resume.
-    prev.ptr() += 1;
+    curr.ptr() = jump; // Jump into the function
+    prev.ptr() += 1;   // The position in the program where it will resume
 
     // Move the required number of arguments over to the new frame
     std::stack<anzu::object> tmp;
@@ -365,7 +365,6 @@ void op_function_call::apply(anzu::context& ctx) const
         tmp.pop();
     }
 
-    curr.ptr() = jump;
 }
 
 void op_return::apply(anzu::context& ctx) const

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -349,23 +349,23 @@ void op_function_end::apply(anzu::context& ctx) const
 
 void op_function_call::apply(anzu::context& ctx) const
 {
-    auto& frame = ctx.top();
-    frame.ptr() += 1; // The position in the program where it will resume.
+    auto& curr = ctx.push({}); // New frame
+    auto& prev = ctx.top(1);   // One under the top
 
-    anzu::frame new_frame;
+    // The position in the program where it will resume.
+    prev.ptr() += 1;
 
     // Move the required number of arguments over to the new frame
     std::stack<anzu::object> tmp;
     for (int i = 0; i != argc; ++i) {
-        tmp.push(frame.pop());
+        tmp.push(prev.pop());
     }
     for (int i = 0; i != argc; ++i) {
-        new_frame.push(tmp.top());
+        curr.push(tmp.top());
         tmp.pop();
     }
 
-    ctx.push(new_frame);
-    ctx.top().ptr() = jump;
+    curr.ptr() = jump;
 }
 
 void op_return::apply(anzu::context& ctx) const

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -129,7 +129,7 @@ void op_mod::apply(anzu::context& ctx) const
 void op_dup::apply(anzu::context& ctx) const
 {
     auto& frame = ctx.top();
-    frame.push(frame.peek());
+    frame.push(frame.top());
     frame.ptr() += 1;
 }
 

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -339,7 +339,7 @@ void op_do::apply(anzu::context& ctx) const
 
 void op_function::apply(anzu::context& ctx) const
 {
-    ctx.top().ptr() += 1;
+    ctx.top().ptr() = jump;
 }
 
 void op_function_end::apply(anzu::context& ctx) const

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -11,38 +11,44 @@ template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 
 }
 
-void op_store::apply(anzu::stack_frame& frame) const
+void op_store::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     frame.load(name, frame.pop());
     frame.ptr() += 1;
 }
 
-void op_dump::apply(anzu::stack_frame& frame) const
+void op_dump::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     fmt::print("{}\n", frame.pop());
     frame.ptr() += 1;
 }
 
-void op_pop::apply(anzu::stack_frame& frame) const
+void op_pop::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     frame.pop();
     frame.ptr() += 1;
 }
 
-void op_push_const::apply(anzu::stack_frame& frame) const
+void op_push_const::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     frame.push(value);
     frame.ptr() += 1;
 }
 
-void op_push_var::apply(anzu::stack_frame& frame) const
+void op_push_var::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     frame.push(frame.fetch(name));
     frame.ptr() += 1;
 }
 
-void op_add::apply(anzu::stack_frame& frame) const
+void op_add::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     auto b = frame.pop();
     auto a = frame.pop();
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
@@ -56,8 +62,9 @@ void op_add::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_sub::apply(anzu::stack_frame& frame) const
+void op_sub::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     auto b = frame.pop();
     auto a = frame.pop();
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
@@ -71,8 +78,9 @@ void op_sub::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_mul::apply(anzu::stack_frame& frame) const
+void op_mul::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     auto b = frame.pop();
     auto a = frame.pop();
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
@@ -86,8 +94,9 @@ void op_mul::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_div::apply(anzu::stack_frame& frame) const
+void op_div::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     auto b = frame.pop();
     auto a = frame.pop();
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
@@ -101,8 +110,9 @@ void op_div::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_mod::apply(anzu::stack_frame& frame) const
+void op_mod::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     auto b = frame.pop();
     auto a = frame.pop();
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
@@ -116,20 +126,23 @@ void op_mod::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_dup::apply(anzu::stack_frame& frame) const
+void op_dup::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     frame.push(frame.peek());
     frame.ptr() += 1;
 }
 
-void op_print_frame::apply(anzu::stack_frame& frame) const
+void op_print_frame::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     frame.print();
     frame.ptr() += 1;
 }
 
-void op_eq::apply(anzu::stack_frame& frame) const
+void op_eq::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     auto b = frame.pop();
     auto a = frame.pop();
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
@@ -143,8 +156,9 @@ void op_eq::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_ne::apply(anzu::stack_frame& frame) const
+void op_ne::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     auto b = frame.pop();
     auto a = frame.pop();
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
@@ -158,8 +172,9 @@ void op_ne::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_lt::apply(anzu::stack_frame& frame) const
+void op_lt::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     auto b = frame.pop();
     auto a = frame.pop();
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
@@ -173,8 +188,9 @@ void op_lt::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_le::apply(anzu::stack_frame& frame) const
+void op_le::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     auto b = frame.pop();
     auto a = frame.pop();
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
@@ -188,8 +204,9 @@ void op_le::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_gt::apply(anzu::stack_frame& frame) const
+void op_gt::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     auto b = frame.pop();
     auto a = frame.pop();
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
@@ -203,8 +220,9 @@ void op_gt::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_ge::apply(anzu::stack_frame& frame) const
+void op_ge::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     auto b = frame.pop();
     auto a = frame.pop();
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
@@ -218,8 +236,9 @@ void op_ge::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_or::apply(anzu::stack_frame& frame) const
+void op_or::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     auto b = frame.pop();
     auto a = frame.pop();
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
@@ -233,8 +252,9 @@ void op_or::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_and::apply(anzu::stack_frame& frame) const
+void op_and::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     auto b = frame.pop();
     auto a = frame.pop();
     std::visit([&]<typename A, typename B>(const A& a, const B& b) {
@@ -248,8 +268,9 @@ void op_and::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_input::apply(anzu::stack_frame& frame) const
+void op_input::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     fmt::print("Input: ");
     std::string in;
     std::cin >> in;
@@ -261,48 +282,57 @@ void op_input::apply(anzu::stack_frame& frame) const
     frame.ptr() += 1;
 }
 
-void op_if::apply(anzu::stack_frame& frame) const
+void op_if::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     frame.ptr() += 1;
 }
 
-void op_end_if::apply(anzu::stack_frame& frame) const
+void op_end_if::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     frame.ptr() += 1;
 }
 
-void op_elif::apply(anzu::stack_frame& frame) const
+void op_elif::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     frame.ptr() = jump;
 }
 
-void op_else::apply(anzu::stack_frame& frame) const
+void op_else::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     frame.ptr() = jump;
 }
 
-void op_while::apply(anzu::stack_frame& frame) const
+void op_while::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     frame.ptr() += 1;
 }
 
-void op_end_while::apply(anzu::stack_frame& frame) const
+void op_end_while::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     frame.ptr() = jump;
 }
 
-void op_break::apply(anzu::stack_frame& frame) const
+void op_break::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     frame.ptr() = jump;
 }
 
-void op_continue::apply(anzu::stack_frame& frame) const
+void op_continue::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     frame.ptr() = jump;
 }
 
-void op_do::apply(anzu::stack_frame& frame) const
+void op_do::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
     auto condition = std::visit(overloaded {
         [](int v) { return v != 0; },
         [](bool v) { return v; }
@@ -315,16 +345,19 @@ void op_do::apply(anzu::stack_frame& frame) const
     }
 }
 
-void op_function::apply(anzu::stack_frame& frame) const
+void op_function::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
 }
 
-void op_function_end::apply(anzu::stack_frame& frame) const
+void op_function_end::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
 }
 
-void op_return::apply(anzu::stack_frame& frame) const
+void op_return::apply(anzu::context& ctx) const
 {
+    auto& frame = ctx.top();
 }
 
 }

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -350,9 +350,7 @@ void op_function::apply(anzu::context& ctx) const
 
 void op_function_end::apply(anzu::context& ctx) const
 {
-    // Move the required number of arguments back to the underlying frame
     transfer_values(ctx.top(0), ctx.top(1), retc);
-    
     ctx.pop(); // Remove stack frame
 }
 
@@ -364,15 +362,12 @@ void op_function_call::apply(anzu::context& ctx) const
     curr.ptr() = jump; // Jump into the function
     prev.ptr() += 1;   // The position in the program where it will resume
 
-    // Move the required number of arguments over to the new frame
     transfer_values(prev, curr, argc);
 }
 
 void op_return::apply(anzu::context& ctx) const
 {
-    // Move the required number of arguments back to the underlying frame
     transfer_values(ctx.top(0), ctx.top(1), retc);
-
     ctx.pop(); // Remove stack frame
 }
 

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -284,50 +284,42 @@ void op_input::apply(anzu::context& ctx) const
 
 void op_if::apply(anzu::context& ctx) const
 {
-    auto& frame = ctx.top();
-    frame.ptr() += 1;
+    ctx.top().ptr() += 1;
 }
 
 void op_end_if::apply(anzu::context& ctx) const
 {
-    auto& frame = ctx.top();
-    frame.ptr() += 1;
+    ctx.top().ptr() += 1;
 }
 
 void op_elif::apply(anzu::context& ctx) const
 {
-    auto& frame = ctx.top();
-    frame.ptr() = jump;
+    ctx.top().ptr() = jump;
 }
 
 void op_else::apply(anzu::context& ctx) const
 {
-    auto& frame = ctx.top();
-    frame.ptr() = jump;
+    ctx.top().ptr() += 1;
 }
 
 void op_while::apply(anzu::context& ctx) const
 {
-    auto& frame = ctx.top();
-    frame.ptr() += 1;
+    ctx.top().ptr() += 1;
 }
 
 void op_end_while::apply(anzu::context& ctx) const
 {
-    auto& frame = ctx.top();
-    frame.ptr() = jump;
+    ctx.top().ptr() = jump;
 }
 
 void op_break::apply(anzu::context& ctx) const
 {
-    auto& frame = ctx.top();
-    frame.ptr() = jump;
+    ctx.top().ptr() = jump;
 }
 
 void op_continue::apply(anzu::context& ctx) const
 {
-    auto& frame = ctx.top();
-    frame.ptr() = jump;
+    ctx.top().ptr() = jump;
 }
 
 void op_do::apply(anzu::context& ctx) const
@@ -347,17 +339,40 @@ void op_do::apply(anzu::context& ctx) const
 
 void op_function::apply(anzu::context& ctx) const
 {
-    auto& frame = ctx.top();
+    ctx.top().ptr() += 1;
 }
 
 void op_function_end::apply(anzu::context& ctx) const
 {
+    ctx.pop(); // Remove stack frame
+}
+
+void op_function_call::apply(anzu::context& ctx) const
+{
     auto& frame = ctx.top();
+    frame.ptr() += 1; // The position in the program where it will resume.
+
+    anzu::frame new_frame;
+
+    // Move the required number of arguments over to the new frame
+    std::stack<anzu::object> tmp;
+    for (int i = 0; i != argc; ++i) {
+        tmp.push(frame.pop());
+    }
+    for (int i = 0; i != argc; ++i) {
+        new_frame.push(tmp.top());
+        tmp.pop();
+    }
+
+    ctx.push(new_frame);
+    ctx.top().ptr() = jump;
 }
 
 void op_return::apply(anzu::context& ctx) const
 {
-    auto& frame = ctx.top();
+    auto ret_val = ctx.top().pop();
+    ctx.pop(); // Remove stack frame
+    ctx.top().push(ret_val);
 }
 
 }

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -315,4 +315,16 @@ void op_do::apply(anzu::stack_frame& frame) const
     }
 }
 
+void op_function::apply(anzu::stack_frame& frame) const
+{
+}
+
+void op_function_end::apply(anzu::stack_frame& frame) const
+{
+}
+
+void op_return::apply(anzu::stack_frame& frame) const
+{
+}
+
 }

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -287,7 +287,7 @@ void op_if::apply(anzu::context& ctx) const
     ctx.top().ptr() += 1;
 }
 
-void op_end_if::apply(anzu::context& ctx) const
+void op_if_end::apply(anzu::context& ctx) const
 {
     ctx.top().ptr() += 1;
 }
@@ -299,7 +299,7 @@ void op_elif::apply(anzu::context& ctx) const
 
 void op_else::apply(anzu::context& ctx) const
 {
-    ctx.top().ptr() += 1;
+    ctx.top().ptr() = jump;
 }
 
 void op_while::apply(anzu::context& ctx) const
@@ -307,7 +307,7 @@ void op_while::apply(anzu::context& ctx) const
     ctx.top().ptr() += 1;
 }
 
-void op_end_while::apply(anzu::context& ctx) const
+void op_while_end::apply(anzu::context& ctx) const
 {
     ctx.top().ptr() = jump;
 }

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -218,7 +218,17 @@ struct op_function
 
 struct op_function_end
 {
-    std::string to_string() const { return fmt::format("OP_FUNCTION_END"); }
+    std::string to_string() const { return fmt::format("OP_FUNCTION_END   JUMP -> CALLSITE"); }
+    void apply(anzu::context& ctx) const;
+};
+
+struct op_function_call
+{
+    std::string    name;
+    int            argc;
+    std::ptrdiff_t jump;
+
+    std::string to_string() const { return fmt::format("OP_FUNCTION_CALL({}, {}) JUMP -> {}", name, argc, jump); }
     void apply(anzu::context& ctx) const;
 };
 
@@ -267,6 +277,7 @@ class op
         // Functions
         op_function,
         op_function_end,
+        op_function_call,
         op_return
     >;
 

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -239,7 +239,9 @@ struct op_function_call
 
 struct op_return
 {
-    std::string to_string() const { return fmt::format(PRINT_JUMP, "OP_RETURN", "[CALLSITE] (WITH VALUE)"); }
+    int retc;
+
+    std::string to_string() const { return fmt::format(PRINT_JUMP, fmt::format("OP_RETURN({})", retc), "[CALLSITE]"); }
     void apply(anzu::context& ctx) const;
 };
 

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -239,7 +239,7 @@ struct op_function_call
 
 struct op_return
 {
-    std::string to_string() const { return fmt::format("OP_RETURN"); }
+    std::string to_string() const { return fmt::format(PRINT_JUMP, "OP_RETURN", "[CALLSITE] (WITH VALUE)"); }
     void apply(anzu::context& ctx) const;
 };
 

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -6,8 +6,8 @@
 
 namespace anzu {
 
-constexpr auto PRINT_JUMP          = std::string_view{"{:<25} JUMP -> {}"};
-constexpr auto PRINT_JUMP_IF_FALSE = std::string_view{"{:<25} JUMP -> {} (IF FALSE)"};
+constexpr auto PRINT_JUMP          = std::string_view{"{:<30} JUMP -> {}"};
+constexpr auto PRINT_JUMP_IF_FALSE = std::string_view{"{:<30} JUMP -> {} (IF FALSE)"};
 
 struct op_store
 {
@@ -209,16 +209,16 @@ struct op_do
 
 struct op_function
 {
-    std::string name;
-    int         argc;
+    std::string    name;
+    std::ptrdiff_t jump = -1;  // Jumps to end of function is it isnt invoked when running.
 
-    std::string to_string() const { return fmt::format("OP_FUNCTION({}, {})", name, argc); }
+    std::string to_string() const { return fmt::format(PRINT_JUMP, "OP_FUNCTION", jump); }
     void apply(anzu::context& ctx) const;
 };
 
 struct op_function_end
 {
-    std::string to_string() const { return fmt::format("OP_FUNCTION_END   JUMP -> CALLSITE"); }
+    std::string to_string() const{ return fmt::format(PRINT_JUMP, "OP_FUNCTION_END", "[CALLSITE]"); }
     void apply(anzu::context& ctx) const;
 };
 
@@ -228,7 +228,12 @@ struct op_function_call
     int            argc;
     std::ptrdiff_t jump;
 
-    std::string to_string() const { return fmt::format("OP_FUNCTION_CALL({}, {}) JUMP -> {}", name, argc, jump); }
+    std::string to_string() const
+    {
+        return fmt::format(
+            PRINT_JUMP, fmt::format("OP_FUNCTION_CALL({}, {})", name, argc), jump
+        ); 
+    }
     void apply(anzu::context& ctx) const;
 };
 

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -207,6 +207,27 @@ struct op_do
     void apply(anzu::stack_frame& frame) const;
 };
 
+struct op_function
+{
+    std::string name;
+    int         argc;
+
+    std::string to_string() const { return fmt::format("OP_FUNCTION({}, {})", name, argc); }
+    void apply(anzu::stack_frame& frame) const;
+};
+
+struct op_function_end
+{
+    std::string to_string() const { return fmt::format("OP_FUNCTION_END"); }
+    void apply(anzu::stack_frame& frame) const;
+};
+
+struct op_return
+{
+    std::string to_string() const { return fmt::format("OP_RETURN"); }
+    void apply(anzu::stack_frame& frame) const;
+};
+
 class op
 {
     using op_type = std::variant<
@@ -241,7 +262,12 @@ class op
         op_end_while,
         op_break,
         op_continue,
-        op_do
+        op_do,
+
+        // Functions
+        op_function,
+        op_function_end,
+        op_return
     >;
 
     op_type d_type;

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -212,13 +212,15 @@ struct op_function
     std::string    name;
     std::ptrdiff_t jump = -1;  // Jumps to end of function is it isnt invoked when running.
 
-    std::string to_string() const { return fmt::format(PRINT_JUMP, "OP_FUNCTION", jump); }
+    std::string to_string() const { return fmt::format(PRINT_JUMP, fmt::format("OP_FUNCTION({})", name), jump); }
     void apply(anzu::context& ctx) const;
 };
 
 struct op_function_end
 {
-    std::string to_string() const{ return fmt::format(PRINT_JUMP, "OP_END_FUNCTION", "[CALLSITE]"); }
+    int retc;
+
+    std::string to_string() const{ return fmt::format(PRINT_JUMP, fmt::format("OP_END_FUNCTION({})", retc), "[CALLSITE]"); }
     void apply(anzu::context& ctx) const;
 };
 

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -210,7 +210,7 @@ struct op_do
 struct op_function
 {
     std::string    name;
-    std::ptrdiff_t jump = -1;  // Jumps to end of function is it isnt invoked when running.
+    std::ptrdiff_t jump = -1;  // Jumps to end of function so it isnt invoked when running.
 
     std::string to_string() const { return fmt::format(PRINT_JUMP, fmt::format("OP_FUNCTION({})", name), jump); }
     void apply(anzu::context& ctx) const;
@@ -232,9 +232,7 @@ struct op_function_call
 
     std::string to_string() const
     {
-        return fmt::format(
-            PRINT_JUMP, fmt::format("OP_FUNCTION_CALL({}, {})", name, argc), jump
-        ); 
+        return fmt::format(PRINT_JUMP, fmt::format("OP_FUNCTION_CALL({}, {})", name, argc), jump); 
     }
     void apply(anzu::context& ctx) const;
 };

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -14,19 +14,19 @@ struct op_store
     std::string name;
 
     std::string to_string() const { return fmt::format("OP_STORE({})", name); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_dump
 {
     std::string to_string() const { return fmt::format("OP_DUMP"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_pop
 {
     std::string to_string() const { return fmt::format("OP_POP"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_push_const
@@ -34,7 +34,7 @@ struct op_push_const
     anzu::object value;
 
     std::string to_string() const { return fmt::format("OP_PUSH_CONST({})", value); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_push_var
@@ -42,115 +42,115 @@ struct op_push_var
     std::string name;
 
     std::string to_string() const { return fmt::format("OP_PUSH_VAR({})", name); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_add
 {
     std::string to_string() const { return fmt::format("OP_ADD"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_sub
 {
     std::string to_string() const { return fmt::format("OP_SUB"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_mul
 {
     std::string to_string() const { return fmt::format("OP_MUL"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_div
 {
     std::string to_string() const { return fmt::format("OP_DIV"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_mod
 {
     std::string to_string() const { return fmt::format("OP_MOD"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_dup
 {
     std::string to_string() const { return fmt::format("OP_DUP"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_print_frame
 {
     std::string to_string() const { return fmt::format("OP_PRINT_FRAME"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_eq
 {
     std::string to_string() const { return fmt::format("OP_EQ"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_ne
 {
     std::string to_string() const { return fmt::format("OP_NE"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_lt
 {
     std::string to_string() const { return fmt::format("OP_LT"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_le
 {
     std::string to_string() const { return fmt::format("OP_LE"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_gt
 {
     std::string to_string() const { return fmt::format("OP_GT"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_ge
 {
     std::string to_string() const { return fmt::format("OP_GE"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_or
 {
     std::string to_string() const { return fmt::format("OP_OR"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_and
 {
     std::string to_string() const { return fmt::format("OP_AND"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_input
 {
     std::string to_string() const { return fmt::format("OP_INPUT"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_if
 {
     std::string to_string() const { return fmt::format("OP_IF"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_end_if
 {
     std::string to_string() const { return fmt::format("OP_END_IF"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_elif
@@ -158,7 +158,7 @@ struct op_elif
     std::ptrdiff_t jump = -1;
 
     std::string to_string() const { return fmt::format(PRINT_JUMP, "OP_ELIF", jump); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_else
@@ -166,13 +166,13 @@ struct op_else
     std::ptrdiff_t jump = -1;
 
     std::string to_string() const { return fmt::format(PRINT_JUMP, "OP_ELSE", jump); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_while
 {
     std::string to_string() const { return fmt::format("OP_WHILE"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_end_while
@@ -180,7 +180,7 @@ struct op_end_while
     std::ptrdiff_t jump = -1;
 
     std::string to_string() const { return fmt::format(PRINT_JUMP, "OP_END_WHILE", jump); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_break
@@ -188,7 +188,7 @@ struct op_break
     std::ptrdiff_t jump = -1;
 
     std::string to_string() const { return fmt::format(PRINT_JUMP, "OP_BREAK", jump); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_continue
@@ -196,7 +196,7 @@ struct op_continue
     std::ptrdiff_t jump = -1;
 
     std::string to_string() const { return fmt::format(PRINT_JUMP, "OP_CONTINUE", jump); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_do
@@ -204,7 +204,7 @@ struct op_do
     std::ptrdiff_t jump = -1;
 
     std::string to_string() const { return fmt::format(PRINT_JUMP_IF_FALSE, "OP_DO", jump); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_function
@@ -213,19 +213,19 @@ struct op_function
     int         argc;
 
     std::string to_string() const { return fmt::format("OP_FUNCTION({}, {})", name, argc); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_function_end
 {
     std::string to_string() const { return fmt::format("OP_FUNCTION_END"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 struct op_return
 {
     std::string to_string() const { return fmt::format("OP_RETURN"); }
-    void apply(anzu::stack_frame& frame) const;
+    void apply(anzu::context& ctx) const;
 };
 
 class op
@@ -283,8 +283,8 @@ public:
         return std::visit([](auto&& o) { return o.to_string(); }, d_type);
     }
 
-    inline void apply(anzu::stack_frame& frame) const {
-        return std::visit([&](auto&& o) { o.apply(frame); }, d_type);
+    inline void apply(anzu::context& ctx) const {
+        return std::visit([&](auto&& o) { o.apply(ctx); }, d_type);
     }
 };
 

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -147,7 +147,7 @@ struct op_if
     void apply(anzu::context& ctx) const;
 };
 
-struct op_end_if
+struct op_if_end
 {
     std::string to_string() const { return fmt::format("OP_END_IF"); }
     void apply(anzu::context& ctx) const;
@@ -175,7 +175,7 @@ struct op_while
     void apply(anzu::context& ctx) const;
 };
 
-struct op_end_while
+struct op_while_end
 {
     std::ptrdiff_t jump = -1;
 
@@ -218,7 +218,7 @@ struct op_function
 
 struct op_function_end
 {
-    std::string to_string() const{ return fmt::format(PRINT_JUMP, "OP_FUNCTION_END", "[CALLSITE]"); }
+    std::string to_string() const{ return fmt::format(PRINT_JUMP, "OP_END_FUNCTION", "[CALLSITE]"); }
     void apply(anzu::context& ctx) const;
 };
 
@@ -270,11 +270,11 @@ class op
 
         // Control Flow
         op_if,
-        op_end_if,
+        op_if_end,
         op_elif,
         op_else,
         op_while,
-        op_end_while,
+        op_while_end,
         op_break,
         op_continue,
         op_do,

--- a/src/stack_frame.cpp
+++ b/src/stack_frame.cpp
@@ -5,29 +5,29 @@
 
 namespace anzu {
 
-auto stack_frame::pop() -> anzu::object
+auto frame::pop() -> anzu::object
 {
     auto value = d_values.back();
     d_values.pop_back();
     return value;
 }
 
-auto stack_frame::push(const anzu::object& value) -> void
+auto frame::push(const anzu::object& value) -> void
 {
     d_values.push_back(value);
 }
 
-auto stack_frame::peek() const -> anzu::object
+auto frame::peek() const -> anzu::object
 {
     return d_values.back();
 }
 
-auto stack_frame::empty() const -> bool
+auto frame::empty() const -> bool
 {
     return d_values.empty();
 }
 
-auto stack_frame::fetch(const std::string& token) const -> anzu::object
+auto frame::fetch(const std::string& token) const -> anzu::object
 {
     if (!d_symbols.contains(token)) {
         fmt::print("Error: Unknown value '{}'", token);
@@ -36,12 +36,12 @@ auto stack_frame::fetch(const std::string& token) const -> anzu::object
     return d_symbols.at(token);
 }
 
-auto stack_frame::load(const std::string& name, const anzu::object& value) -> void
+auto frame::load(const std::string& name, const anzu::object& value) -> void
 {
     d_symbols[name] = value;
 }
 
-auto stack_frame::print() const -> void
+auto frame::print() const -> void
 {
     fmt::print("Values:\n");
     for (const auto& val : d_values) {

--- a/src/stack_frame.cpp
+++ b/src/stack_frame.cpp
@@ -7,24 +7,22 @@ namespace anzu {
 
 auto frame::pop() -> anzu::object
 {
-    auto value = d_values.back();
-    d_values.pop_back();
-    return value;
+    return d_values.pop();
 }
 
 auto frame::push(const anzu::object& value) -> void
 {
-    d_values.push_back(value);
+    d_values.push(value);
 }
 
 auto frame::peek() const -> anzu::object
 {
-    return d_values.back();
+    return d_values.top();
 }
 
 auto frame::empty() const -> bool
 {
-    return d_values.empty();
+    return d_values.size() == 0;
 }
 
 auto frame::fetch(const std::string& token) const -> anzu::object
@@ -44,7 +42,7 @@ auto frame::load(const std::string& name, const anzu::object& value) -> void
 auto frame::print() const -> void
 {
     fmt::print("Values:\n");
-    for (const auto& val : d_values) {
+    for (const auto& val : d_values.all()) {
         fmt::print(" - {}\n", val);
     }
     fmt::print("Symbols:\n");

--- a/src/stack_frame.cpp
+++ b/src/stack_frame.cpp
@@ -20,6 +20,11 @@ auto frame::peek() const -> anzu::object
     return d_values.top();
 }
 
+auto frame::top(std::size_t index) const -> const anzu::object&
+{
+    return d_values.top(index);
+}
+
 auto frame::empty() const -> bool
 {
     return d_values.size() == 0;

--- a/src/stack_frame.cpp
+++ b/src/stack_frame.cpp
@@ -15,11 +15,6 @@ auto frame::push(const anzu::object& value) -> void
     d_values.push(value);
 }
 
-auto frame::peek() const -> anzu::object
-{
-    return d_values.top();
-}
-
 auto frame::top(std::size_t index) const -> const anzu::object&
 {
     return d_values.top(index);

--- a/src/stack_frame.hpp
+++ b/src/stack_frame.hpp
@@ -10,7 +10,7 @@ namespace anzu {
 
 // A small wrapper for the value stack. This will eventually handle error
 // checking and checking that values are available.
-class stack_frame
+class frame
 {
     std::vector<anzu::object>                     d_values;
     std::unordered_map<std::string, anzu::object> d_symbols;
@@ -32,5 +32,7 @@ public:
     std::ptrdiff_t& ptr() { return d_ptr; }
     std::ptrdiff_t ptr() const { return d_ptr; }
 };
+
+using context = std::stack<anzu::frame>;
 
 }

--- a/src/stack_frame.hpp
+++ b/src/stack_frame.hpp
@@ -59,6 +59,7 @@ public:
     auto pop() -> anzu::object;
     auto push(const anzu::object& value) -> void;
     auto peek() const -> anzu::object;
+    auto top(std::size_t index = 0) const -> const anzu::object&;
 
     auto fetch(const std::string& name) const -> anzu::object;
     auto load(const std::string& name, const anzu::object& value) -> void;

--- a/src/stack_frame.hpp
+++ b/src/stack_frame.hpp
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <string>
 #include <variant>
+#include <ranges>
 
 namespace anzu {
 
@@ -41,13 +42,15 @@ public:
     {
         return d_values.size();
     }
+
+    auto all() const { return d_values | std::views::reverse; }
 };
 
 // A small wrapper for the value stack. This will eventually handle error
 // checking and checking that values are available.
 class frame
 {
-    std::vector<anzu::object>                     d_values;
+    anzu::stack<anzu::object>                     d_values;
     std::unordered_map<std::string, anzu::object> d_symbols;
 
     std::ptrdiff_t d_ptr = 0;

--- a/src/stack_frame.hpp
+++ b/src/stack_frame.hpp
@@ -58,7 +58,6 @@ class frame
 public:
     auto pop() -> anzu::object;
     auto push(const anzu::object& value) -> void;
-    auto peek() const -> anzu::object;
     auto top(std::size_t index = 0) const -> const anzu::object&;
 
     auto fetch(const std::string& name) const -> anzu::object;

--- a/src/stack_frame.hpp
+++ b/src/stack_frame.hpp
@@ -8,6 +8,40 @@
 
 namespace anzu {
 
+template <typename T>
+class stack
+{
+    std::vector<T> d_values;
+
+public:
+    auto pop() -> T
+    {
+        T val = d_values.back();
+        d_values.pop_back();
+        return val;
+    }
+
+    auto push(const T& value) -> void
+    {
+        d_values.push_back(value);
+    }
+
+    auto top(std::size_t index = 0) const -> const T&
+    {
+        return d_values[d_values.size() - index - 1];
+    }
+
+    auto top(std::size_t index = 0) -> T&
+    {
+        return d_values[d_values.size() - index - 1];
+    }
+
+    auto size() const -> std::size_t
+    {
+        return d_values.size();
+    }
+};
+
 // A small wrapper for the value stack. This will eventually handle error
 // checking and checking that values are available.
 class frame
@@ -33,6 +67,6 @@ public:
     std::ptrdiff_t ptr() const { return d_ptr; }
 };
 
-using context = std::stack<anzu::frame>;
+using context = anzu::stack<anzu::frame>;
 
 }

--- a/src/stack_frame.hpp
+++ b/src/stack_frame.hpp
@@ -21,9 +21,10 @@ public:
         return val;
     }
 
-    auto push(const T& value) -> void
+    auto push(const T& value) -> T&
     {
         d_values.push_back(value);
+        return d_values.back();
     }
 
     auto top(std::size_t index = 0) const -> const T&


### PR DESCRIPTION
* Add functions into the language. Syntax is `function <name> <argc> <retc> ... end`. `argc` is the number of elements at the top of the stack carried into the function, and `retc` is the number returned.
* Functions return at the end of the function, and can be returned from early using `return`.
* The stack transfers are carried out in a single block, that is, no reordering is done. For example, given `function print 2 0 . . end` (function thats two parameters and returns none), the output of `1 2 print` would be '2 1', as 2 is on top of the stack and would get printed first.
* Ops now take a `anzu::context == anzu::stack<anzu::frame>` rather than a single `frame` now. New frames are added for each function call.