### PR TITLE
Object Class

### DIFF
--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,3 +1,4 @@
 // test file to manually testing new features
 
--5 (int) .
+"Input: " .
+input (int) .

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,5 +1,3 @@
 // test file to manually testing new features
 
-input (int) 10 != .
-
-
+-5 (int) .

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,5 +1,5 @@
 // test file to manually testing new features
 
-"hello" 3 + .
+input (int) 10 != .
 
 

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,4 +1,2 @@
 // test file to manually testing new features
 
-"Input: " .
-input (int) .

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -32,13 +32,26 @@ void run_program(const std::vector<anzu::op>& program)
     }
 }
 
+void run_program_debug(const std::vector<anzu::op>& program)
+{
+    anzu::context ctx;
+    ctx.push({});
+
+    while (ctx.top().ptr() < std::ssize(program)) {
+        const auto& op = program[ctx.top().ptr()];
+        fmt::print("{:>4} - {}\n", ctx.top().ptr(), op);
+        op.apply(ctx);
+    }
+}
+
 void print_usage()
 {
-    fmt::print("usage: anzu.exe <program_file> (lex|parse|run)\n\n");
+    fmt::print("usage: anzu.exe <program_file> (lex|parse|debug|run)\n\n");
     fmt::print("The Anzu Programming Language\n\n");
     fmt::print("options:\n");
     fmt::print("    lex   - displays the program after lexing into tokens\n");
     fmt::print("    parse - displays the program after parsig to bytecode\n");
+    fmt::print("    debug - executes the program and prints each op code executed\n");
     fmt::print("    run   - executes the program\n");
 }
 
@@ -69,6 +82,10 @@ int main(int argc, char** argv)
 
     if (mode == "run") {
         run_program(program);
+        return 0;
+    }
+    else if (mode == "debug") {
+        run_program_debug(program);
         return 0;
     }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -177,7 +177,11 @@ void swap(object& lhs, object& rhs)
 
 auto is_int(const std::string& token) -> bool
 {
-    return token.find_first_not_of("0123456789") == std::string::npos;
+    auto it = token.begin();
+    if (token.starts_with("-")) {
+        std::advance(it, 1);
+    }
+    return std::all_of(it, token.end(), std::isdigit);
 }
 
 auto to_int(const std::string& token) -> int

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -7,23 +7,63 @@ namespace {
 
 template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 
-}
-
-auto is_int(const std::string& token) -> bool
+auto type_error(const anzu::object& lhs, const anzu::object& rhs, std::string_view op) -> void
 {
-    return token.find_first_not_of("0123456789") == std::string::npos;
+    fmt::print("type error: cannot evaluate {} {} {}\n", lhs.to_repr(), rhs.to_repr(), op);
+    std::exit(1);
 }
 
-auto to_int(const std::string& token) -> int
+auto division_by_zero_error() -> void
 {
-    if (!is_int(token)) {
-        fmt::print("type error: cannot convert '{}' to int\n", token);
-        std::exit(1);
-    }
-    return std::stoi(token);
+    fmt::print("division by zero error\n");
+    std::exit(1);
 }
 
