### PR TITLE
String Literals

### DIFF
--- a/examples/recursion.anzu
+++ b/examples/recursion.anzu
@@ -1,4 +1,4 @@
-// fibbonacci to demonstrate functions and recursion
+# fibbonacci to demonstrate functions and recursion
 
 function fibb 1 1
     if dup 0 == do

--- a/examples/recursion.anzu
+++ b/examples/recursion.anzu
@@ -1,4 +1,4 @@
-# fibbonacci to demonstrate functions and recursion
+// fibbonacci to demonstrate functions and recursion
 
 function fibb 1 1
     if dup 0 == do

--- a/examples/recursion.anzu
+++ b/examples/recursion.anzu
@@ -1,5 +1,9 @@
 // fibbonacci to demonstrate functions and recursion
 
+function print 1 0
+    . "\n" .
+end
+
 function fibb 1 1
     if dup 0 == do
         0 return
@@ -13,6 +17,6 @@ function fibb 1 1
 end
 
 0 while dup 10 < do
-    dup fibb .
+    dup fibb print
     1 + 
 end

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,8 +1,5 @@
 // test file to manually testing new features
 
-function print 1 0
-    . "\n" .
-end
+"hello" 3 + .
 
-"hello" . " world\n" print
-"this is a string test" print 5 print 6 print
+

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,3 +1,3 @@
 // test file to manually testing new features
 
-.sdffdgs "test \"case 1 2 3"sdf sdf
+"\r" . a\\a\\a

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,3 +1,8 @@
 // test file to manually testing new features
 
-"hello" "world\n" swap . .
+function print 1 0
+    . "\n" .
+end
+
+"hello" . " world\n" print
+"this is a string test" print 5 print 6 print

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,3 +1,3 @@
 // test file to manually testing new features
 
-ar "abc\t d"    \r   . a\\a\\a
+"hello" "world\n" swap . .

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,3 +1,3 @@
 // test file to manually testing new features
 
-.sdffdgs \"test case 1 2 3"sdf sdf
+.sdffdgs "test \"case 1 2 3"sdf sdf

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,3 +1,3 @@
 // test file to manually testing new features
 
-"\r" . a\\a\\a
+ar "abc\t d"    \r   . a\\a\\a

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,3 +1,3 @@
 // test file to manually testing new features
 
-.
+.sdffdgs \"test case 1 2 3"sdf sdf

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1,5 +1,6 @@
 #include "lexer.hpp"
 
+#include <algorithm>
 #include <ranges>
 #include <fstream>
 #include <sstream>
