### PR TITLE
Lists and Builtin Functions

### DIFF
--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,8 +1,8 @@
 # test file to manually testing new features
 
-[]
-dup 1 list_push
+[1, 2, 3, 4, 5, 6] -> x
 
-print
-
-
+0 while dup x list_size < do
+    x over list_at print
+    1 + 
+end

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,11 +1,7 @@
 # test file to manually testing new features
 
-[1, 2, true, [1, 2], "hello world\n", 3]
-
-dup 3 list_at -> x
-
-x 3 list_push
-x print
+[]
+dup 1 list_push
 
 print
 

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,20 +1,8 @@
 # test file to manually testing new features
 
-list_new -> l
+list_new
 
-l 5 list_push
-l 2 list_push
-l 8 list_push
-l 0 list_push
-l 51 list_push
+dup 1 list_push
+dup 2 list_push
 
-l list_size -> size
-0 -> count
-while count size < do
-    l count list_at print
-    count 1 + -> count
-end
-
-# for x in l do
-#     x print
-# end
+dup print

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,6 +1,6 @@
 # test file to manually testing new features
 
-list_new
+[1, 2, "hello world\n", 3]
 
 dup 1 list_push
 dup 2 list_push

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,8 +1,12 @@
 # test file to manually testing new features
 
-[1, 2, "hello world\n", 3]
+[1, 2, true, [1, 2], "hello world\n", 3]
 
-dup 1 list_push
-dup 2 list_push
+dup 3 list_at -> x
 
-dup print
+x 3 list_push
+x print
+
+print
+
+

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,3 +1,13 @@
 # test file to manually testing new features
 
-array 5 arr.push
+l
+5 list_push
+6 list_push
+7 list_push
+
+l list_size .
+
+
+for x in l do
+
+end

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,19 +1,3 @@
 # test file to manually testing new features
 
-"hello world\n" .
-
-function euler 0 1
-    0 -> count
-
-    0 while (dup 1000 <) do
-        if dup 3 % 0 == do
-            dup count + -> count
-        elif dup 5 % 0 == do
-            dup count + -> count
-        end
-        1 +
-    end
-    count
-end
-
-euler .
+array 5 arr.push

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,13 +1,20 @@
 # test file to manually testing new features
 
-list_new
-5 list_push
-6 list_push
-"string" list_push
+list_new -> l
 
-list_new
-1 list_push
-2 list_push
-list_push
+l 5 list_push
+l 2 list_push
+l 8 list_push
+l 0 list_push
+l 51 list_push
 
-dup print
+l list_size -> size
+0 -> count
+while count size < do
+    l count list_at print
+    count 1 + -> count
+end
+
+# for x in l do
+#     x print
+# end

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,13 +1,3 @@
 # test file to manually testing new features
 
-l
-5 list_push
-6 list_push
-7 list_push
-
-l list_size .
-
-
-for x in l do
-
-end
+5 print

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,3 +1,13 @@
 # test file to manually testing new features
 
-5 print
+list_new
+5 list_push
+6 list_push
+"string" list_push
+
+list_new
+1 list_push
+2 list_push
+list_push
+
+dup print

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(anzu
                op_codes.cpp
                lexer.cpp
                parser.cpp
-               object.cpp)
+               object.cpp
+               functions.cpp)
 
 target_include_directories(anzu PRIVATE .)

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -18,29 +18,25 @@ auto verify(bool condition, std::string_view msg) -> void
 auto builtin_print(anzu::context& ctx) -> void
 {
     verify(!ctx.top().empty(), "frame stack is empty, nothing to print\n");
-    anzu::print("{}", ctx.top().pop());
-    ctx.top().ptr() += 1;
+    anzu::print("{}\n", ctx.top().pop());
 }
 
 auto builtin_stack_size(anzu::context& ctx) -> void
 {
     auto stack_size = static_cast<int>(ctx.top().stack_size());
     ctx.top().push(stack_size);
-    ctx.top().ptr() += 1;
 };
 
 auto builtin_print_frame(anzu::context& ctx) -> void
 {
     auto& frame = ctx.top();
     frame.print();
-    frame.ptr() += 1;
 }
 
 auto builtin_list_new(anzu::context& ctx) -> void
 {
     auto& frame = ctx.top();
     frame.push(std::make_shared<std::vector<anzu::object>>());
-    frame.ptr() += 1;
 }
 
 auto builtin_list_push(anzu::context& ctx) -> void