-auto to_repr(const anzu::object& obj) -> std::string
+}
+
+auto object::is_int() const -> bool
+{
+    return std::holds_alternative<int>(d_value);
+}
+
+auto object::is_bool() const -> bool
+{
+    return std::holds_alternative<bool>(d_value);
+}
+
+auto object::is_str() const -> bool
+{
+    return std::holds_alternative<std::string>(d_value);
+}
+
+auto object::to_int() const -> int
+{
+    return std::visit(overloaded {
+        [](int v) { return v; },
+        [](bool v) { return v ? 1 : 0; },
+        [](const std::string& v) { return anzu::to_int(v); }
+    }, d_value);
+}
+
+auto object::to_bool() const -> bool
+{
+    return std::visit(overloaded {
+        [](int v) { return v != 0; },
+        [](bool v) { return v; },
+        [](const std::string& v) { return v.size() > 0; }
+    }, d_value);
+}
+
+auto object::to_str() const -> std::string
+{
+    return std::visit(overloaded {
+        [](int v) { return std::to_string(v); },
+        [](bool v) { return std::string{v ? "true" : "false"}; },
+        [](const std::string& v) { return v; }
+    }, d_value);
+}
+
+auto object::to_repr() const -> std::string
 {
     return std::visit(overloaded {
         [](int val) { return std::to_string(val); },
@@ -41,7 +81,112 @@ auto to_repr(const anzu::object& obj) -> std::string
             ret += '"';
             return ret;
         }
-    }, obj);
+    }, d_value);
+}
+
+template <typename T>
+concept addable = requires(T a, T b) { { a + b }; };
+
+object operator+(const object& lhs, const object& rhs)
+{
+    return std::visit([]<typename A, typename B>(const A& a, const B& b) -> anzu::object {
+        if constexpr (std::is_same_v<A, B> && addable<A>) {
+            return a + b;
+        } else {
+            anzu::type_error(a, b, "+");
+            return 0;
+        }
+    }, lhs.d_value, rhs.d_value);
+}
+
+template <typename T>
+concept subtractible = requires(T a, T b) { { a - b }; };
+
+object operator-(const object& lhs, const object& rhs)
+{
+    return std::visit([&]<typename A, typename B>(const A& a, const B& b) -> anzu::object {
+        if constexpr (std::is_same_v<A, B> && subtractible<A>) {
+            return a - b;
+        } else {
+            anzu::type_error(a, b, "-");
+            return 0;
+        }
+    }, lhs.d_value, rhs.d_value);
+}
+
+template <typename T>
+concept multipliable = requires(T a, T b) { { a * b }; };
+
+object operator*(const object& lhs, const object& rhs)
+{
+    return std::visit([&]<typename A, typename B>(const A& a, const B& b) -> anzu::object {
+        if constexpr (std::is_same_v<A, B> && multipliable<A>) {
+            return a * b;
+        } else {
+            anzu::type_error(a, b, "*");
+            return 0;
+        }
+    }, lhs.d_value, rhs.d_value);
+}
+
+object operator/(const object& lhs, const object& rhs)
+{
+    return std::visit([&]<typename A, typename B>(const A& a, const B& b) -> anzu::object {
+        if constexpr (std::is_same_v<A, int> && std::is_same_v<B, int>) {
+            if (b != 0) {
+                return a / b;
+            }
+            anzu::division_by_zero_error();
+            return 0;
+        } else {
+            anzu::type_error(a, b, "/");
+            return 0;
+        }
+    }, lhs.d_value, rhs.d_value);
+}
+
+template <typename A, typename B>
+concept moddable = requires(A a, B b) { { a % b }; };
+
+object operator%(const object& lhs, const object& rhs)
+{
+    return std::visit([&]<typename A, typename B>(const A& a, const B& b) -> anzu::object {
+        if constexpr (moddable<A, B>) {
+            return a % b;
+        } else {
+            anzu::type_error(a, b, "%");
+            return 0;
+        }
+    }, lhs.d_value, rhs.d_value);
+}
+
+bool operator||(const object& lhs, const object& rhs)
+{
+    return lhs.to_bool() || rhs.to_bool();
+}
+
+bool operator&&(const object& lhs, const object& rhs)
+{
+    return lhs.to_bool() && rhs.to_bool();
+}
+
+void swap(object& lhs, object& rhs)
+{
+    swap(lhs.d_value, rhs.d_value);
+}
+
+auto is_int(const std::string& token) -> bool
+{
+    return token.find_first_not_of("0123456789") == std::string::npos;
+}
+
+auto to_int(const std::string& token) -> int
+{
+    if (!is_int(token)) {
+        fmt::print("type error: cannot convert '{}' to int\n", token);
+        std::exit(1);
+    }
+    return std::stoi(token);
 }
 
 }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -5,8 +5,6 @@
 
 namespace anzu {
 
-class invalid {};
-
 class object
 {
     using value_type = std::variant<

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -55,6 +55,6 @@ auto to_int(const std::string& token) -> int;
 template <> struct fmt::formatter<anzu::object> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.end(); }
     auto format(const anzu::object& obj, auto& ctx) {
-        return format_to(ctx.out(), obj.to_repr());
+        return format_to(ctx.out(), obj.to_str());
     }
 };

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -5,23 +5,56 @@
 
 namespace anzu {
 
-using object = std::variant<int, bool, std::string>;
+class invalid {};
+
+class object
+{
+    using value_type = std::variant<
+        int,
+        bool,
+        std::string
+    >;
+
+    value_type d_value;
+
+public:
+    template <typename Obj>
+    object(const Obj& obj) : d_value{obj} {}
+    
+    object() : d_value{0} {}
+
+    auto is_int() const -> bool;
+    auto is_bool() const -> bool;
+    auto is_str() const -> bool;
+
+    auto to_int() const -> int;
+    auto to_bool() const -> bool;
+    auto to_str() const -> std::string;
+
+    auto to_repr() const -> std::string;
+
+    friend object operator+(const object& lhs, const object& rhs);
+    friend object operator-(const object& lhs, const object& rhs);
+    friend object operator*(const object& lhs, const object& rhs);
+    friend object operator/(const object& lhs, const object& rhs);
+    friend object operator%(const object& lhs, const object& rhs);
+    
+    friend auto operator<=>(const object& lhs, const object& rhs) = default;
+
+    friend bool operator||(const object& lhs, const object& rhs);
+    friend bool operator&&(const object& lhs, const object& rhs);
+
+    friend void swap(object& lhs, object& rhs);
+};
 
 auto is_int(const std::string& token) -> bool;
 auto to_int(const std::string& token) -> int;
-
-// Returns a printable representation of an object. Should not be used
-// to convert to an anzu::object storing a string at it puts quotation marks
-// around string and escapes special charcters.
-auto to_repr(const anzu::object& obj) -> std::string;
 
 }
 
 template <> struct fmt::formatter<anzu::object> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.end(); }
     auto format(const anzu::object& obj, auto& ctx) {
-        return std::visit([&](const auto& o) {
-            return format_to(ctx.out(), "{}", o);
-        }, obj);
+        return format_to(ctx.out(), obj.to_repr());
     }
 };

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -336,7 +336,6 @@ void op_to_str::apply(anzu::context& ctx) const
 void op_input::apply(anzu::context& ctx) const
 {
     auto& frame = ctx.top();
-    fmt::print("Input: ");
     std::string in;
     std::cin >> in;
     frame.push(in);

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -138,13 +138,7 @@ void op_continue::apply(anzu::context& ctx) const
 void op_do::apply(anzu::context& ctx) const
 {
     auto& frame = ctx.top();
-    auto condition = std::visit(overloaded {
-        [](int v) { return v != 0; },
-        [](bool v) { return v; },
-        [](const std::string& v) { return v.size() > 0; }
-    }, frame.pop());
-
-    if (condition) {
+    if (frame.pop().to_bool()) {
         frame.ptr() += 1;
     } else {
         frame.ptr() = jump;
@@ -188,14 +182,7 @@ void op_add::apply(anzu::context& ctx) const
     anzu::verify_stack(frame, 2, "+");
     auto b = frame.pop();
     auto a = frame.pop();
-    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
-        if constexpr (addable<A, B>) {
-            frame.push(a + b);
-        } else {
-            fmt::print("cannot evaluate '{} {} +'\n", a, b);
-            std::exit(1);
-        }
-    }, a, b);
+    frame.push(a + b);
     frame.ptr() += 1;
 }
 
@@ -208,14 +195,7 @@ void op_sub::apply(anzu::context& ctx) const
     anzu::verify_stack(frame, 2, "-");
     auto b = frame.pop();
     auto a = frame.pop();
-    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
-        if constexpr (subtractable<A, B>) {
-            frame.push(a - b);
-        } else {
-            fmt::print("cannot evaluate '{} {} -'\n", a, b);
-            std::exit(1);
-        }
-    }, a, b);
+    frame.push(a - b);
     frame.ptr() += 1;
 }
 
