### PR TITLE
Assignment Operator

### DIFF
--- a/examples/euler.anzu
+++ b/examples/euler.anzu
@@ -1,14 +1,15 @@
 # project euler #1, sum of multiple of 3 and 5 below 1000
 
-0 -> count
+count = 0
+i = 0
 
-0 while dup 1000 < do
-    if dup 3 % 0 == do
-        dup count + -> count
-    elif dup 5 % 0 == do
-        dup count + -> count
+while i < 1000 do
+    if i % 3 == 0 do
+        count = count + i
+    elif i % 5 == 0 do
+        count = count + i
     end
-    1 + 
+    i = i + 1
 end
 
-count .
+count print

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,11 +1,8 @@
 # fibbonacci to demonstrate functions and recursion
 
-"Enter value: " print
-input -> x
-x to_int -> x
+x = 5
+y = 2 * x
+y println
 
-2 * x -> x
-x println
-
-3 * x -> y
+y = 3 * x
 y println

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -28,17 +28,6 @@ auto consume_only(token_iterator& it, std::string_view tok) -> void
 
 }
 
-void node_op::evaluate(compiler_context& ctx)
-{
-    ctx.program.push_back(op);
-}
-
-void node_op::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}Op: {}\n", spaces, op);
-}
-
 void node_sequence::evaluate(compiler_context& ctx)
 {
     for (const auto& node : sequence) {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -295,6 +295,21 @@ void node_bin_op::print(int indent)
     rhs->print(indent + 1);
 }
 
+void node_assignment::evaluate(compiler_context& ctx)
+{
+    value->evaluate(ctx);
+    ctx.program.emplace_back(anzu::op_store{ .name=name });
+}
+
+void node_assignment::print(int indent)
+{
+    const auto spaces = std::string(4 * indent, ' ');
+    anzu::print("{}Assignment\n", spaces);
+    anzu::print("{}- Name: {}\n", spaces, name);
+    anzu::print("{}- Value:\n", spaces);
+    value->print(indent + 1);
+}
+
 namespace {
 
 auto handle_list_literal(parser_context& ctx) -> anzu::object;
@@ -417,6 +432,21 @@ auto parse_expression(parser_context& ctx) -> node_ptr
     return parse_compound_factor(ctx, std::ssize(bin_ops_table) - 1i64);
 }
 
+auto parse_assignment(parser_context& ctx) -> node_ptr
+{
+    if (ctx.curr->type != token_type::name) {
+        anzu::print("syntax error: cannot assign to '{}'\n", ctx.curr->text);
+        std::exit(1);
+    }
+    auto name = (ctx.curr++)->text;
+    consume_only(ctx.curr, "=");
+
+    auto assign = std::make_unique<anzu::node_assignment>();
+    assign->name = name;
+    assign->value = parse_expression(ctx);
+    return assign;
+}
+
 auto parse_statement(parser_context& ctx) -> node_ptr;
 
 // statement_list:
@@ -503,10 +533,9 @@ auto parse_statement(parser_context& ctx) -> node_ptr
     else if (consume_maybe(ctx.curr, "continue")) {
         return std::make_unique<anzu::node_continue>(); 
     }
-    else if (consume_maybe(ctx.curr, "->")) {
-        return std::make_unique<anzu::node_op>(op_store{ .name=(ctx.curr++)->text });
+    else if (auto next = std::next(ctx.curr); next != ctx.end && next->text == "=") {
+        return parse_assignment(ctx);
     }
-
     else if (ctx.function_names.contains(ctx.curr->text)) {
         return std::make_unique<anzu::node_function_call>((ctx.curr++)->text);
     }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -11,8 +11,6 @@ namespace anzu {
 struct parser_context;
 struct compiler_context;
 
-constexpr auto STORE       = std::string_view{"->"};
-
 constexpr auto IF          = std::string_view{"if"};
 constexpr auto ELIF        = std::string_view{"elif"};
 constexpr auto ELSE        = std::string_view{"else"};
@@ -53,18 +51,6 @@ struct node
     virtual ~node() {}
     virtual void evaluate(compiler_context& ctx) = 0;
     virtual void print(int indent = 0) = 0;
-};
-
-// This is just a temporary node for storing bytecode, with the goal
-// of retiring the old parser. This will eventually get used less and less as more code
-// gets translated to proper nodes.
-struct node_op : public node
-{
-    anzu::op op;
-
-    node_op(const anzu::op& new_op) : op(new_op) {}
-    void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 struct node_sequence : public node

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -11,35 +11,26 @@ namespace anzu {
 struct parser_context;
 struct compiler_context;
 
-// Store Manipulation
-
 constexpr auto STORE       = std::string_view{"->"};
-
-// Control Flow / Functions
 
 constexpr auto IF          = std::string_view{"if"};
 constexpr auto ELIF        = std::string_view{"elif"};
 constexpr auto ELSE        = std::string_view{"else"};
-
 constexpr auto WHILE       = std::string_view{"while"};
 constexpr auto BREAK       = std::string_view{"break"};
 constexpr auto CONTINUE    = std::string_view{"continue"};
-
 constexpr auto FUNCTION    = std::string_view{"function"};
 constexpr auto RETURN      = std::string_view{"return"};
-
 constexpr auto DO          = std::string_view{"do"};
 constexpr auto END         = std::string_view{"end"};
-
-// Numerical Operators
+constexpr auto TRUE_LIT    = std::string_view{"true"};
+constexpr auto FALSE_LIT   = std::string_view{"false"};
 
 constexpr auto ADD         = std::string_view{"+"};
 constexpr auto SUB         = std::string_view{"-"};
 constexpr auto MUL         = std::string_view{"*"};
 constexpr auto DIV         = std::string_view{"/"};
 constexpr auto MOD         = std::string_view{"%"};
-
-// Logical Operators
 
 constexpr auto EQ          = std::string_view{"=="};
 constexpr auto NE          = std::string_view{"!="};
@@ -50,10 +41,8 @@ constexpr auto GE          = std::string_view{">="};
 constexpr auto OR          = std::string_view{"||"};
 constexpr auto AND         = std::string_view{"&&"};
 
-// Literals
+constexpr auto ASSIGN      = std::string_view{"="};
 
-constexpr auto TRUE_LIT    = std::string_view{"true"};
-constexpr auto FALSE_LIT   = std::string_view{"false"};
 
 // I normally avoid inheritance trees, however dealing with variants here was a bit
 // cumbersome and required wrapping the variant in a struct to allow recusrion (due
@@ -175,6 +164,15 @@ struct node_bin_op : public node
     std::string op; // TODO: make into enum
     std::unique_ptr<node> lhs;
     std::unique_ptr<node> rhs;
+
+    void evaluate(compiler_context& ctx) override;
+    void print(int indent = 0) override;
+};
+
+struct node_assignment : public node
+{
+    std::string name;
+    std::unique_ptr<node> value;
 
     void evaluate(compiler_context& ctx) override;
     void print(int indent = 0) override;

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -44,7 +44,8 @@ static const std::unordered_set<std::string_view> symbols = {
     "[",
     "]",
     ",",
-    "."
+    ".",
+    "="
 };
 
 enum class token_type

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -33,8 +33,7 @@ static const std::unordered_set<std::string_view> bin_ops = {
     ">=",
     "||",
     "&&",
-    "=",
-    "->"
+    "="
 };
 
 static const std::unordered_set<std::string_view> symbols = {

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -43,8 +43,7 @@ static const std::unordered_set<std::string_view> symbols = {
     "[",
     "]",
     ",",
-    ".",
-    "="
+    "."
 };
 
 enum class token_type


### PR DESCRIPTION
* Added `=` as an assignment operator.
* Under the hood the assignment is parsed into an `anzu::node_assignment` which translates to `anzu::op_store` op code.
* Remove `anzu::node_op` as it is no longer needed.
* Removed the `->` operator.