@@ -49,8 +45,35 @@ auto builtin_list_push(anzu::context& ctx) -> void
     verify(frame.stack_size() >= 2, "stack must contain two elements for list_push\n");
     verify(frame.top(1).is_list(), "second element on stack must be a list for list_push\n");
     auto elem = frame.pop();
-    frame.top().as_list()->push_back(elem);
-    frame.ptr() += 1;
+    auto list = frame.pop();
+    list.as_list()->push_back(elem);
+}
+
+auto builtin_list_pop(anzu::context& ctx) -> void
+{
+    auto& frame = ctx.top();
+    verify(frame.top().is_list(), "top element on stack must be a list for list_pop\n");
+    auto list = frame.pop();
+    list.as_list()->pop_back();
+}
+
+auto builtin_list_size(anzu::context& ctx) -> void
+{
+    auto& frame = ctx.top();
+    verify(frame.top().is_list(), "top element on stack must be a list for list_size\n");
+    auto list = frame.pop();
+    frame.push(static_cast<int>(list.as_list()->size()));
+}
+
+auto builtin_list_at(anzu::context& ctx) -> void
+{
+    auto& frame = ctx.top();
+    verify(frame.stack_size() >= 2, "stack must contain two elements for list_push\n");
+    verify(frame.top(0).is_int(), "first element of stack must be an integer (index into list)\n");
+    verify(frame.top(1).is_list(), "second element on stack must be a list for list_push\n");
+    auto pos = frame.pop();
+    auto list = frame.pop();
+    frame.push(list.as_list()->at(static_cast<std::size_t>(pos.to_int())));
 }
 
 }
@@ -62,6 +85,9 @@ static const std::unordered_map<std::string, std::function<void(anzu::context&)>
     // List functions
     { "list_new", builtin_list_new },
     { "list_push", builtin_list_push },
+    { "list_pop", builtin_list_pop },
+    { "list_size", builtin_list_size },
+    { "list_at", builtin_list_at },
 
     // Debug functions
     { "__print_frame__", builtin_print_frame }
@@ -77,6 +103,7 @@ auto is_builtin(const std::string& name) -> bool
 auto call_builtin(const std::string& name, anzu::context& ctx) -> void
 {
     builtins.at(name)(ctx);
+    ctx.top().ptr() += 1;
 }
 
 }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -74,7 +74,7 @@ auto builtin_list_at(anzu::context& ctx) -> void
 
 }
 
-static const std::unordered_map<std::string, std::function<void(anzu::context&)>> builtins = {
+static const std::unordered_map<std::string, void(*)(anzu::context&)> builtins = {
     { "print", builtin_print },
     { "stack_size", builtin_stack_size },
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1,0 +1,23 @@
+#include "functions.hpp"
+
+#include <unordered_map>
+#include <string>
+#include <functional>
+
+static const std::unordered_map<std::string, std::function<void(anzu::context&)>> builtins = {
+
+};
+
+namespace anzu {
+
+auto is_builtin(const std::string& name) -> bool
+{
+    return builtins.contains(name);
+}
+
+auto call_builtin(const std::string& name, anzu::context& ctx) -> void
+{
+    builtins.at(name)(ctx);
+}
+
+}

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1,10 +1,12 @@
 #include "functions.hpp"
 #include "print.hpp"
+#include "object.hpp"
 
 #include <unordered_map>
 #include <string>
 #include <functional>
 
+namespace anzu {
 namespace {
 
 auto verify(bool condition, std::string_view msg) -> void
@@ -46,7 +48,7 @@ auto builtin_list_push(anzu::context& ctx) -> void
     verify(frame.top(1).is_list(), "second element on stack must be a list for list_push\n");
     auto elem = frame.pop();
     auto list = frame.pop();
-    list.as_list()->push_back(elem);
+    list.as<object_list>()->push_back(elem);
 }
 
 auto builtin_list_pop(anzu::context& ctx) -> void
@@ -54,7 +56,7 @@ auto builtin_list_pop(anzu::context& ctx) -> void
     auto& frame = ctx.top();
     verify(frame.top().is_list(), "top element on stack must be a list for list_pop\n");
     auto list = frame.pop();
-    list.as_list()->pop_back();
+    list.as<object_list>()->pop_back();
 }
 
 auto builtin_list_size(anzu::context& ctx) -> void
@@ -62,7 +64,7 @@ auto builtin_list_size(anzu::context& ctx) -> void
     auto& frame = ctx.top();
     verify(frame.top().is_list(), "top element on stack must be a list for list_size\n");
     auto list = frame.pop();
-    frame.push(static_cast<int>(list.as_list()->size()));
+    frame.push(static_cast<int>(list.as<object_list>()->size()));
 }
 
 auto builtin_list_at(anzu::context& ctx) -> void
@@ -73,7 +75,7 @@ auto builtin_list_at(anzu::context& ctx) -> void
     verify(frame.top(1).is_list(), "second element on stack must be a list for list_push\n");
     auto pos = frame.pop();
     auto list = frame.pop();
-    frame.push(list.as_list()->at(static_cast<std::size_t>(pos.to_int())));
+    frame.push(list.as<object_list>()->at(static_cast<std::size_t>(pos.to_int())));
 }
 
 }