@@ -228,14 +208,7 @@ void op_mul::apply(anzu::context& ctx) const
     anzu::verify_stack(frame, 2, "*");
     auto b = frame.pop();
     auto a = frame.pop();
-    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
-        if constexpr (multipliable<A, B>) {
-            frame.push(a * b);
-        } else {
-            fmt::print("cannot evaluate '{} {} *'\n", a, b);
-            std::exit(1);
-        }
-    }, a, b);
+    frame.push(a * b);
     frame.ptr() += 1;
 }
 
@@ -245,14 +218,7 @@ void op_div::apply(anzu::context& ctx) const
     anzu::verify_stack(frame, 2, "/");
     auto b = frame.pop();
     auto a = frame.pop();
-    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
-        if constexpr (std::is_same_v<A, int> && std::is_same_v<B, int>) {
-            frame.push(a / b);
-        } else {
-            fmt::print("cannot evaluate '{} {} /'\n", a, b);
-            std::exit(1);
-        }
-    }, a, b);
+    frame.push(a / b);
     frame.ptr() += 1;
 }
 
@@ -262,14 +228,7 @@ void op_mod::apply(anzu::context& ctx) const
     anzu::verify_stack(frame, 2, "%");
     auto b = frame.pop();
     auto a = frame.pop();
-    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
-        if constexpr (std::is_same_v<A, int> && std::is_same_v<B, int>) {
-            frame.push(a % b);
-        } else {
-            fmt::print("Can only sub integers\n");
-            std::exit(1);
-        }
-    }, a, b);
+    frame.push(a % b);
     frame.ptr() += 1;
 }
 
