### PR TITLE
Token Improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["run", "${workspaceFolder}/recursion.anzu"],
+            "args": ["${workspaceFolder}/examples/test.anzu", "run"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,6 +74,7 @@
         "xutility": "cpp",
         "fstream": "cpp",
         "variant": "cpp",
-        "iostream": "cpp"
+        "iostream": "cpp",
+        "unordered_set": "cpp"
     }
 }

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,6 +1,6 @@
 # test file to manually testing new features
 
-
+"hello world\n" .
 
 function euler 0 1
     0 -> count

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,4 +1,4 @@
-// test file to manually testing new features
+# test file to manually testing new features
 
 "hello world\n" .
 

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,8 +1,8 @@
 // test file to manually testing new features
 
+"hello world\n" .
 
-
-function euler 0 1
+function euler 0 1:
     0 -> count
 
     0 while dup 1000 < do

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,8 +1,8 @@
 # test file to manually testing new features
 
-"hello world\n" .
 
-function euler 0 1:
+
+function euler 0 1
     0 -> count
 
     0 while dup 1000 < do
@@ -10,10 +10,10 @@ function euler 0 1:
             dup count + -> count
         elif dup 5 % 0 == do
             dup count + -> count
-        else
+        end
         1 +
     end
     count
 end
 
-euler
+euler .

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,2 +1,19 @@
 // test file to manually testing new features
 
+
+
+function euler 0 1
+    0 -> count
+
+    0 while dup 1000 < do
+        if dup 3 % 0 == do
+            dup count + -> count
+        elif dup 5 % 0 == do
+            dup count + -> count
+        else
+        1 +
+    end
+    count
+end
+
+euler

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -11,7 +11,10 @@ void print_tokens(const std::vector<anzu::token>& tokens)
 {
     for (const auto& token : tokens) {
         const auto text = fmt::format("'{}'", anzu::convert_to_raw(token.text));
-        fmt::print("{:<10} - {:<20} {:<5} {:<5}\n", anzu::to_string(token.type), text, token.line, token.col);
+        fmt::print(
+            "{:<10} - {:<20} {:<5} {:<5}\n",
+            anzu::to_string(token.type), text, token.line, token.col
+        );
     }
 }
 

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -10,8 +10,8 @@
 void print_tokens(const std::vector<anzu::token>& tokens)
 {
     for (const auto& token : tokens) {
-        const auto text = fmt::format("'{}'", token.text);
-        fmt::print("{:<20} {:<5} {:<5}\n", text, token.line, token.col);
+        const auto text = fmt::format("'{}'", anzu::convert_to_raw(token.text));
+        fmt::print("{:<10} - {:<20} {:<5} {:<5}\n", anzu::to_string(token.type), text, token.line, token.col);
     }
 }
 

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -10,7 +10,7 @@
 void print_tokens(const std::vector<anzu::token>& tokens)
 {
     for (const auto& token : tokens) {
-        const auto text = fmt::format("'{}'", anzu::convert_to_raw(token.text));
+        const auto text = fmt::format("'{}'", token.text);
         fmt::print(
             "{:<10} - {:<20} {:<5} {:<5}\n",
             anzu::to_string(token.type), text, token.line, token.col

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -7,10 +7,11 @@
 #include <string>
 #include <variant>
 
-void print_tokens(const std::vector<std::string>& tokens)
+void print_tokens(const std::vector<anzu::token>& tokens)
 {
     for (const auto& token : tokens) {
-        fmt::print("'{}'\n", token);
+        const auto text = fmt::format("'{}'", token.text);
+        fmt::print("{:<20} {:<5} {:<5}\n", text, token.line, token.col);
     }
 }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -38,7 +38,12 @@ auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const i
         ++col;
         if (parsing_string_literal) {
             if (*it == '"') { // End of literal
-                tokens.push_back({ .text=text, .line=lineno, .col=token_col });
+                tokens.push_back({
+                    .text=text,
+                    .line=lineno,
+                    .col=token_col,
+                    .type=token_type::string
+                });
                 text.clear();
                 parsing_string_literal = false;
             }
@@ -62,7 +67,6 @@ auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const i
                 fmt::print("unknown string type: {}\n", text);
                 std::exit(1);
             }
-            tokens.push_back({ .text="__string", .line=lineno, .col=token_col });
             parsing_string_literal = true;
         }
 
@@ -72,7 +76,12 @@ auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const i
 
         else {
             if (!text.empty()) {
-                tokens.push_back({ .text=text, .line=lineno, .col=token_col });
+                tokens.push_back({
+                    .text=text,
+                    .line=lineno,
+                    .col=token_col,
+                    .type=token_type::symbol
+                });
                 text.clear();
             }
             token_col = col;
@@ -80,7 +89,12 @@ auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const i
     }
 
     if (!text.empty()) {
-        tokens.push_back({ .text=text, .line=lineno, .col=token_col });
+        tokens.push_back({
+            .text=text,
+            .line=lineno,
+            .col=token_col,
+            .type=token_type::symbol
+        });
     }
 
     if (parsing_string_literal) {
@@ -89,6 +103,19 @@ auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const i
     }
 }
 
+}
+
+auto to_string(token_type type) -> std::string
+{
+    switch (type) {
+        break; case token_type::keyword: { return "keyword"; };
+        break; case token_type::bin_op:  { return "bin_op"; };
+        break; case token_type::symbol:  { return "symbol"; };
+        break; case token_type::name:    { return "name"; };
+        break; case token_type::number:  { return "number"; };
+        break; case token_type::string:  { return "string"; };
+        break; default:                  { return "UNKNOWN"; };
+    }
 }
 
 auto lex(const std::string& file) -> std::vector<anzu::token>

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1,4 +1,5 @@
 #include "lexer.hpp"