@@ -92,8 +94,6 @@ static const std::unordered_map<std::string, std::function<void(anzu::context&)>
     // Debug functions
     { "__print_frame__", builtin_print_frame }
 };
-
-namespace anzu {
 
 auto is_builtin(const std::string& name) -> bool
 {

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1,11 +1,31 @@
 #include "functions.hpp"
+#include "print.hpp"
 
 #include <unordered_map>
 #include <string>
 #include <functional>
 
-static const std::unordered_map<std::string, std::function<void(anzu::context&)>> builtins = {
+namespace {
 
+auto verify(bool condition, std::string_view msg) -> void
+{
+    if (!condition) {
+        anzu::print(msg);
+        std::exit(1);
+    }
+}
+
+auto builtin_print(anzu::context& ctx) -> void
+{
+    verify(!ctx.top().empty(), "frame stack is empty, nothing to print\n");
+    anzu::print("{}", ctx.top().pop());
+    ctx.top().ptr() += 1;
+}
+
+}
+
+static const std::unordered_map<std::string, std::function<void(anzu::context&)>> builtins = {
+    { "print", builtin_print }
 };
 
 namespace anzu {

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -35,12 +35,6 @@ auto builtin_print_frame(anzu::context& ctx) -> void
     frame.print();
 }
 
-auto builtin_list_new(anzu::context& ctx) -> void
-{
-    auto& frame = ctx.top();
-    frame.push(std::make_shared<std::vector<anzu::object>>());
-}
-
 auto builtin_list_push(anzu::context& ctx) -> void
 {
     auto& frame = ctx.top();
@@ -85,7 +79,6 @@ static const std::unordered_map<std::string, std::function<void(anzu::context&)>
     { "stack_size", builtin_stack_size },
 
     // List functions
-    { "list_new", builtin_list_new },
     { "list_push", builtin_list_push },
     { "list_pop", builtin_list_pop },
     { "list_size", builtin_list_size },

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -74,7 +74,7 @@ auto builtin_list_at(anzu::context& ctx) -> void
 
 }
 
-static const std::unordered_map<std::string, void(*)(anzu::context&)> builtins = {
+static const std::unordered_map<std::string, builtin_function> builtins = {
     { "print", builtin_print },
     { "stack_size", builtin_stack_size },
 
@@ -93,10 +93,9 @@ auto is_builtin(const std::string& name) -> bool
     return builtins.contains(name);
 }
 
-auto call_builtin(const std::string& name, anzu::context& ctx) -> void
+auto fetch_builtin(const std::string& name) -> builtin_function
 {
-    builtins.at(name)(ctx);
-    ctx.top().ptr() += 1;
+    return builtins.at(name);
 }
 
 }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -22,10 +22,49 @@ auto builtin_print(anzu::context& ctx) -> void
     ctx.top().ptr() += 1;
 }
 
+auto builtin_stack_size(anzu::context& ctx) -> void
+{
+    auto stack_size = static_cast<int>(ctx.top().stack_size());
+    ctx.top().push(stack_size);
+    ctx.top().ptr() += 1;
+};
+
+auto builtin_print_frame(anzu::context& ctx) -> void
+{
+    auto& frame = ctx.top();
+    frame.print();
+    frame.ptr() += 1;
+}
+
+auto builtin_list_new(anzu::context& ctx) -> void
+{
+    auto& frame = ctx.top();
+    frame.push(std::make_shared<std::vector<anzu::object>>());
+    frame.ptr() += 1;
+}
+
+auto builtin_list_push(anzu::context& ctx) -> void
+{
+    auto& frame = ctx.top();
+    verify(frame.stack_size() >= 2, "stack must contain two elements for list_push\n");
+    verify(frame.top(1).is_list(), "second element on stack must be a list for list_push\n");
+    auto elem = frame.pop();
+    frame.top().as_list()->push_back(elem);
+    frame.ptr() += 1;
+}
+
 }
 
 static const std::unordered_map<std::string, std::function<void(anzu::context&)>> builtins = {
-    { "print", builtin_print }
+    { "print", builtin_print },
+    { "stack_size", builtin_stack_size },
+
+    // List functions
+    { "list_new", builtin_list_new },
+    { "list_push", builtin_list_push },
+
+    // Debug functions
+    { "__print_frame__", builtin_print_frame }
 };
 
 namespace anzu {

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -1,0 +1,12 @@
+#pragma once
+// Builtin functions that can be called from scripts
+#include "stack_frame.hpp"
+
+#include <string>
+
+namespace anzu {
+
+auto is_builtin(const std::string& name) -> bool;
+auto call_builtin(const std::string& name, anzu::context& ctx) -> void;
+    
+}

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -6,7 +6,9 @@
 
 namespace anzu {
 
+using builtin_function = void(*)(anzu::context&);
+
 auto is_builtin(const std::string& name) -> bool;
-auto call_builtin(const std::string& name, anzu::context& ctx) -> void;
+auto fetch_builtin(const std::string& name) -> builtin_function;
     
 }

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -49,7 +49,8 @@ static const std::unordered_set<std::string_view> symbols = {
     ")",
     ":",
     "[",
-    "]"
+    "]",
+    ","
 };
 
 enum class token_type

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -28,7 +28,7 @@ auto format_error(const std::string& str) -> void
     std::exit(1);
 }
 
-auto type_error_list_convversion(std::string_view type) -> void
+auto type_error_list_conversion(std::string_view type) -> void
 {
     anzu::print("type error: cannot convert list to {}\n", type);
     std::exit(1);
@@ -77,8 +77,8 @@ auto object::to_int() const -> int
         [](int v) { return v; },
         [](bool v) { return v ? 1 : 0; },
         [](const std::string& v) { return anzu::to_int(v); },
-        [](const std::shared_ptr<std::vector<object>>& v) {
-            type_error_list_convversion("int");
+        [](const object_list& v) {
+            type_error_list_conversion("int");
             return 0;
         }
     }, d_value);
@@ -90,7 +90,7 @@ auto object::to_bool() const -> bool
         [](int v) { return v != 0; },
         [](bool v) { return v; },
         [](const std::string& v) { return v.size() > 0; },
-        [](const std::shared_ptr<std::vector<object>>& v) { return v->size() > 0; }
+        [](const object_list& v) { return v->size() > 0; }
     }, d_value);
 }
 