@@ -279,14 +238,7 @@ void op_eq::apply(anzu::context& ctx) const
     anzu::verify_stack(frame, 2, "==");
     auto b = frame.pop();
     auto a = frame.pop();
-    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
-        if constexpr (std::is_same_v<A, B>) {
-            frame.push(a == b);
-        } else {
-            fmt::print("Can only compare values of the same type\n");
-            std::exit(1);
-        }
-    }, a, b);
+    frame.push(a == b);
     frame.ptr() += 1;
 }
 
@@ -296,14 +248,7 @@ void op_ne::apply(anzu::context& ctx) const
     anzu::verify_stack(frame, 2, "!=");
     auto b = frame.pop();
     auto a = frame.pop();
-    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
-        if constexpr (std::is_same_v<A, B>) {
-            frame.push(a != b);
-        } else {
-            fmt::print("Can only compare values of the same type\n");
-            std::exit(1);
-        }
-    }, a, b);
+    frame.push(a != b);
     frame.ptr() += 1;
 }
 
@@ -313,14 +258,7 @@ void op_lt::apply(anzu::context& ctx) const
     anzu::verify_stack(frame, 2, "<");
     auto b = frame.pop();
     auto a = frame.pop();
-    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
-        if constexpr (std::is_same_v<A, B>) {
-            frame.push(a < b);
-        } else {
-            fmt::print("Can only compare values of the same type\n");
-            std::exit(1);
-        }
-    }, a, b);
+    frame.push(a < b);
     frame.ptr() += 1;
 }
 
@@ -330,14 +268,7 @@ void op_le::apply(anzu::context& ctx) const
     anzu::verify_stack(frame, 2, "<=");
     auto b = frame.pop();
     auto a = frame.pop();
-    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
-        if constexpr (std::is_same_v<A, B>) {
-            frame.push(a <= b);
-        } else {
-            fmt::print("Can only compare values of the same type\n");
-            std::exit(1);
-        }
-    }, a, b);
+    frame.push(a <= b);
     frame.ptr() += 1;
 }
 
@@ -347,14 +278,7 @@ void op_gt::apply(anzu::context& ctx) const
     anzu::verify_stack(frame, 2, ">");
     auto b = frame.pop();
     auto a = frame.pop();
-    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
-        if constexpr (std::is_same_v<A, B>) {
-            frame.push(a > b);
-        } else {
-            fmt::print("Can only compare values of the same type\n");
-            std::exit(1);
-        }
-    }, a, b);
+    frame.push(a >b);
     frame.ptr() += 1;
 }
 
@@ -364,14 +288,7 @@ void op_ge::apply(anzu::context& ctx) const
     anzu::verify_stack(frame, 2, ">=");
     auto b = frame.pop();
     auto a = frame.pop();
-    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
-        if constexpr (std::is_same_v<A, B>) {
-            frame.push(a >= b);
-        } else {
-            fmt::print("Can only compare values of the same type\n");
-            std::exit(1);
-        }
-    }, a, b);
+    frame.push(a >= b);
     frame.ptr() += 1;
 }
 
@@ -381,14 +298,7 @@ void op_or::apply(anzu::context& ctx) const
     anzu::verify_stack(frame, 2, "or");
     auto b = frame.pop();
     auto a = frame.pop();
-    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
-        if constexpr (std::is_same_v<A, bool> && std::is_same_v<B, bool>) {
-            frame.push(a || b);
-        } else {
-            fmt::print("Logical OR can only be used on bools\n");
-            std::exit(1);
-        }
-    }, a, b);
+    frame.push(a || b);
     frame.ptr() += 1;
 }
 