+#include "object.hpp"
 
 #include <fmt/format.h>
 #include <algorithm>
@@ -27,6 +28,23 @@ auto bad_backspace()
     fmt::print("Backspace character did not escape anything\n");
     std::exit(1);
 };
+
+auto get_token_type(std::string_view text) -> anzu::token_type
+{
+    if (keywords.contains(text)) {
+        return anzu::token_type::keyword;
+    }
+    if (bin_ops.contains(text)) {
+        return anzu::token_type::bin_op;
+    }
+    if (symbols.contains(text)) {
+        return anzu::token_type::symbol;
+    }
+    if (anzu::is_int(text)) {
+        return anzu::token_type::number;
+    }
+    return anzu::token_type::name;
+}
 
 auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const int lineno) -> void
 {
@@ -80,7 +98,7 @@ auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const i
                     .text=text,
                     .line=lineno,
                     .col=token_col,
-                    .type=token_type::symbol
+                    .type=get_token_type(text)
                 });
                 text.clear();
             }
@@ -93,7 +111,7 @@ auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const i
             .text=text,
             .line=lineno,
             .col=token_col,
-            .type=token_type::symbol
+            .type=get_token_type(text)
         });
     }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -78,7 +78,6 @@ auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const i
             }
             text += c;
         }
-
         else {
             push_token(get_token_type(text));
         }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -66,6 +66,12 @@ auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const i
         else if (c == '#') {
             break;
         }