@@ -100,8 +100,8 @@ auto object::to_str() const -> std::string
         [](int v) { return std::to_string(v); },
         [](bool v) { return std::string{v ? "true" : "false"}; },
         [](const std::string& v) { return anzu::format_special_chars(v); },
-        [](const std::shared_ptr<std::vector<object>>& v) {
-            type_error_list_convversion("str");
+        [](const object_list& v) {
+            type_error_list_conversion("str");
             return std::string{};
         }
     }, d_value);
@@ -113,7 +113,9 @@ auto object::to_repr() const -> std::string
         [](int val) { return std::to_string(val); },
         [](bool val) { return std::string{val ? "true" : "false"}; },
         [](const std::string& val) { return std::format("'{}'", val); },
-        [](const std::shared_ptr<std::vector<object>>& v) { return std::string{"list (repr not implemented)"}; }
+        [](const object_list& v) {
+            return std::string{"list (repr not implemented)"};
+        }
     }, d_value);
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -28,6 +28,12 @@ auto format_error(const std::string& str) -> void
     std::exit(1);
 }
 
+auto type_error_array_convversion(std::string_view type) -> void
+{
+    anzu::print("type error: cannot convert list to {}\n", type);
+    std::exit(1);
+}
+
 }
 
 auto format_special_chars(const std::string& str) -> std::string