@@ -398,50 +308,28 @@ void op_and::apply(anzu::context& ctx) const
     anzu::verify_stack(frame, 2, "and");
     auto b = frame.pop();
     auto a = frame.pop();
-    std::visit([&]<typename A, typename B>(const A& a, const B& b) {
-        if constexpr (std::is_same_v<A, bool> && std::is_same_v<B, bool>) {
-            frame.push(a && b);
-        } else {
-            fmt::print("Logical AND can only be used on bools\n");
-            std::exit(1);
-        }
-    }, a, b);
+    frame.push(a && b);
     frame.ptr() += 1;
 }
 
 void op_to_int::apply(anzu::context& ctx) const
 {
     auto& frame = ctx.top();
-    auto new_val = std::visit(overloaded {
-        [](int v) { return v; },
-        [](bool v) { return v ? 1 : 0; },
-        [](const std::string& v) { return anzu::to_int(v); }
-    }, frame.pop());
-    frame.push(new_val);
+    frame.push(frame.pop().to_int());
     frame.ptr() += 1;
 }
 
 void op_to_bool::apply(anzu::context& ctx) const
 {
     auto& frame = ctx.top();
-    auto new_val = std::visit(overloaded {
-        [](int v) { return v != 0; },
-        [](bool v) { return v; },
-        [](const std::string& v) { return v.size() > 0; }
-    }, frame.pop());
-    frame.push(new_val);
+    frame.push(frame.pop().to_bool());
     frame.ptr() += 1;
 }
 
 void op_to_str::apply(anzu::context& ctx) const
 {
     auto& frame = ctx.top();
-    auto new_val = std::visit(overloaded {
-        [](int v) { return std::to_string(v); },
-        [](bool v) { return std::string{v ? "true" : "false"}; },
-        [](const std::string& v) { return v; }
-    }, frame.pop());
-    frame.push(new_val);
+    frame.push(frame.pop().to_str());
     frame.ptr() += 1;
 }
 

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -83,7 +83,7 @@ struct op_if_end
 
 struct op_elif
 {
-    std::ptrdiff_t jump = -1;
+    std::intptr_t jump = -1;
 
     std::string to_string() const
     {
@@ -95,7 +95,7 @@ struct op_elif
 
 struct op_else
 {
-    std::ptrdiff_t jump = -1;
+    std::intptr_t jump = -1;
 
     std::string to_string() const
     {
@@ -113,7 +113,7 @@ struct op_while
 
 struct op_while_end
 {
-    std::ptrdiff_t jump = -1;
+    std::intptr_t jump = -1;
 
     std::string to_string() const
     {
@@ -125,7 +125,7 @@ struct op_while_end
 
 struct op_break
 {
-    std::ptrdiff_t jump = -1;
+    std::intptr_t jump = -1;
 
     std::string to_string() const
     {
@@ -137,7 +137,7 @@ struct op_break
 
 struct op_continue
 {
-    std::ptrdiff_t jump = -1;
+    std::intptr_t jump = -1;
 
     std::string to_string() const
     {
@@ -149,7 +149,7 @@ struct op_continue
 
 struct op_do
 {
-    std::ptrdiff_t jump = -1;
+    std::intptr_t jump = -1;
 
     std::string to_string() const
     {
@@ -162,7 +162,7 @@ struct op_do
 struct op_function
 {
     std::string    name;
-    std::ptrdiff_t jump = -1;  // Jumps to end of function so it isnt invoked when running.
+    std::intptr_t jump = -1;  // Jumps to end of function so it isnt invoked when running.
 
     std::string to_string() const
     {
@@ -187,9 +187,9 @@ struct op_function_end
 
 struct op_function_call
 {
-    std::string    name;
-    int            argc;
-    std::ptrdiff_t jump;
+    std::string   name;
+    int           argc;
+    std::intptr_t jump;
 
     std::string to_string() const
     {

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -15,7 +15,7 @@ struct op_push_const
 {
     anzu::object value;
 
-    std::string to_string() const { return fmt::format("OP_PUSH_CONST({})", anzu::to_repr(value)); }
+    std::string to_string() const { return fmt::format("OP_PUSH_CONST({})", value.to_repr()); }
     void apply(anzu::context& ctx) const;
 };
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -33,9 +33,9 @@ inline T pop_top(std::stack<T>& stack)
     return ret;
 }
 
-void process_if_block(std::vector<anzu::op>& program, std::stack<std::ptrdiff_t>& stmt_stack)
+void process_if_block(std::vector<anzu::op>& program, std::stack<std::intptr_t>& stmt_stack)
 {
-    std::deque<std::ptrdiff_t> block;
+    std::deque<std::intptr_t> block;
     while (!program[stmt_stack.top()].get_if<anzu::op_if>()) {
         block.push_front(pop_top(stmt_stack)); // do/else/elif/end
     }
@@ -44,11 +44,11 @@ void process_if_block(std::vector<anzu::op>& program, std::stack<std::ptrdiff_t>
     auto end_ptr = block.back();
 
     for (std::size_t i = 0; i != block.size(); ++i) {
-        std::ptrdiff_t ptr = block[i];
+        std::intptr_t ptr = block[i];
         auto& op = program[ptr];
 
         if (auto* data = op.get_if<anzu::op_do>()) {
-            std::ptrdiff_t next_ptr = block[i+1]; // end or else
+            std::intptr_t next_ptr = block[i+1]; // end or else
             data->jump = next_ptr + 1;
         }
         else if (auto* data = op.get_if<anzu::op_elif>()) {
@@ -66,9 +66,9 @@ void process_if_block(std::vector<anzu::op>& program, std::stack<std::ptrdiff_t>
     }
 }
 
-void process_while_block(std::vector<anzu::op>& program, std::stack<std::ptrdiff_t>& stmt_stack)
+void process_while_block(std::vector<anzu::op>& program, std::stack<std::intptr_t>& stmt_stack)
 {
-    std::deque<std::ptrdiff_t> block;
+    std::deque<std::intptr_t> block;
     while (!program[stmt_stack.top()].get_if<anzu::op_while>()) {
         block.push_front(pop_top(stmt_stack)); // do/break/continue/end
     }
@@ -76,7 +76,7 @@ void process_while_block(std::vector<anzu::op>& program, std::stack<std::ptrdiff
     auto begin_ptr = pop_top(stmt_stack); // while
     auto end_ptr = block.back();
 
-    for (std::ptrdiff_t ptr : block) {
+    for (std::intptr_t ptr : block) {
         auto& op = program[ptr];
 
         if (auto* data = op.get_if<anzu::op_do>()) {
@@ -103,7 +103,7 @@ struct function_def
 {
     int            argc;
     int            retc;
-    std::ptrdiff_t ptr;
+    std::intptr_t ptr;
 };
 
 auto parse(const std::vector<std::string>& tokens) -> std::vector<anzu::op>
@@ -112,8 +112,8 @@ auto parse(const std::vector<std::string>& tokens) -> std::vector<anzu::op>
 
     // Contains a stack of indices to previous control flow statements suchs as
     // 'if', 'do' and 'else' so the jumps can be set up correctly.
-    std::stack<std::ptrdiff_t> if_stack;
-    std::stack<std::ptrdiff_t> while_stack;
+    std::stack<std::intptr_t> if_stack;
+    std::stack<std::intptr_t> while_stack;
 
     // Functions info
     std::optional<std::string> curr_func;

--- a/src/stack_frame.hpp
+++ b/src/stack_frame.hpp
@@ -53,7 +53,7 @@ class frame
     anzu::stack<anzu::object>                     d_values;
     std::unordered_map<std::string, anzu::object> d_symbols;
 
-    std::ptrdiff_t d_ptr = 0;
+    std::intptr_t d_ptr = 0;
 
 public:
     auto pop() -> anzu::object;
@@ -69,8 +69,8 @@ public:
 
     auto print() const -> void;
 
-    std::ptrdiff_t& ptr() { return d_ptr; }
-    std::ptrdiff_t ptr() const { return d_ptr; }
+    std::intptr_t& ptr() { return d_ptr; }
+    std::intptr_t ptr() const { return d_ptr; }
 };
 
 using context = anzu::stack<anzu::frame>;


### PR DESCRIPTION
* Wraps the object variant in a class, encapsulating all the logic and removing the need to have `std::visit` everywhere.
* Adds a `debug` mode, which executes the program and prints each op code hit.
* Use `intptr_t` rather than `ptrdiff_t`, which are the same types but more accurate in how we use them.