+        else if (symbols.contains(std::string{c})) {
+            push_token(get_token_type(text));
+            text += c;
+            token_col = col;
+            push_token(token_type::symbol);
+        }
         else if (!std::isspace(c)) {
             if (text.empty()) {
                 token_col = col;

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -1,14 +1,75 @@
 #pragma once
 #include <vector>
 #include <string>
+#include <unordered_set>
 
 namespace anzu {
+
+static const std::unordered_set<std::string_view> keywords = {
+    "pop",
+    "dup",
+    "swap",
+    "rot",
+    "over",
+
+    "function",
+    "if",
+    "elif",
+    "else"
+    "while",
+    "break",
+    "continue",
+    "do",
+    "end",
+
+    "true",
+    "false",
+};
+
+static const std::unordered_set<std::string_view> bin_ops = {
+    "+",
+    "-",
+    "*",
+    "/",
+    "%",
+    "==",
+    "!=",
+    "<",
+    "<=",
+    ">",
+    ">=",
+    "||",
+    "&&",
+    "=",
+    "->"
+};
+
+static const std::unordered_set<std::string_view> punctuation = {
+    "(",
+    ")",
+    ":",
+    "[",
+    "]"
+};
+
+enum class token_type
+{
+    keyword,
+    bin_op,
+    symbol,
+    name,
+    number,
+    string
+};
+
+auto to_string(token_type type) -> std::string;
 
 struct token
 {
     std::string text;
     int         line;
     int         col;
+    token_type  type;
 };
 
 auto lex(const std::string& file) -> std::vector<anzu::token>;

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -4,6 +4,13 @@
 
 namespace anzu {
 
-auto lex(const std::string& file) -> std::vector<std::string>;
+struct token
+{
+    std::string text;
+    int         line;
+    int         col;
+};
+
+auto lex(const std::string& file) -> std::vector<anzu::token>;
 
 }

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -44,7 +44,7 @@ static const std::unordered_set<std::string_view> bin_ops = {
     "->"
 };
 
-static const std::unordered_set<std::string_view> punctuation = {
+static const std::unordered_set<std::string_view> symbols = {
     "(",
     ")",
     ":",

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -19,17 +19,29 @@ auto division_by_zero_error() -> void
     std::exit(1);
 }
 
+auto format_error(const std::string& str) -> void
+{
+    fmt::print("format error: could not format special chars in '{}'\n", str);
+    std::exit(1);
 }
 
-auto convert_to_raw(const std::string& str) -> std::string
+}
+
+auto format_special_chars(const std::string& str) -> std::string
 {
     std::string ret;
-    for (auto c : str) {
-        switch (c) {
-            break; case '\n': ret += "\\n";
-            break; case '\t': ret += "\\t";
-            break; case '\r': ret += "\\r";
-            break; default: ret += c;
+    for (auto it = str.begin(); it != str.end(); ++it) {
+        if (*it == '\\') {
+            if (++it == str.end()) { format_error(str); }
+            switch (*it) {
+                break; case 'n': ret += '\n';
+                break; case 't': ret += '\t';
+                break; case 'r': ret += '\r';
+                break; default: format_error(str);
+            }
+        }
+        else {
+            ret += *it;
         }
     }
     return ret;
@@ -73,7 +85,7 @@ auto object::to_str() const -> std::string
     return std::visit(overloaded {
         [](int v) { return std::to_string(v); },
         [](bool v) { return std::string{v ? "true" : "false"}; },
-        [](const std::string& v) { return v; }
+        [](const std::string& v) { return anzu::format_special_chars(v); }
     }, d_value);
 }
 
@@ -83,7 +95,7 @@ auto object::to_repr() const -> std::string
         [](int val) { return std::to_string(val); },
         [](bool val) { return std::string{val ? "true" : "false"}; },
         [](const std::string& val) {
-            return fmt::format("'{}'", anzu::convert_to_raw(val));
+            return fmt::format("'{}'", val);
         }
     }, d_value);
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -179,7 +179,7 @@ void swap(object& lhs, object& rhs)
     swap(lhs.d_value, rhs.d_value);
 }
 
-auto is_int(const std::string& token) -> bool
+auto is_int(std::string_view token) -> bool
 {
     auto it = token.begin();
     if (token.starts_with("-")) {
@@ -188,13 +188,13 @@ auto is_int(const std::string& token) -> bool
     return std::all_of(it, token.end(), std::isdigit);
 }
 
-auto to_int(const std::string& token) -> int
+auto to_int(std::string_view token) -> int
 {
     if (!is_int(token)) {
         fmt::print("type error: cannot convert '{}' to int\n", token);
         std::exit(1);
     }
-    return std::stoi(token);
+    return std::stoi(std::string{token});
 }
 
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -21,6 +21,20 @@ auto division_by_zero_error() -> void
 
 }
 
+auto convert_to_raw(const std::string& str) -> std::string
+{
+    std::string ret;
+    for (auto c : str) {
+        switch (c) {
+            break; case '\n': ret += "\\n";
+            break; case '\t': ret += "\\t";
+            break; case '\r': ret += "\\r";
+            break; default: ret += c;
+        }
+    }
+    return ret;
+}
+
 auto object::is_int() const -> bool
 {
     return std::holds_alternative<int>(d_value);
@@ -69,17 +83,7 @@ auto object::to_repr() const -> std::string
         [](int val) { return std::to_string(val); },
         [](bool val) { return std::string{val ? "true" : "false"}; },
         [](const std::string& val) {
-            std::string ret{'"'};
-            for (char c : val) {
-                switch (c) {
-                    break; case '\n': ret += "\\n";
-                    break; case '\t': ret += "\\t";
-                    break; case '\r': ret += "\\r";
-                    break; default: ret += c;
-                }
-            }
-            ret += '"';
-            return ret;
+            return fmt::format("'{}'", anzu::convert_to_raw(val));
         }
     }, d_value);
 }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -48,8 +48,7 @@ public:
 auto is_int(const std::string& token) -> bool;
 auto to_int(const std::string& token) -> int;
 