@@ -70,7 +76,11 @@ auto object::to_int() const -> int
     return std::visit(overloaded {
         [](int v) { return v; },
         [](bool v) { return v ? 1 : 0; },
-        [](const std::string& v) { return anzu::to_int(v); }
+        [](const std::string& v) { return anzu::to_int(v); },
+        [](const std::shared_ptr<std::vector<object>>& v) {
+            type_error_array_convversion("int");
+            return 0;
+        }
     }, d_value);
 }
 
@@ -79,7 +89,8 @@ auto object::to_bool() const -> bool
     return std::visit(overloaded {
         [](int v) { return v != 0; },
         [](bool v) { return v; },
-        [](const std::string& v) { return v.size() > 0; }
+        [](const std::string& v) { return v.size() > 0; },
+        [](const std::shared_ptr<std::vector<object>>& v) { return v->size() > 0; }
     }, d_value);
 }
 
@@ -88,7 +99,11 @@ auto object::to_str() const -> std::string
     return std::visit(overloaded {
         [](int v) { return std::to_string(v); },
         [](bool v) { return std::string{v ? "true" : "false"}; },
-        [](const std::string& v) { return anzu::format_special_chars(v); }
+        [](const std::string& v) { return anzu::format_special_chars(v); },
+        [](const std::shared_ptr<std::vector<object>>& v) {
+            type_error_array_convversion("str");
+            return std::string{};
+        }
     }, d_value);
 }
 
@@ -97,9 +112,8 @@ auto object::to_repr() const -> std::string
     return std::visit(overloaded {
         [](int val) { return std::to_string(val); },
         [](bool val) { return std::string{val ? "true" : "false"}; },
-        [](const std::string& val) {
-            return std::format("'{}'", val);
-        }
+        [](const std::string& val) { return std::format("'{}'", val); },
+        [](const std::shared_ptr<std::vector<object>>& v) { return std::string{"array (repr not implemented)"}; }
     }, d_value);
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -112,15 +112,6 @@ auto object::to_str() const -> std::string
     }, d_value);
 }
 
-auto object::as_list() -> object_list&
-{
-    if (is_list()) {
-        return std::get<object_list>(d_value);
-    }
-    anzu::print("error: {} is not a list\n", to_repr());
-    std::exit(1);
-}
-
 auto object::to_repr() const -> std::string
 {
     return std::visit(overloaded {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -28,7 +28,7 @@ auto format_error(const std::string& str) -> void
     std::exit(1);
 }
 
-auto type_error_array_convversion(std::string_view type) -> void
+auto type_error_list_convversion(std::string_view type) -> void
 {
     anzu::print("type error: cannot convert list to {}\n", type);
     std::exit(1);
@@ -78,7 +78,7 @@ auto object::to_int() const -> int
         [](bool v) { return v ? 1 : 0; },
         [](const std::string& v) { return anzu::to_int(v); },
         [](const std::shared_ptr<std::vector<object>>& v) {
-            type_error_array_convversion("int");
+            type_error_list_convversion("int");
             return 0;
         }
     }, d_value);
@@ -101,7 +101,7 @@ auto object::to_str() const -> std::string
         [](bool v) { return std::string{v ? "true" : "false"}; },
         [](const std::string& v) { return anzu::format_special_chars(v); },
         [](const std::shared_ptr<std::vector<object>>& v) {
-            type_error_array_convversion("str");
+            type_error_list_convversion("str");
             return std::string{};
         }
     }, d_value);
@@ -113,7 +113,7 @@ auto object::to_repr() const -> std::string
         [](int val) { return std::to_string(val); },
         [](bool val) { return std::string{val ? "true" : "false"}; },
         [](const std::string& val) { return std::format("'{}'", val); },