@@ -22,9 +23,27 @@ auto end_of_line(const std::string& line) -> std::string::const_iterator
 auto lex_line(std::vector<std::string>& tokens, const std::string& line) -> void
 {
     std::string token;
+    bool parsing_string_literal = false;
     for (auto it = line.begin(); it != end_of_line(line); ++it) {
-
-        if (!std::isspace(*it)) {
+        if (parsing_string_literal) {
+            if (*it == '"') {
+                tokens.push_back(token);
+                token.clear();
+                parsing_string_literal = false;
+            }
+            else {
+                token.push_back(*it);
+            }
+        }
+        else if (*it == '"') {
+            if (!token.empty()) {
+                tokens.push_back(token);
+                token.clear();
+            }
+            tokens.push_back("__literal");
+            parsing_string_literal = true;
+        }
+        else if (!std::isspace(*it)) {
             token += *it;
         }
         else if (!token.empty()) {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -7,13 +7,22 @@
 namespace anzu {
 namespace {
 
+// Returns an iterator to one past the end of the line (ignores comments)
+auto end_of_line(const std::string& line) -> std::string::const_iterator
+{
+    const auto line_end = line.find_first_of("//");
+    if (line_end != std::string::npos) {
+        auto it = line.begin();
+        std::advance(it, line_end);
+        return it;
+    }
+    return line.end();
+}
+
 auto lex_line(std::vector<std::string>& tokens, const std::string& line) -> void
 {
     std::string token;
-    for (auto it = line.begin(); it != line.end(); ++it) {
-        if (*it == '#') { // Ignore comments
-            break;
-        }
+    for (auto it = line.begin(); it != end_of_line(line); ++it) {
 
         if (!std::isspace(*it)) {
             token += *it;

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1,5 +1,6 @@
 #include "lexer.hpp"
 
+#include <fmt/format.h>
 #include <algorithm>
 #include <ranges>
 #include <fstream>
@@ -25,7 +26,11 @@ auto lex_line(std::vector<std::string>& tokens, const std::string& line) -> void
     std::string token;
     bool parsing_string_literal = false;
     for (auto it = line.begin(); it != end_of_line(line); ++it) {
-        if (parsing_string_literal) {
+        if (*it == '\\') {
+            ++it;
+            token.push_back(*it);
+        }
+        else if (parsing_string_literal) {
             if (*it == '"') {
                 tokens.push_back(token);
                 token.clear();
@@ -54,6 +59,11 @@ auto lex_line(std::vector<std::string>& tokens, const std::string& line) -> void
 
     if (!token.empty()) {
         tokens.push_back(token);
+    }
+
+    if (parsing_string_literal) {
+        fmt::print("lexing failed, string literal not closed\n");
+        std::exit(1);
     }
 }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -33,33 +33,32 @@ auto lex_line(std::vector<std::string>& tokens, const std::string& line) -> void
     std::string token;
     bool parsing_string_literal = false;
     for (auto it = line.begin(); it != end_of_line(line); ++it) {
-        // Backspace chars escape the next char, which must be of a certain group
-        if (*it == '\\') {
-            if (++it == line.end()) { bad_backspace(); }
-            switch (*it) {
-                break; case '\\': token.push_back('\\');
-                break; case '"': token.push_back('"');
-                break; case 'n': token.push_back('\n');
-                break; case 't': token.push_back('\t');
-                break; case 'r': token.push_back('\r');
-                break; default: bad_backspace();
-            }
-        }
-        else if (parsing_string_literal) {
-            if (*it == '"') {
+        
+        if (parsing_string_literal) {
+            if (*it == '"') { // End of literal
                 tokens.push_back(token);
                 token.clear();
                 parsing_string_literal = false;
+            }
+            else if (*it == '\\') { // Special character
+                if (++it == line.end()) { bad_backspace(); }
+                switch (*it) {
+                    break; case '\\': token.push_back('\\');
+                    break; case '"': token.push_back('"');
+                    break; case 'n': token.push_back('\n');
+                    break; case 't': token.push_back('\t');
+                    break; case 'r': token.push_back('\r');
+                    break; default: bad_backspace();
+                }
             }
             else {
                 token.push_back(*it);
             }
         }
-
-        else if (*it == '"') {
+        else if (*it == '"') { // Start of literal
             if (!token.empty()) {
-                tokens.push_back(token);
-                token.clear();
+                fmt::print("unknown string type: {}\n", token);
+                std::exit(1);
             }
             tokens.push_back("__literal");
             parsing_string_literal = true;

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -60,7 +60,7 @@ auto lex_line(std::vector<std::string>& tokens, const std::string& line) -> void
                 fmt::print("unknown string type: {}\n", token);
                 std::exit(1);
             }
-            tokens.push_back("__literal");
+            tokens.push_back("__string");
             parsing_string_literal = true;
         }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -5,6 +5,31 @@
 #include <sstream>
 
 namespace anzu {
+namespace {
+
+auto lex_line(std::vector<std::string>& tokens, const std::string& line) -> void
+{
+    std::string token;
+    for (auto it = line.begin(); it != line.end(); ++it) {
+        if (*it == '#') { // Ignore comments
+            break;
+        }
+
+        if (!std::isspace(*it)) {
+            token += *it;
+        }
+        else if (!token.empty()) {
+            tokens.push_back(token);
+            token.clear();
+        }
+    }
+
+    if (!token.empty()) {
+        tokens.push_back(token);
+    }
+}
+
+}
 
 auto lex(const std::string& file) -> std::vector<std::string>
 {
@@ -14,12 +39,7 @@ auto lex(const std::string& file) -> std::vector<std::string>
     std::ifstream file_stream{file};
     std::string line;
     while (std::getline(file_stream, line)) {
-        std::istringstream line_stream{line};
-        for (const auto& token : std::ranges::istream_view<std::string>(line_stream)
-                               | std::views::take_while([](auto&& tok) { return tok != "//"; }))
-        {
-            tokens.emplace_back(token);
-        }
+        lex_line(tokens, line);
     }
     return tokens;
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -4,33 +4,18 @@
 
 namespace anzu {
 
-bool is_literal(const std::string& token)
+auto is_int(const std::string& token) -> bool
 {
-    return token == "false"
-        || token == "true"
-        || token.find_first_not_of("0123456789") == std::string::npos;
+    return token.find_first_not_of("0123456789") == std::string::npos;
 }
 
-anzu::object parse_literal(const std::string& token)
+auto to_int(const std::string& token) -> int
 {
-    if (token == "true") {
-        return true;
+    if (!is_int(token)) {
+        fmt::print("cannot convert '{}' to int\n", token);
+        std::exit(1);
     }
-    if (token == "false") {
-        return false;
-    }
-    return parse_int(token);
-    fmt::print("[Fatal] Could not parse constant: {}\n", token);
-    std::exit(1);
-}
-
-int parse_int(const std::string& token)
-{
-    if (token.find_first_not_of("0123456789") == std::string::npos) {
-        return std::stoi(token);
-    }
-    fmt::print("[Fatal] Could not parse constant: {}\n", token);
-    std::exit(1);
+    return std::stoi(token);
 }
 
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -12,7 +12,7 @@ auto is_int(const std::string& token) -> bool
 auto to_int(const std::string& token) -> int
 {
     if (!is_int(token)) {
-        fmt::print("cannot convert '{}' to int\n", token);
+        fmt::print("type error: cannot convert '{}' to int\n", token);
         std::exit(1);
     }
     return std::stoi(token);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -3,6 +3,11 @@
 #include <fmt/format.h>
 
 namespace anzu {
+namespace {
+
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+
+}
 
 auto is_int(const std::string& token) -> bool
 {
@@ -16,6 +21,27 @@ auto to_int(const std::string& token) -> int
         std::exit(1);
     }
     return std::stoi(token);
+}
+
+auto to_repr(const anzu::object& obj) -> std::string
+{
+    return std::visit(overloaded {
+        [](int val) { return std::to_string(val); },
+        [](bool val) { return std::string{val ? "true" : "false"}; },
+        [](const std::string& val) {
+            std::string ret{'"'};
+            for (char c : val) {
+                switch (c) {
+                    break; case '\n': ret += "\\n";
+                    break; case '\t': ret += "\\t";
+                    break; case '\r': ret += "\\r";
+                    break; default: ret += c;
+                }
+            }
+            ret += '"';
+            return ret;
+        }
+    }, obj);
 }
 
 }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -10,6 +10,11 @@ using object = std::variant<int, bool, std::string>;
 auto is_int(const std::string& token) -> bool;
 auto to_int(const std::string& token) -> int;
 
+// Returns a printable representation of an object. Should not be used
+// to convert to an anzu::object storing a string at it puts quotation marks
+// around string and escapes special charcters.
+auto to_repr(const anzu::object& obj) -> std::string;
+
 }
 
 template <> struct fmt::formatter<anzu::object> {

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -7,10 +7,8 @@ namespace anzu {
 
 using object = std::variant<int, bool, std::string>;
 
-bool is_literal(const std::string& token);
-anzu::object parse_literal(const std::string& token);
-
-int parse_int(const std::string& token);
+auto is_int(const std::string& token) -> bool;
+auto to_int(const std::string& token) -> int;
 
 }
 

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -418,7 +418,7 @@ void op_dump::apply(anzu::context& ctx) const
 {
     auto& frame = ctx.top();
     anzu::verify_stack(frame, 1, ".");
-    fmt::print("{}\n", frame.pop());
+    fmt::print("{}", frame.pop());
     frame.ptr() += 1;
 }
 

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -406,11 +406,7 @@ void op_input::apply(anzu::context& ctx) const
     fmt::print("Input: ");
     std::string in;
     std::cin >> in;
-    if (!anzu::is_literal(in)) {
-        fmt::print("[BAD INPUT]\n");
-        std::exit(1);
-    }
-    frame.push(anzu::parse_literal(in));
+    frame.push(in);
     frame.ptr() += 1;
 }
 

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -15,7 +15,7 @@ struct op_push_const
 {
     anzu::object value;
 
-    std::string to_string() const { return fmt::format("OP_PUSH_CONST({})", value); }
+    std::string to_string() const { return fmt::format("OP_PUSH_CONST({})", anzu::to_repr(value)); }
     void apply(anzu::context& ctx) const;
 };
 

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -295,6 +295,26 @@ struct op_and
     void apply(anzu::context& ctx) const;
 };
 
+// Casts
+
+struct op_to_int
+{
+    std::string to_string() const { return "OP_TO_INT"; }
+    void apply(anzu::context& ctx) const;
+};
+
+struct op_to_bool
+{
+    std::string to_string() const { return "OP_TO_BOOL"; }
+    void apply(anzu::context& ctx) const;
+};
+
+struct op_to_str
+{
+    std::string to_string() const { return "OP_STR"; }
+    void apply(anzu::context& ctx) const;
+};
+
 // IO
 
 struct op_input
@@ -365,6 +385,11 @@ class op
         op_ge,
         op_or,
         op_and,
+
+        // Casts
+        op_to_int,
+        op_to_bool,
+        op_to_str,
 
         // IO
         op_input,

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -306,6 +306,17 @@ auto parse(const std::vector<std::string>& tokens) -> std::vector<anzu::op>
             });
         }
 
+        // Casts
+        else if (token == TO_INT) {
+            program.emplace_back(anzu::op_to_int{});
+        }
+        else if (token == TO_BOOL) {
+            program.emplace_back(anzu::op_to_bool{});
+        }
+        else if (token == TO_STR) {
+            program.emplace_back(anzu::op_to_str{});
+        }
+
         // Debug
         else if (token == PRINT_FRAME) {
             program.emplace_back(anzu::op_print_frame{});

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -284,6 +284,13 @@ auto parse(const std::vector<std::string>& tokens) -> std::vector<anzu::op>
             program.emplace_back(anzu::op_dump{});
         }
 
+        // Lexer Specials
+        else if (token == STRING_LIT) {
+            program.emplace_back(anzu::op_push_const{
+                .value=next(it)
+            });
+        }
+
         // Debug
         else if (token == PRINT_FRAME) {
             program.emplace_back(anzu::op_print_frame{});

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -185,8 +185,8 @@ auto parse(const std::vector<std::string>& tokens) -> std::vector<anzu::op>
             curr_func = name;
 
             function_def def = {
-                .argc=anzu::parse_int(next(it)),
-                .retc=anzu::parse_int(next(it)),
+                .argc=anzu::to_int(next(it)),
+                .retc=anzu::to_int(next(it)),
                 .ptr=std::ssize(program)
             };
             all_functions.emplace(name, def);
@@ -284,7 +284,22 @@ auto parse(const std::vector<std::string>& tokens) -> std::vector<anzu::op>
             program.emplace_back(anzu::op_dump{});
         }
 
-        // Lexer Specials
+        // Literals
+        else if (anzu::is_int(token)) {
+            program.emplace_back(anzu::op_push_const{
+                .value=anzu::to_int(token)
+            });
+        }
+        else if (token == TRUE_LIT) {
+            program.emplace_back(anzu::op_push_const{
+                .value=true
+            });
+        }
+        else if (token == FALSE_LIT) {
+            program.emplace_back(anzu::op_push_const{
+                .value=false
+            });
+        }
         else if (token == STRING_LIT) {
             program.emplace_back(anzu::op_push_const{
                 .value=next(it)
@@ -297,11 +312,6 @@ auto parse(const std::vector<std::string>& tokens) -> std::vector<anzu::op>
         }
 
         // Rest
-        else if (anzu::is_literal(token)) {
-            program.emplace_back(anzu::op_push_const{
-                .value=anzu::parse_literal(token)
-            });
-        }
         else if (all_functions.contains(token)) {
             auto [argc, retc, ptr] = all_functions[token];
             program.emplace_back(anzu::op_function_call{

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -64,6 +64,12 @@ constexpr auto TRUE_LIT    = std::string_view{"true"};
 constexpr auto FALSE_LIT   = std::string_view{"false"};
 constexpr auto STRING_LIT  = std::string_view{"__string"};
 
+// Casts
+
+constexpr auto TO_INT      = std::string_view{"(int)"};
+constexpr auto TO_BOOL     = std::string_view{"(bool)"};
+constexpr auto TO_STR      = std::string_view{"(str)"};
+
 // Debug
 
 constexpr auto PRINT_FRAME = std::string_view{"frame"};

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -58,8 +58,10 @@ constexpr auto AND         = std::string_view{"and"};
 constexpr auto INPUT       = std::string_view{"input"};
 constexpr auto DUMP        = std::string_view{"."};
 
-// Lexer Specials
+// Literals
 
+constexpr auto TRUE_LIT    = std::string_view{"true"};
+constexpr auto FALSE_LIT   = std::string_view{"false"};
 constexpr auto STRING_LIT  = std::string_view{"__string"};
 
 // Debug

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -58,6 +58,10 @@ constexpr auto AND         = std::string_view{"and"};
 constexpr auto INPUT       = std::string_view{"input"};
 constexpr auto DUMP        = std::string_view{"."};
 
+// Lexer Specials
+
+constexpr auto STRING_LIT  = std::string_view{"__string"};
+
 // Debug
 
 constexpr auto PRINT_FRAME = std::string_view{"frame"};


### PR DESCRIPTION
* Improved the lexer to be able to parse string literals.
* Removed `is_literal` and `parse_literal`. Now, `true` and `false` are keywords which are specifically handled in the parser, and ints are found and converted via `is_int` and `to_int`. For string, the lexer inserts a `__string` token before a token representing a string literal, which the parser uses to recognise a literal.
* Expanded the "numerical" operators a bit more. Specifically strings can be concatenated with `+`. May revert some of this however since it converts bools to ints before any operations which may not be desired.
* Added `(int)`, `(bool)` and `(str)` keywords which attempt to cast the top element of the stack to the specified type. The only conversion that can fail is `string` to `int`, and only succeeds if the string represents an integer (no way to currently test this, will need another function in the future).
* `input` now always returns just a string, requiring an explicit cast to use as a bool or an int.
* For `OP_PUSH_CONST`, added a function `anzu::to_repr` for printing objects. This is different to a `to_string` function as `to_repr` puts the object in quotations if its a string literal and escapes any special characters. Informally this returns what should be written in anzu source code to get back the original 