-
-auto convert_special_characters(const std::string& str) -> std::string;
+auto convert_to_raw(const std::string& str) -> std::string;
 
 }
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -48,6 +48,9 @@ public:
 auto is_int(const std::string& token) -> bool;
 auto to_int(const std::string& token) -> int;
 
+
+auto convert_special_characters(const std::string& str) -> std::string;
+
 }
 
 template <> struct fmt::formatter<anzu::object> {

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -45,8 +45,8 @@ public:
     friend void swap(object& lhs, object& rhs);
 };
 
-auto is_int(const std::string& token) -> bool;
-auto to_int(const std::string& token) -> int;
+auto is_int(std::string_view token) -> bool;
+auto to_int(std::string_view token) -> int;
 
 auto convert_to_raw(const std::string& str) -> std::string;
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -48,7 +48,7 @@ public:
 auto is_int(std::string_view token) -> bool;
 auto to_int(std::string_view token) -> int;
 
-auto convert_to_raw(const std::string& str) -> std::string;
+auto foramt_special_chars(const std::string& str) -> std::string;
 
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -233,7 +233,8 @@ auto parse(const std::vector<anzu::token>& tokens) -> std::vector<anzu::op>
             else if (blocks.top() == "FUNCTION") {
                 auto def = all_functions[*curr_func];
                 curr_func.reset();
-                program[def.ptr].get_if<anzu::op_function>()->jump = std::ssize(program) + 1;
+                auto func = program[def.ptr].get_if<anzu::op_function>();
+                func->jump = std::ssize(program) + 1;
                 program.emplace_back(anzu::op_function_end{ .retc=def.retc });
             }
             else {
@@ -340,6 +341,11 @@ auto parse(const std::vector<anzu::token>& tokens) -> std::vector<anzu::op>
             });
         }
         ++it;