-        [](const std::shared_ptr<std::vector<object>>& v) { return std::string{"array (repr not implemented)"}; }
+        [](const std::shared_ptr<std::vector<object>>& v) { return std::string{"list (repr not implemented)"}; }
     }, d_value);
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -71,6 +71,11 @@ auto object::is_str() const -> bool
     return std::holds_alternative<std::string>(d_value);
 }
 
+auto object::is_list() const -> bool
+{
+    return std::holds_alternative<object_list>(d_value);
+}
+
 auto object::to_int() const -> int
 {
     return std::visit(overloaded {
@@ -107,6 +112,13 @@ auto object::to_str() const -> std::string
     }, d_value);
 }
 
+auto object::as_list() -> object_list&
+{
+    if (is_list()) {
+        return std::get<object_list>(d_value);
+    }
+}
+
 auto object::to_repr() const -> std::string
 {
     return std::visit(overloaded {
@@ -114,7 +126,12 @@ auto object::to_repr() const -> std::string
         [](bool val) { return std::string{val ? "true" : "false"}; },
         [](const std::string& val) { return std::format("'{}'", val); },
         [](const object_list& v) {
-            return std::string{"list (repr not implemented)"};
+            std::string ret{"["};
+            for (const auto& obj : *v) {
+                ret += std::format("{}, ", obj);
+            }
+            ret += "]";
+            return ret;
         }
     }, d_value);
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -3,6 +3,7 @@
 #include "print.hpp"
 
 #include <algorithm>
+#include <ranges>
 #include <string_view>
 
 namespace anzu {
@@ -119,11 +120,19 @@ auto object::to_repr() const -> std::string
         [](bool val) { return std::string{val ? "true" : "false"}; },
         [](const std::string& val) { return std::format("'{}'", val); },
         [](const object_list& v) {
-            std::string ret;
-            for (const auto& obj : *v) {
-                ret += std::format("{}, ", obj);
+            switch (v->size()) {
+                break; case 0:
+                    return std::string{"[]"};
+                break; case 1:
+                    return std::format("[{}]", v->at(0));
+                break; default:
+                    std::string ret = std::format("[{}", v->at(0));
+                    for (const auto& obj : *v | std::views::drop(1)) {
+                        ret += std::format(", {}", obj);
+                    }
+                    ret += "]";
+                    return ret;
             }
-            return std::format("[{}]", ret);
         }
     }, d_value);
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -117,6 +117,8 @@ auto object::as_list() -> object_list&
     if (is_list()) {
         return std::get<object_list>(d_value);
     }
+    anzu::print("error: {} is not a list\n", to_repr());
+    std::exit(1);
 }
 
 auto object::to_repr() const -> std::string
@@ -126,12 +128,11 @@ auto object::to_repr() const -> std::string
         [](bool val) { return std::string{val ? "true" : "false"}; },
         [](const std::string& val) { return std::format("'{}'", val); },
         [](const object_list& v) {
-            std::string ret{"["};
+            std::string ret;
             for (const auto& obj : *v) {
                 ret += std::format("{}, ", obj);
             }
-            ret += "]";
-            return ret;
+            return std::format("[{}]", ret);
         }
     }, d_value);
 }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -32,10 +32,13 @@ public:
     auto is_str() const -> bool;
     auto is_list() const -> bool;
 
+    // Casts, for certain types, converts the object to the requested type.
     auto to_int() const -> int;
     auto to_bool() const -> bool;
     auto to_str() const -> std::string;
-    auto to_list() const -> object_list;
+    
+    // Only returns if the value is the correct type, otherwise exits.
+    auto as_list() -> object_list&;
 
     auto to_repr() const -> std::string;
 
@@ -63,7 +66,7 @@ auto foramt_special_chars(const std::string& str) -> std::string;
 template <> struct std::formatter<anzu::object> : std::formatter<std::string> {
     auto format(const anzu::object& obj, auto& ctx) {
         return std::formatter<std::string>::format(
-            std::format("{}", obj.to_str()), ctx
+            std::format("{}", obj.to_repr()), ctx
         );
     }
 };

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -1,7 +1,9 @@
 #pragma once
