### PR TITLE
AST for Expressions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/recursion.anzu", "run", "ast"],
+            "args": ["${workspaceFolder}/examples/test.anzu", "parse"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,10 +1,9 @@
 # fibbonacci to demonstrate functions and recursion
 
-function print 1 0
-    . expr "\n" .
-end
-
+expr "Enter value: " print
 input -> x
 expr x to_int -> x
 
-expr 2 * x print
+expr 2 * x println
+
+expr 3 * x println

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -4,6 +4,4 @@ function print 1 0
     . expr "\n" .
 end
 
-expr 1 + 2 * 3 == 7
-
-__print_frame__
+expr 1 to_bool to_str print

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,5 +1,9 @@
 # fibbonacci to demonstrate functions and recursion
 
-6 -> x
+function print 1 0
+    . expr "\n" .
+end
 
-expr 6 % x == 1 . "\n" .
+expr 5 + 6 -> x
+
+expr x print

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -4,4 +4,8 @@ function print 1 0
     . "\n" .
 end
 
-expr 1 + 2 * 3 print
+if expr 6 % 5 do
+    "yes" print
+else
+    "no" print
+end

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -4,6 +4,6 @@ function print 1 0
     . expr "\n" .
 end
 
-expr 5 + 6 > 10 -> x
+expr (1 + 2) * 3 
 
-expr x print
+__print_frame__

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,9 +1,11 @@
 # fibbonacci to demonstrate functions and recursion
 
-expr "Enter value: " print
+"Enter value: " print
 input -> x
-expr x to_int -> x
+x to_int -> x
 
-expr 2 * x println
+2 * x -> x
+x println
 
-expr 3 * x println
+3 * x -> y
+y println

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -4,4 +4,7 @@ function print 1 0
     . expr "\n" .
 end
 
-expr 1 to_bool to_str print
+input -> x
+expr x to_int -> x
+
+expr 2 * x print

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -4,6 +4,6 @@ function print 1 0
     . expr "\n" .
 end
 
-expr 5 + 6 -> x
+expr 5 + 6 > 10 -> x
 
 expr x print

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,11 +1,11 @@
 # fibbonacci to demonstrate functions and recursion
 
-[1, 2, 3] -> arr
-arr . "\n" .
-
-"Hello world\n" . "\n" .
-
-0 while dup 5 < do
-    dup . "\n".
-    1 + 
+function print 1 0
+    . "\n" .
 end
+
+true print
+false print
+1 print
+"hello world" print
+[1, "hi there", true, false] print

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,3 +1,5 @@
 # fibbonacci to demonstrate functions and recursion
 
-expr 6 % 2 == 1 . "\n" .
+6 -> x
+
+expr 6 % x == 1 . "\n" .

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -4,6 +4,6 @@ function print 1 0
     . expr "\n" .
 end
 
-expr (1 + 2) * 3 
+expr 1 + 2 * 3 == 7
 
 __print_frame__

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,11 +1,3 @@
 # fibbonacci to demonstrate functions and recursion
 
-function print 1 0
-    . "\n" .
-end
-
-if expr 6 % 5 do
-    "yes" print
-else
-    "no" print
-end
+expr 6 % 2 == 1 . "\n" .

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -4,8 +4,4 @@ function print 1 0
     . "\n" .
 end
 
-true print
-false print
-1 print
-"hello world" print
-[1, "hi there", true, false] print
+expr 1 + 2 * 3 print

--- a/grammar.txt
+++ b/grammar.txt
@@ -11,6 +11,19 @@ literal:
   | string_literal
   | list_literal
 
+expression:
+  | term
+  | term '+' expression
+  | term '-' expression
+
+term:
+  | factor
+  | factor '*' term
+  | factor '/' term
+
+factor:
+  | literal
+
 statement:
   | 'function' function_body
   | 'while' while_body
@@ -18,7 +31,7 @@ statement:
   | 'return'
   | 'break'
   | 'continue'
-  | literal
+  | expression
   | function_identifier
   | builtin_identifier
   | op_code  # This is temporary and will be removed

--- a/grammar.txt
+++ b/grammar.txt
@@ -31,7 +31,11 @@ statement:
   | 'return'
   | 'break'
   | 'continue'
-  | expression
+
+  # We will remove the 'expr' token eventually, this is just for during development.
+  # When assignments and function calls can be included, this can be the last thing
+  # that a statement is parsed as, resulting in a failure otherwise.
+  | 'expr' expression
   | function_identifier
   | builtin_identifier
   | op_code  # This is temporary and will be removed

--- a/grammar.txt
+++ b/grammar.txt
@@ -17,9 +17,19 @@ expression:
   | term '-' expression
 
 term:
+  | comparison
+  | comparison '*' term
+  | comparison '/' term
+  | comparison '%' term
+
+comparison:
   | factor
-  | factor '*' term
-  | factor '/' term
+  | factor '<'  term
+  | factor '<=' term
+  | factor '>'  term
+  | factor '>=' term
+  | factor '==' term
+  | factor '!=' term
 
 factor:
   | literal

--- a/grammar.txt
+++ b/grammar.txt
@@ -1,26 +1,42 @@
 program:
   | statement_list
 
-statement:
-  | 'while' statement_list 'do' statement_list 'end'
-  | 'while' statement_list 'do' 'end'
-  | 'break'
-  | 'continue'
-  | 'if' if_body
-  | 'function' function_declaration
-  | 'return'
-  | num_literal
-  | string_literal
-  | identifier
-
 statement_list:
   | statement
   | statement statement_list
 
+literal:
+  | int_literal
+  | bool_literal
+  | string_literal
+  | list_literal
+
+statement:
+  | 'function' function_body
+  | 'while' while_body
+  | 'if' if_body
+  | 'return'
+  | 'break'
+  | 'continue'
+  | literal
+  | function_identifier
+  | builtin_identifier
+  | op_code  # This is temporary and will be removed
+
+function_identifier:
+  | string_literal
+
+builtin_identifier:
+  | string_literal
+
+function_body:
+  | function_identifier int_literal int_literal statement_list 'end'
+  | function_identifier int_literal int_literal 'end'
+
+while_body:
+  | statement_list 'do' statement_list 'end'
+  | statement_list 'do' 'end'
+
 if_body:
   | statement_list 'do' statement_list 'elif' if_body
   | statement_list 'do' statement_list 'end'
-
-function_declaration:
-  | identifier num_literal num_literal statement_list 'end'
-  | identifier num_literal num_literal 'end'

--- a/grammar.txt
+++ b/grammar.txt
@@ -12,27 +12,27 @@ literal:
   | list_literal
 
 expression:
-  | term
-  | term '+' expression
-  | term '-' expression
+  | level_5_expression
 
-term:
-  | comparison
-  | comparison '*' term
-  | comparison '/' term
-  | comparison '%' term
+level_5_expression:
+  | level_4_expression [('*'|'/'|'%') level_5_expression]*
 
-comparison:
-  | factor
-  | factor '<'  term
-  | factor '<=' term
-  | factor '>'  term
-  | factor '>=' term
-  | factor '==' term
-  | factor '!=' term
+level_4_expression:
+  | level_3_expression [('+'|'-') level_4_expression]*
+
+level_3_expression:
+  | level_2_expression [('<'|'<='|'>'|'>='|'=='|'!=') level_3_expression]*
+
+level_2_expression:
+  | level_1_expression ['&&' level_2_expression]*
+
+level_1_expression:
+  | factor ['||' level_1_expression]*
 
 factor:
   | literal
+  | variable_name
+  | '(' expression ')'
 
 statement:
   | 'function' function_body

--- a/grammar.txt
+++ b/grammar.txt
@@ -1,0 +1,26 @@
+program:
+  | statement_list
+
+statement:
+  | 'while' statement_list 'do' statement_list 'end'
+  | 'while' statement_list 'do' 'end'
+  | 'break'
+  | 'continue'
+  | 'if' if_body
+  | 'function' function_declaration
+  | 'return'
+  | num_literal
+  | string_literal
+  | identifier
+
+statement_list:
+  | statement
+  | statement statement_list
+
+if_body:
+  | statement_list 'do' statement_list 'elif' if_body
+  | statement_list 'do' statement_list 'end'
+
+function_declaration:
+  | identifier num_literal num_literal statement_list 'end'
+  | identifier num_literal num_literal 'end'

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -256,6 +256,7 @@ void node_bin_op::evaluate(compiler_context& ctx)
         break; case '-': ctx.program.push_back(anzu::op_sub{});
         break; case '*': ctx.program.push_back(anzu::op_mul{});
         break; case '/': ctx.program.push_back(anzu::op_div{});
+        break; case '%': ctx.program.push_back(anzu::op_mod{});
         break; default: {
             anzu::print("syntax error: unknown binary operator '{}'\n", op);
             std::exit(1);
@@ -297,11 +298,6 @@ auto parse_op(parser_context& ctx) -> anzu::op
     if (token == SWAP)    return op_swap{};
     if (token == ROT)     return op_rot{};
     if (token == OVER)    return op_over{};
-    if (token == ADD)     return op_add{};
-    if (token == SUB)     return op_sub{};
-    if (token == MUL)     return op_mul{};
-    if (token == DIV)     return op_div{};
-    if (token == MOD)     return op_mod{};
     if (token == EQ)      return op_eq{};
     if (token == NE)      return op_ne{};
     if (token == LT)      return op_lt{};
@@ -343,7 +339,9 @@ auto parse_expression(parser_context& ctx) -> node_ptr
 
 auto parse_term(parser_context& ctx) -> node_ptr
 {
-    static const auto ops = std::unordered_set<std::string_view>{"*", "/"};
+    static const auto ops = std::unordered_set<std::string_view>{
+        "*", "/", "%"
+    };
 
     auto left = parse_factor(ctx);
     while (ctx.curr != ctx.end && ops.contains(ctx.curr->text)) {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -305,8 +305,6 @@ auto parse_op(parser_context& ctx) -> anzu::op
     const auto token = ctx.curr->text;
     ++ctx.curr;
     if (token == STORE)   return op_store{ .name=(ctx.curr++)->text };
-    if (token == INPUT)   return op_input{};
-    if (token == DUMP)    return op_dump{};
     anzu::print("unknown token '{}'\n", token);
     std::exit(1);
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -310,8 +310,6 @@ auto parse_op(parser_context& ctx) -> anzu::op
     if (token == SWAP)    return op_swap{};
     if (token == ROT)     return op_rot{};
     if (token == OVER)    return op_over{};
-    if (token == OR)      return op_or{};
-    if (token == AND)     return op_and{};
     if (token == INPUT)   return op_input{};
     if (token == DUMP)    return op_dump{};
     if (token == TO_INT)  return op_to_int{};

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -243,6 +243,33 @@ void node_return::print(int indent)
     anzu::print("{}Return\n", spaces);
 }
 
+void node_bin_op::evaluate(compiler_context& ctx)
+{
+    lhs->evaluate(ctx);
+    rhs->evaluate(ctx);
+    switch (op) {
+        break; case '+': ctx.program.push_back(anzu::op_add{});
+        break; case '-': ctx.program.push_back(anzu::op_sub{});
+        break; case '*': ctx.program.push_back(anzu::op_mul{});
+        break; case '/': ctx.program.push_back(anzu::op_div{});
+        break; default: {
+            anzu::print("syntax error: unknown binary operator '{}'\n", op);
+            std::exit(1);
+        }
+    }
+}
+
+void node_bin_op::print(int indent)
+{
+    const auto spaces = std::string(4 * indent, ' ');
+    anzu::print("{}BinOp\n", spaces);
+    anzu::print("{}- Op: {}\n", spaces, op);
+    anzu::print("{}- Lhs:\n", spaces);
+    lhs->print(indent + 1);
+    anzu::print("{}- Rhs:\n", spaces);
+    rhs->print(indent + 1);
+}
+
 namespace {
 
 // A temporary function during migration between the old and new parsers. This will
@@ -414,7 +441,7 @@ auto parse_statement(parser_context& ctx) -> node_ptr
     else if (ctx.curr->text == "[") {
         return std::make_unique<anzu::node_literal>(handle_list_literal(ctx));
     }
-    
+
     else if (ctx.function_names.contains(ctx.curr->text)) {
         return std::make_unique<anzu::node_function_call>((ctx.curr++)->text);
     }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -305,11 +305,6 @@ auto parse_op(parser_context& ctx) -> anzu::op
     const auto token = ctx.curr->text;
     ++ctx.curr;
     if (token == STORE)   return op_store{ .name=(ctx.curr++)->text };
-    if (token == POP)     return op_pop{};
-    if (token == DUP)     return op_dup{};
-    if (token == SWAP)    return op_swap{};
-    if (token == ROT)     return op_rot{};
-    if (token == OVER)    return op_over{};
     if (token == INPUT)   return op_input{};
     if (token == DUMP)    return op_dump{};
     if (token == TO_INT)  return op_to_int{};

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -302,7 +302,7 @@ namespace {
 // nodes.
 auto parse_op(parser_context& ctx) -> anzu::op
 {
-    const auto& token = ctx.curr->text;
+    const auto token = ctx.curr->text;
     ++ctx.curr;
     if (token == STORE)   return op_store{ .name=(ctx.curr++)->text };
     if (token == POP)     return op_pop{};
@@ -317,7 +317,8 @@ auto parse_op(parser_context& ctx) -> anzu::op
     if (token == TO_INT)  return op_to_int{};
     if (token == TO_BOOL) return op_to_bool{};
     if (token == TO_STR)  return op_to_str{};
-    return op_push_var{.name=token};
+    anzu::print("unknown token '{}'\n", token);
+    std::exit(1);
 }
 
 auto try_parse_literal(parser_context& ctx) -> std::optional<anzu::object>;
@@ -547,10 +548,6 @@ auto parse_statement(parser_context& ctx) -> node_ptr
     }
     else if (consume_maybe(ctx.curr, "expr")) {
         return parse_comparison(ctx);
-    }
-
-    else if (auto obj = try_parse_literal(ctx); obj.has_value()) {
-        return std::make_unique<anzu::node_literal>(*obj);
     }
 
     else if (ctx.function_names.contains(ctx.curr->text)) {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -372,6 +372,21 @@ auto parse_if_body(parser_context& ctx) -> node_ptr
     return stmt;
 }
 
+auto parse_factor(parser_context& ctx) -> node_ptr
+{
+    return nullptr;
+}
+
+auto parse_term(parser_context& ctx) -> node_ptr
+{
+    return nullptr;
+}
+
+auto parse_expression(parser_context& ctx) -> node_ptr
+{
+    return nullptr;
+}
+
 auto handle_list_literal(parser_context& ctx) -> anzu::object_list
 {
     auto list = std::make_shared<std::vector<anzu::object>>();
@@ -430,6 +445,9 @@ auto parse_statement(parser_context& ctx) -> node_ptr
     }
     else if (consume_maybe(ctx.curr, "continue")) {
         return std::make_unique<anzu::node_continue>(); 
+    }
+    else if (consume_maybe(ctx.curr, "expr")) {
+        return parse_expression(ctx);
     }
 
     else if (ctx.curr->type == token_type::number) {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -503,6 +503,9 @@ auto parse_statement(parser_context& ctx) -> node_ptr
     else if (consume_maybe(ctx.curr, "continue")) {
         return std::make_unique<anzu::node_continue>(); 
     }
+    else if (consume_maybe(ctx.curr, "->")) {
+        return std::make_unique<anzu::node_op>(op_store{ .name=(ctx.curr++)->text });
+    }
 
     else if (ctx.function_names.contains(ctx.curr->text)) {
         return std::make_unique<anzu::node_function_call>((ctx.curr++)->text);
@@ -510,17 +513,8 @@ auto parse_statement(parser_context& ctx) -> node_ptr
     else if (anzu::is_builtin(ctx.curr->text)) {
         return std::make_unique<anzu::node_builtin_call>((ctx.curr++)->text);
     }
-    else if (consume_maybe(ctx.curr, "expr")) {
-        return parse_expression(ctx);
-    }
     else if (ctx.curr != ctx.end) {
-        const auto token = ctx.curr->text;
-        ++ctx.curr;
-        if (token == STORE) {
-            return std::make_unique<anzu::node_op>(op_store{ .name=(ctx.curr++)->text });
-        }
-        anzu::print("unknown token '{}'\n", token);
-        std::exit(1);
+        return parse_expression(ctx);
     }
     return nullptr;
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -307,9 +307,6 @@ auto parse_op(parser_context& ctx) -> anzu::op
     if (token == STORE)   return op_store{ .name=(ctx.curr++)->text };
     if (token == INPUT)   return op_input{};
     if (token == DUMP)    return op_dump{};
-    if (token == TO_INT)  return op_to_int{};
-    if (token == TO_BOOL) return op_to_bool{};
-    if (token == TO_STR)  return op_to_str{};
     anzu::print("unknown token '{}'\n", token);
     std::exit(1);
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -297,18 +297,6 @@ void node_bin_op::print(int indent)
 
 namespace {
 
-// A temporary function during migration between the old and new parsers. This will
-// get smaller and smaller as we move these operations to be stored in proper tree
-// nodes.
-auto parse_op(parser_context& ctx) -> anzu::op
-{
-    const auto token = ctx.curr->text;
-    ++ctx.curr;
-    if (token == STORE)   return op_store{ .name=(ctx.curr++)->text };
-    anzu::print("unknown token '{}'\n", token);
-    std::exit(1);
-}
-
 auto handle_list_literal(parser_context& ctx) -> anzu::object;
 
 auto try_parse_literal(parser_context& ctx) -> std::optional<anzu::object>
@@ -526,7 +514,13 @@ auto parse_statement(parser_context& ctx) -> node_ptr
         return parse_expression(ctx);
     }
     else if (ctx.curr != ctx.end) {
-        return std::make_unique<anzu::node_op>(parse_op(ctx));
+        const auto token = ctx.curr->text;
+        ++ctx.curr;
+        if (token == STORE) {
+            return std::make_unique<anzu::node_op>(op_store{ .name=(ctx.curr++)->text });
+        }
+        anzu::print("unknown token '{}'\n", token);
+        std::exit(1);
     }
     return nullptr;
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -180,6 +180,14 @@ struct node_literal : public node
     void print(int indent = 0) override;
 };
 
+struct node_variable : public node
+{
+    std::string name;
+    node_variable(const std::string& n) : name(n) {}
+    void evaluate(compiler_context& ctx) override;
+    void print(int indent = 0) override;
+};
+
 struct node_bin_op : public node
 {
     std::string op; // TODO: make into enum

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -182,7 +182,7 @@ struct node_literal : public node
 
 struct node_bin_op : public node
 {
-    char op; // TODO: make into enum
+    std::string op; // TODO: make into enum
     std::unique_ptr<node> lhs;
     std::unique_ptr<node> rhs;
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -180,6 +180,16 @@ struct node_literal : public node
     void print(int indent = 0) override;
 };
 
+struct node_bin_op : public node
+{
+    char op; // TODO: make into enum
+    std::unique_ptr<node> lhs;
+    std::unique_ptr<node> rhs;
+
+    void evaluate(compiler_context& ctx) override;
+    void print(int indent = 0) override;
+};
+
 using token_iterator = std::vector<anzu::token>::const_iterator;
 using node_ptr       = std::unique_ptr<anzu::node>;
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -55,8 +55,8 @@ constexpr auto LT          = std::string_view{"<"};
 constexpr auto LE          = std::string_view{"<="};
 constexpr auto GT          = std::string_view{">"};
 constexpr auto GE          = std::string_view{">="};
-constexpr auto OR          = std::string_view{"or"};
-constexpr auto AND         = std::string_view{"and"};
+constexpr auto OR          = std::string_view{"||"};
+constexpr auto AND         = std::string_view{"&&"};
 
 // IO
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -183,6 +183,7 @@ struct node_literal : public node
 struct node_variable : public node
 {
     std::string name;
+    
     node_variable(const std::string& n) : name(n) {}
     void evaluate(compiler_context& ctx) override;
     void print(int indent = 0) override;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -11,14 +11,6 @@ namespace anzu {
 struct parser_context;
 struct compiler_context;
 
-// Stack Manipulation
-
-constexpr auto POP         = std::string_view{"pop"};
-constexpr auto DUP         = std::string_view{"dup"};
-constexpr auto SWAP        = std::string_view{"swap"};
-constexpr auto ROT         = std::string_view{"rot"};
-constexpr auto OVER        = std::string_view{"over"};
-
 // Store Manipulation
 
 constexpr auto STORE       = std::string_view{"->"};
@@ -67,12 +59,6 @@ constexpr auto DUMP        = std::string_view{"."};
 
 constexpr auto TRUE_LIT    = std::string_view{"true"};
 constexpr auto FALSE_LIT   = std::string_view{"false"};
-
-// Casts
-
-constexpr auto TO_INT      = std::string_view{"(int)"};
-constexpr auto TO_BOOL     = std::string_view{"(bool)"};
-constexpr auto TO_STR      = std::string_view{"(str)"};
 
 // I normally avoid inheritance trees, however dealing with variants here was a bit
 // cumbersome and required wrapping the variant in a struct to allow recusrion (due
@@ -183,7 +169,7 @@ struct node_literal : public node
 struct node_variable : public node
 {
     std::string name;
-    
+
     node_variable(const std::string& n) : name(n) {}
     void evaluate(compiler_context& ctx) override;
     void print(int indent = 0) override;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -50,11 +50,6 @@ constexpr auto GE          = std::string_view{">="};
 constexpr auto OR          = std::string_view{"||"};
 constexpr auto AND         = std::string_view{"&&"};
 
-// IO
-
-constexpr auto INPUT       = std::string_view{"input"};
-constexpr auto DUMP        = std::string_view{"."};
-
 // Literals
 
 constexpr auto TRUE_LIT    = std::string_view{"true"};

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -66,6 +66,24 @@ auto builtin_list_at(anzu::context& ctx) -> void
     frame.push(list.as<object_list>()->at(static_cast<std::size_t>(pos.to_int())));
 }
 
+auto builtin_to_int(anzu::context& ctx) -> void
+{
+    auto& frame = ctx.top();
+    frame.push(frame.pop().to_int());
+}
+
+auto builtin_to_bool(anzu::context& ctx) -> void
+{
+    auto& frame = ctx.top();
+    frame.push(frame.pop().to_bool());
+}
+
+auto builtin_to_str(anzu::context& ctx) -> void
+{
+    auto& frame = ctx.top();
+    frame.push(frame.pop().to_str());
+}
+
 }
 
 static const std::unordered_map<std::string, builtin_function> builtins = {
@@ -78,7 +96,12 @@ static const std::unordered_map<std::string, builtin_function> builtins = {
     { "list_at",         builtin_list_at     },
 
     // Debug functions
-    { "__print_frame__", builtin_print_frame }
+    { "__print_frame__", builtin_print_frame },
+
+    // Old Op Codes
+    { "to_int",          builtin_to_int      },
+    { "to_bool",         builtin_to_bool     },
+    { "to_str",          builtin_to_str      }
 };
 
 auto is_builtin(const std::string& name) -> bool

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -84,6 +84,36 @@ auto builtin_to_str(anzu::context& ctx) -> void
     frame.push(frame.pop().to_str());
 }
 
+auto builtin_print(anzu::context& ctx) -> void
+{
+    auto& frame = ctx.top();
+    const auto obj = frame.pop();
+    if (obj.is<std::string>()) {
+        anzu::print("{}", anzu::format_special_chars(obj.as<std::string>()));
+    } else {
+        anzu::print("{}", obj);
+    }
+}
+
+auto builtin_println(anzu::context& ctx) -> void
+{
+    auto& frame = ctx.top();
+    const auto obj = frame.pop();
+    if (obj.is<std::string>()) {
+        anzu::print("{}\n", anzu::format_special_chars(obj.as<std::string>()));
+    } else {
+        anzu::print("{}\n", obj);
+    }
+}
+
+auto builtin_input(anzu::context& ctx) -> void
+{
+    auto& frame = ctx.top();
+    std::string in;
+    std::cin >> in;
+    frame.push(in);
+}
+
 }
 
 static const std::unordered_map<std::string, builtin_function> builtins = {
@@ -101,7 +131,12 @@ static const std::unordered_map<std::string, builtin_function> builtins = {
     // Old Op Codes
     { "to_int",          builtin_to_int      },
     { "to_bool",         builtin_to_bool     },
-    { "to_str",          builtin_to_str      }
+    { "to_str",          builtin_to_str      },
+
+    // I/O
+    { "print",           builtin_print       },
+    { "println",         builtin_println     },
+    { "input",           builtin_input       }
 };
 
 auto is_builtin(const std::string& name) -> bool

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -15,10 +15,8 @@ static const std::unordered_set<std::string_view> keywords = {
     "continue",
     "do",
     "end",
-
     "true",
-    "false",
-    "expr"
+    "false"
 };
 
 static const std::unordered_set<std::string_view> bin_ops = {

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -6,12 +6,6 @@
 namespace anzu {
 
 static const std::unordered_set<std::string_view> keywords = {
-    "pop",
-    "dup",
-    "swap",
-    "rot",
-    "over",
-
     "function",
     "if",
     "elif",

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -24,6 +24,7 @@ static const std::unordered_set<std::string_view> keywords = {
 
     "true",
     "false",
+    "expr"
 };
 
 static const std::unordered_set<std::string_view> bin_ops = {
@@ -50,7 +51,8 @@ static const std::unordered_set<std::string_view> symbols = {
     ":",
     "[",
     "]",
-    ","
+    ",",
+    "."
 };
 
 enum class token_type

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -95,7 +95,7 @@ auto object::to_str() const -> std::string
                 break; default:
                     std::string ret = std::format("[{}", v->at(0));
                     for (const auto& obj : *v | std::views::drop(1)) {
-                        ret += std::format(", {}", obj);
+                        ret += std::format(", {}", obj.to_repr());
                     }
                     ret += "]";
                     return ret;
@@ -119,7 +119,7 @@ auto object::to_repr() const -> std::string
                 break; default:
                     std::string ret = std::format("[{}", v->at(0));
                     for (const auto& obj : *v | std::views::drop(1)) {
-                        ret += std::format(", {}", obj);
+                        ret += std::format(", {}", obj.to_repr());
                     }
                     ret += "]";
                     return ret;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -68,7 +68,7 @@ public:
     friend object operator/(const object& lhs, const object& rhs);
     friend object operator%(const object& lhs, const object& rhs);
     
-    friend auto operator<=>(const object& lhs, const object& rhs) = default;
+    friend std::strong_ordering operator<=>(const object& lhs, const object& rhs) = default;
 
     friend bool operator||(const object& lhs, const object& rhs);
     friend bool operator&&(const object& lhs, const object& rhs);

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -277,27 +277,6 @@ void op_and::apply(anzu::context& ctx) const
     frame.ptr() += 1;
 }
 
-void op_to_int::apply(anzu::context& ctx) const
-{
-    auto& frame = ctx.top();
-    frame.push(frame.pop().to_int());
-    frame.ptr() += 1;
-}
-
-void op_to_bool::apply(anzu::context& ctx) const
-{
-    auto& frame = ctx.top();
-    frame.push(frame.pop().to_bool());
-    frame.ptr() += 1;
-}
-
-void op_to_str::apply(anzu::context& ctx) const
-{
-    auto& frame = ctx.top();
-    frame.push(frame.pop().to_str());
-    frame.ptr() += 1;
-}
-
 void op_input::apply(anzu::context& ctx) const
 {
     auto& frame = ctx.top();

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -50,44 +50,6 @@ void op_push_var::apply(anzu::context& ctx) const
     frame.ptr() += 1;
 }
 
-void op_pop::apply(anzu::context& ctx) const
-{
-    auto& frame = ctx.top();
-    frame.pop();
-    frame.ptr() += 1;
-}
-
-void op_dup::apply(anzu::context& ctx) const
-{
-    auto& frame = ctx.top();
-    frame.push(frame.top());
-    frame.ptr() += 1;
-}
-
-void op_swap::apply(anzu::context& ctx) const
-{
-    auto& frame = ctx.top();
-    anzu::verify_stack(frame, 2, "swap");
-    swap(frame.top(0), frame.top(1));
-    frame.ptr() += 1;
-}
-
-void op_rot::apply(anzu::context& ctx) const
-{
-    auto& frame = ctx.top();
-    anzu::verify_stack(frame, 3, "rot");
-    swap(frame.top(0), frame.top(1));
-    swap(frame.top(1), frame.top(2));
-    frame.ptr() += 1;
-}
-
-void op_over::apply(anzu::context& ctx) const
-{
-    auto& frame = ctx.top();
-    anzu::verify_stack(frame, 2, "over");
-    frame.push(frame.top(1));
-    frame.ptr() += 1;
-}
 
 void op_store::apply(anzu::context& ctx) const
 {

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -277,26 +277,4 @@ void op_and::apply(anzu::context& ctx) const
     frame.ptr() += 1;
 }
 
-void op_input::apply(anzu::context& ctx) const
-{
-    auto& frame = ctx.top();
-    std::string in;
-    std::cin >> in;
-    frame.push(in);
-    frame.ptr() += 1;
-}
-
-void op_dump::apply(anzu::context& ctx) const
-{
-    auto& frame = ctx.top();
-    anzu::verify_stack(frame, 1, ".");
-    const auto obj = frame.pop();
-    if (obj.is<std::string>()) {
-        anzu::print("{}", anzu::format_special_chars(obj.as<std::string>()));
-    } else {
-        anzu::print("{}", obj);
-    }
-    frame.ptr() += 1;
-}
-
 }

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -28,36 +28,6 @@ struct op_push_var
     void apply(anzu::context& ctx) const;
 };
 
-struct op_pop
-{
-    std::string to_string() const { return "OP_POP"; }
-    void apply(anzu::context& ctx) const;
-};
-
-struct op_dup
-{
-    std::string to_string() const { return "OP_DUP"; }
-    void apply(anzu::context& ctx) const;
-};
-
-struct op_swap
-{
-    std::string to_string() const { return "OP_SWAP"; }
-    void apply(anzu::context& ctx) const;
-};
-
-struct op_rot
-{
-    std::string to_string() const { return "OP_ROT"; }
-    void apply(anzu::context& ctx) const;
-};
-
-struct op_over
-{
-    std::string to_string() const { return "OP_OVER"; }
-    void apply(anzu::context& ctx) const;
-};
-
 // Store Manipulation
 
 struct op_store
@@ -330,14 +300,8 @@ struct op_dump
 class op
 {
     using op_type = std::variant<
-        // Stack Manipulation
         op_push_const,
         op_push_var,
-        op_pop,
-        op_dup,
-        op_swap,
-        op_rot,
-        op_over,
 
         // Store Manipulation
         op_store,

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -263,20 +263,6 @@ struct op_and
     void apply(anzu::context& ctx) const;
 };
 
-// IO
-
-struct op_input
-{
-    std::string to_string() const { return "OP_INPUT"; }
-    void apply(anzu::context& ctx) const;
-};
-
-struct op_dump
-{
-    std::string to_string() const { return "OP_DUMP"; }
-    void apply(anzu::context& ctx) const;
-};
-
 class op
 {
     using op_type = std::variant<
@@ -318,11 +304,7 @@ class op
         op_gt,
         op_ge,
         op_or,
-        op_and,
-
-        // IO
-        op_input,
-        op_dump
+        op_and
     >;
 
     op_type d_type;

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -263,26 +263,6 @@ struct op_and
     void apply(anzu::context& ctx) const;
 };
 
-// Casts
-
-struct op_to_int
-{
-    std::string to_string() const { return "OP_TO_INT"; }
-    void apply(anzu::context& ctx) const;
-};
-
-struct op_to_bool
-{
-    std::string to_string() const { return "OP_TO_BOOL"; }
-    void apply(anzu::context& ctx) const;
-};
-
-struct op_to_str
-{
-    std::string to_string() const { return "OP_STR"; }
-    void apply(anzu::context& ctx) const;
-};
-
 // IO
 
 struct op_input
@@ -339,11 +319,6 @@ class op
         op_ge,
         op_or,
         op_and,
-
-        // Casts
-        op_to_int,
-        op_to_bool,
-        op_to_str,
 
         // IO
         op_input,


### PR DESCRIPTION
* Added a grammar file. This is currently rough and will be refined as we move further from the stack based syntax.
* Add `anzu::node_variable` and `anzu::no_bin_op` to use alongside the existing `anzu::node_literal` in new logic for parsing expressions involving arithmetic operators, boolean operations and comparison operations.
* Removed most of the use cases that use `anzu::node_op`, which was always a temporary way to store op data in the tree.
* `.` has been replaced by the builtin function `print` for printing the top of the stack. There is a version that also prints a new line spelled `println`.
* Forth-style stack manipulation has been removed.
* All op codes for operations above are now handled by expressions and their ordering generated by the AST.
* All casts, printing and input are now builtin functions.
* Only `op_store` is now inserted via `node_op`, which will go away next PR.
* Clean up the AST code, simplifying the parsing of literals and extracting the parsing of `while` and `function` bodies into separate functions. The rough goal here is to have each function map to a section of the grammar file.