+    }
+
+    if (!blocks.empty()) {
+        fmt::print("syntax error: not all blocks have been closed\n");
+        std::exit(1);
     }
     return program;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -13,11 +13,6 @@
 namespace anzu {
 namespace {
 
-inline std::string next(std::vector<std::string>::const_iterator& it)
-{
-    return *(++it);
-}
-
 template <typename... Args>
 inline void exit_bad(std::string_view format, Args&&... args)
 {
@@ -106,7 +101,7 @@ struct function_def
     std::intptr_t ptr;
 };
 
-auto parse(const std::vector<std::string>& tokens) -> std::vector<anzu::op>
+auto parse(const std::vector<anzu::token>& tokens) -> std::vector<anzu::op>
 {
     std::vector<anzu::op> program;
 
@@ -124,7 +119,7 @@ auto parse(const std::vector<std::string>& tokens) -> std::vector<anzu::op>
 
     auto it = tokens.begin();
     while (it != tokens.end()) {
-        const auto& token = *it;
+        const auto& token = it->text;
 
         // Stack Manipulation
         if (token == POP) {
@@ -145,7 +140,7 @@ auto parse(const std::vector<std::string>& tokens) -> std::vector<anzu::op>
 
         // Store Manipulation
         else if (token == STORE) {
-            program.emplace_back(anzu::op_store{ .name=next(it) });
+            program.emplace_back(anzu::op_store{ .name=(++it)->text });
         }
 
         // Control Flow
@@ -181,12 +176,12 @@ auto parse(const std::vector<std::string>& tokens) -> std::vector<anzu::op>
                 fmt::print("error: cannot nest functions, '{}' has not been completed\n", *curr_func);
                 std::exit(1);
             }
-            std::string name = next(it);
+            std::string name = (++it)->text;
             curr_func = name;
 
             function_def def = {
-                .argc=anzu::to_int(next(it)),
-                .retc=anzu::to_int(next(it)),
+                .argc=anzu::to_int((++it)->text),
+                .retc=anzu::to_int((++it)->text),
                 .ptr=std::ssize(program)
             };
             all_functions.emplace(name, def);
@@ -302,7 +297,7 @@ auto parse(const std::vector<std::string>& tokens) -> std::vector<anzu::op>
         }
         else if (token == STRING_LIT) {
             program.emplace_back(anzu::op_push_const{
-                .value=next(it)
+                .value=(++it)->text
             });
         }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -121,8 +121,19 @@ auto parse(const std::vector<anzu::token>& tokens) -> std::vector<anzu::op>
     while (it != tokens.end()) {
         const auto& token = it->text;
 
+        if (it->type == token_type::string) {
+            program.emplace_back(anzu::op_push_const{
+                .value=it->text
+            });
+        }
+        else if (it->type == token_type::number) {
+            program.emplace_back(anzu::op_push_const{
+                .value=anzu::to_int(it->text)
+            });
+        }
+
         // Stack Manipulation
-        if (token == POP) {
+        else if (token == POP) {
             program.emplace_back(anzu::op_pop{});
         }
         else if (token == DUP) {
@@ -173,7 +184,11 @@ auto parse(const std::vector<anzu::token>& tokens) -> std::vector<anzu::op>
         else if (token == FUNCTION) {
             blocks.push("FUNCTION");
             if (curr_func.has_value()) {
-                fmt::print("error: cannot nest functions, '{}' has not been completed\n", *curr_func);
+                fmt::print(
+                    "syntax error line {} col {}: cannot nest functions, '{}' has not been completed\n",
+                    it->line,
+                    it->col,
+                    *curr_func);
                 std::exit(1);
             }
             std::string name = (++it)->text;
@@ -293,11 +308,6 @@ auto parse(const std::vector<anzu::token>& tokens) -> std::vector<anzu::op>
         else if (token == FALSE_LIT) {
             program.emplace_back(anzu::op_push_const{
                 .value=false
-            });
-        }
-        else if (token == STRING_LIT) {
-            program.emplace_back(anzu::op_push_const{
-                .value=(++it)->text
             });
         }
 

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -63,7 +63,6 @@ constexpr auto DUMP        = std::string_view{"."};
 
 constexpr auto TRUE_LIT    = std::string_view{"true"};
 constexpr auto FALSE_LIT   = std::string_view{"false"};
-constexpr auto STRING_LIT  = std::string_view{"__string"};
 
 // Casts
 

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "op_codes.hpp"
+#include "lexer.hpp"
 
 #include <vector>
 #include <string>
@@ -74,6 +75,6 @@ constexpr auto TO_STR      = std::string_view{"(str)"};
 
 constexpr auto PRINT_FRAME = std::string_view{"frame"};
 
-auto parse(const std::vector<std::string>& tokens) -> std::vector<anzu::op>;
+auto parse(const std::vector<anzu::token>& tokens) -> std::vector<anzu::op>;
 
 }


### PR DESCRIPTION
* Tokens produced by the lexer now contain the row and line number, as well as a token type.
* The "string" token type is now used to recognise string literals rather than inserting a special token before it.
* Similarly, integer literals are recognised as "number"s.
* String literals are stored in their raw form, with special characters like `\n` only being processed when printed to the screen. This will be a problem if we introduce a way to get the length of a string, but that can be dealt with via a separate function.