+#include <format>
+#include <memory>
 #include <string>
 #include <variant>
-#include <format>
+#include <vector>
 
 namespace anzu {
 
@@ -10,7 +12,8 @@ class object
     using value_type = std::variant<
         int,
         bool,
-        std::string
+        std::string,
+        std::shared_ptr<std::vector<object>>
     >;
 
     value_type d_value;
@@ -24,10 +27,12 @@ public:
     auto is_int() const -> bool;
     auto is_bool() const -> bool;
     auto is_str() const -> bool;
+    auto is_array() const -> bool;
 
     auto to_int() const -> int;
     auto to_bool() const -> bool;
     auto to_str() const -> std::string;
+    auto to_array() const -> std::shared_ptr<std::vector<object>>;
 
     auto to_repr() const -> std::string;
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -5,6 +5,8 @@
 #include <variant>
 #include <vector>
 
+#include "print.hpp"
+
 namespace anzu {
 
 class object;
@@ -37,8 +39,15 @@ public:
     auto to_bool() const -> bool;
     auto to_str() const -> std::string;
     
-    // Only returns if the value is the correct type, otherwise exits.
-    auto as_list() -> object_list&;
+    template <typename T>
+    auto as() -> T&
+    {
+        if (std::holds_alternative<T>(d_value)) {
+            return std::get<T>(d_value);
+        }
+        anzu::print("error: {} is not a list\n", to_repr());
+        std::exit(1);
+    }
 
     auto to_repr() const -> std::string;
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -7,13 +7,16 @@
 
 namespace anzu {
 
+class object;
+using object_list = std::shared_ptr<std::vector<object>>;
+
 class object
 {
     using value_type = std::variant<
         int,
         bool,
         std::string,
-        std::shared_ptr<std::vector<object>>
+        object_list
     >;
 
     value_type d_value;
@@ -32,7 +35,7 @@ public:
     auto to_int() const -> int;
     auto to_bool() const -> bool;
     auto to_str() const -> std::string;
-    auto to_list() const -> std::shared_ptr<std::vector<object>>;
+    auto to_list() const -> object_list;
 
     auto to_repr() const -> std::string;
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -27,12 +27,12 @@ public:
     auto is_int() const -> bool;
     auto is_bool() const -> bool;
     auto is_str() const -> bool;
-    auto is_array() const -> bool;
+    auto is_list() const -> bool;
 
     auto to_int() const -> int;
     auto to_bool() const -> bool;
     auto to_str() const -> std::string;
-    auto to_array() const -> std::shared_ptr<std::vector<object>>;
+    auto to_list() const -> std::shared_ptr<std::vector<object>>;
 
     auto to_repr() const -> std::string;
 

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -177,7 +177,8 @@ void op_return::apply(anzu::context& ctx) const
 
 void op_builtin_function_call::apply(anzu::context& ctx) const
 {
-    anzu::call_builtin(name, ctx);
+    func(ctx);
+    ctx.top().ptr() += 1;
 }
 
 template <typename A, typename B>

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -357,11 +357,4 @@ void op_dump::apply(anzu::context& ctx) const
     frame.ptr() += 1;
 }
 
-void op_print_frame::apply(anzu::context& ctx) const
-{
-    auto& frame = ctx.top();
-    frame.print();
-    frame.ptr() += 1;
-}
-
 }

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -1,6 +1,7 @@
 #include "op_codes.hpp"
 #include "object.hpp"
 #include "print.hpp"
+#include "functions.hpp"
 
 #include <iostream>
 #include <string>
@@ -172,6 +173,11 @@ void op_return::apply(anzu::context& ctx) const
 {
     transfer_values(ctx.top(0), ctx.top(1), retc);
     ctx.pop(); // Remove stack frame
+}
+
+void op_builtin_function_call::apply(anzu::context& ctx) const
+{
+    anzu::call_builtin(name, ctx);
 }
 
 template <typename A, typename B>

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -213,6 +213,14 @@ struct op_return
     void apply(anzu::context& ctx) const;
 };
 
+struct op_builtin_function_call
+{
+    std::string name;
+
+    std::string to_string() const { return std::format("OP_BUILTIN_FUNCTION_CALL({})", name); }
+    void apply(anzu::context& ctx) const;
+};
+
 // Numerical Operators
 
 struct op_add
@@ -368,6 +376,7 @@ class op
         op_function_call,
         op_function_end,
         op_return,
+        op_builtin_function_call,
 
         // Numerical Operators
         op_add,

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "stack_frame.hpp"
+#include "functions.hpp"
 
 #include <variant>
 #include <format>
@@ -216,6 +217,7 @@ struct op_return
 struct op_builtin_function_call
 {
     std::string name;
+    anzu::builtin_function func;
 
     std::string to_string() const { return std::format("OP_BUILTIN_FUNCTION_CALL({})", name); }
     void apply(anzu::context& ctx) const;

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -337,14 +337,6 @@ struct op_dump
     void apply(anzu::context& ctx) const;
 };
 
-// Debug
-
-struct op_print_frame
-{
-    std::string to_string() const { return "OP_PRINT_FRAME"; }
-    void apply(anzu::context& ctx) const;
-};
-
 class op
 {
     using op_type = std::variant<
@@ -402,10 +394,7 @@ class op
 
         // IO
         op_input,
-        op_dump,
-
-        // Debug
-        op_print_frame
+        op_dump
     >;
 
     op_type d_type;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -344,11 +344,6 @@ auto parse(const std::vector<anzu::token>& tokens) -> std::vector<anzu::op>
             program.emplace_back(anzu::op_to_str{});
         }
 
-        // Debug
-        else if (token == PRINT_FRAME) {
-            program.emplace_back(anzu::op_print_frame{});
-        }
-
         // Rest
         else if (all_functions.contains(token)) {
             auto [argc, retc, ptr] = all_functions[token];

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -11,6 +11,8 @@
 #include <sstream>
 #include <optional>
 
+#include "functions.hpp"
+
 namespace anzu {
 namespace {
 
@@ -352,6 +354,11 @@ auto parse(const std::vector<anzu::token>& tokens) -> std::vector<anzu::op>
             auto [argc, retc, ptr] = all_functions[token];
             program.emplace_back(anzu::op_function_call{
                 .name=token, .argc=argc, .jump=ptr + 1
+            });
+        }
+        else if (anzu::is_builtin(token)) {
+            program.emplace_back(anzu::op_builtin_function_call{
+                .name=token
             });
         }
         else {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2,6 +2,7 @@
 #include "op_codes.hpp"
 #include "object.hpp"
 #include "print.hpp"
+#include "functions.hpp"
 
 #include <stack>
 #include <cstdint>
@@ -400,7 +401,8 @@ auto parse(const std::vector<anzu::token>& tokens) -> std::vector<anzu::op>
         }
         else if (anzu::is_builtin(token)) {
             program.emplace_back(anzu::op_builtin_function_call{
-                .name=token
+                .name=token,
+                .func=anzu::fetch_builtin(token)
             });
         }
         else {

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -70,10 +70,6 @@ constexpr auto TO_INT      = std::string_view{"(int)"};
 constexpr auto TO_BOOL     = std::string_view{"(bool)"};
 constexpr auto TO_STR      = std::string_view{"(str)"};
 
-// Debug
-
-constexpr auto PRINT_FRAME = std::string_view{"frame"};
-
 auto parse(const std::vector<anzu::token>& tokens) -> std::vector<anzu::op>;
 
 }


### PR DESCRIPTION
* Add ability to create lists. The syntax for a list literal to identical to python.
* Nested lists are possible.
* Under the hood they are implemented within a `shared_ptr`, so the reference semantics of lists match python.
* Added builtin functions, C++ functions that can be invoked directly on the `anzu::context`. Similar to op codes except this single op code stores a function pointer which it executes.
* `print` and `__print_frame__` are now builtin functions. The latter replacing the `OP_PRINT_FRAME` op code. `frame` is no longer a keyword.
* Added `list_push`, `list_pop`, `list_at` and `list_size` builtin functions for operating on lists.
* Can query the size of the stack with `stack_size` builtin.
* Added `object::as<T>` which returns a `T&` if the object contains a type `T` and exits otherwise. This is different to the cast functions which try to coerce the value to the specified type. This along with `repr`/`string` will be cleaned up in the future.