### PR TITLE
Functions with Parameter Lists

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/test.anzu", "parse"],
+            "args": ["${workspaceFolder}/examples/test.anzu", "run"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/examples/recursion.anzu
+++ b/examples/recursion.anzu
@@ -1,30 +1,17 @@
 # fibbonacci to demonstrate functions and recursion
 
-
-function fibb 1 1
-    if dup 0 == do
-        0 return
-    elif dup 1 == do
-        1 return
+function fibb(n) do
+    if n == 0 do
+        return 0
+    elif n == 1 do
+        return 1
     end
 
-    dup 1 - -> a
-    dup 2 - -> b
-    a fibb b fibb +
+    return fibb(n - 1) + fibb(n - 2)
 end
 
-0 while dup 10 < do
-    dup fibb .
-    1 +
+i = 0
+while i < 10 do
+    println(fibb(i))
+    i = i + 1
 end
-
-0 while dup 10 < do
-    dup . "\n" .
-    if dup 6 == do
-        break
-    end
-    1 +
-end
-
-1 2 3
-__print_frame__

--- a/examples/recursion.anzu
+++ b/examples/recursion.anzu
@@ -1,5 +1,6 @@
 # fibbonacci to demonstrate functions and recursion
 
+
 function fibb 1 1
     if dup 0 == do
         0 return

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,6 +1,3 @@
 # fibbonacci to demonstrate functions and recursion
 
-function foo(x, y) do
-    t = (x + 2) * y
-    return 2 * t
-end
+print("hello")

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,8 +1,14 @@
 # fibbonacci to demonstrate functions and recursion
 
+function foo(x, y) do
+    t = 5 + y
+end
+
 x = 5
 y = 2 * x
-y println
 
 y = 3 * x
-y println
+
+2 * x + 1
+
+x = 12

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,7 +1,27 @@
 # fibbonacci to demonstrate functions and recursion
 
-if to_bool(0) do
-    println("in if")
-else
-    print("in else\n")
+x = 1
+
+println(1)
+__print_frame__()
+println(2)
+
+
+function foo() do
+    d = 1
+    __print_frame__()
 end
+
+println(3)
+
+x = 1
+y = 2
+z = 3
+
+println(4)
+
+__print_frame__()
+
+println(5)
+foo()
+println(6)

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,4 +1,7 @@
 # fibbonacci to demonstrate functions and recursion
 
-if 2 < 4 do
+if to_bool(0) do
+    println("in if")
+else
+    print("in else\n")
 end

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,14 +1,6 @@
 # fibbonacci to demonstrate functions and recursion
 
 function foo(x, y) do
-    t = 5 + y
+    t = (x + 2) * y
+    return 2 * t
 end
-
-x = 5
-y = 2 * x
-
-y = 3 * x
-
-2 * x + 1
-
-x = 12

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -5,4 +5,13 @@ x = [1, 2, 3]
 list_push(x, 4)
 list_push(x, 5)
 
+index = 0
+while index < list_size(x) do
+    elem = list_at(x, index)
+
+    println(elem)
+
+    index = index + 1
+end
+
 println(x)

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,3 +1,4 @@
 # fibbonacci to demonstrate functions and recursion
 
-print("hello")
+if 2 < 4 do
+end

--- a/examples/test.anzu
+++ b/examples/test.anzu
@@ -1,27 +1,8 @@
 # fibbonacci to demonstrate functions and recursion
 
-x = 1
+x = [1, 2, 3]
 
-println(1)
-__print_frame__()
-println(2)
+list_push(x, 4)
+list_push(x, 5)
 
-
-function foo() do
-    d = 1
-    __print_frame__()
-end
-
-println(3)
-
-x = 1
-y = 2
-z = 3
-
-println(4)
-
-__print_frame__()
-
-println(5)
-foo()
-println(6)
+println(x)

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -126,6 +126,12 @@ void node_if_statement::print(int indent)
 
 void node_builtin_call::evaluate(compiler_context& ctx)
 {
+    // Push the args to the stack
+    for (const auto& arg : args) {
+        arg->evaluate(ctx);
+    }
+
+    // Call the function
     ctx.program.emplace_back(anzu::op_builtin_function_call{
         .name=function_name,
         .func=anzu::fetch_builtin(function_name)

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -529,10 +529,26 @@ auto parse_function(parser_context& ctx) -> node_ptr
     return ret;
 }
 
+auto parse_return(parser_context& ctx) -> node_ptr
+{
+    static const auto sentinel = std::unordered_set<std::string_view>{"end", "elif", "do", "else"};
+
+    auto ret_node = std::make_unique<anzu::node_return>();
+    if (!sentinel.contains(ctx.curr->text)) {
+        ret_node->return_value = parse_expression(ctx);
+    } else {
+        ret_node->return_value = std::make_unique<anzu::node_literal>(anzu::object{false}); // TODO: Make null
+    }
+    return ret_node;
+}
+
 auto parse_statement(parser_context& ctx) -> node_ptr
 {
     if (consume_maybe(ctx.curr, "function")) {
         return parse_function(ctx);
+    }
+    else if (consume_maybe(ctx.curr, "return")) {
+        return parse_return(ctx);
     }
     else if (consume_maybe(ctx.curr, "while")) {
         return parse_while_body(ctx);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -471,7 +471,7 @@ auto parse_statement_list(parser_context& ctx) -> node_ptr
 auto parse_while_body(parser_context& ctx) -> node_ptr
 {
     auto stmt = std::make_unique<anzu::node_while_statement>();
-    stmt->condition = parse_statement_list(ctx);
+    stmt->condition = parse_expression(ctx);
     consume_only(ctx.curr, "do");
     stmt->body = parse_statement_list(ctx);
     consume_only(ctx.curr, "end");
@@ -481,7 +481,7 @@ auto parse_while_body(parser_context& ctx) -> node_ptr
 auto parse_if_body(parser_context& ctx) -> node_ptr
 {
     auto stmt = std::make_unique<node_if_statement>();
-    stmt->condition = parse_statement_list(ctx);
+    stmt->condition = parse_expression(ctx);
     consume_only(ctx.curr, "do");
     stmt->body = parse_statement_list(ctx);
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -232,9 +232,7 @@ void node_discard_expression::evaluate(compiler_context& ctx)
 void node_discard_expression::print(int indent)
 {
     const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}DiscardExpr:\n", spaces);
-    anzu::print("{}- Value:\n", spaces);
-    expr->print(indent + 1);
+    expr->print(indent);
 }
 
 void node_function_def::evaluate(compiler_context& ctx)

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -17,8 +17,6 @@ constexpr auto ELSE        = std::string_view{"else"};
 constexpr auto WHILE       = std::string_view{"while"};
 constexpr auto BREAK       = std::string_view{"break"};
 constexpr auto CONTINUE    = std::string_view{"continue"};
-constexpr auto FUNCTION    = std::string_view{"function"};
-constexpr auto RETURN      = std::string_view{"return"};
 constexpr auto DO          = std::string_view{"do"};
 constexpr auto END         = std::string_view{"end"};
 constexpr auto TRUE_LIT    = std::string_view{"true"};
@@ -80,26 +78,6 @@ struct node_if_statement : public node
     void print(int indent = 0) override;
 };
 
-struct node_function_definition : public node
-{
-    std::string name;
-    int argc;
-    int retc;
-    std::unique_ptr<node> body;
-
-    void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
-};
-
-struct node_function_call : public node
-{
-    std::string name;
-
-    node_function_call(const std::string& n) : name(n) {}
-    void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
-};
-
 struct node_builtin_call : public node
 {
     std::string name;
@@ -116,12 +94,6 @@ struct node_break : public node
 };
 
 struct node_continue : public node
-{
-    void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
-};
-
-struct node_return : public node
 {
     void evaluate(compiler_context& ctx) override;
     void print(int indent = 0) override;
@@ -173,23 +145,13 @@ struct parser_context
 {
     token_iterator       curr;
     const token_iterator end;
-
-    std::unordered_set<std::string> function_names;
 };
 
 // Struct used to store information while compiling an AST. Contains the output program
 // as well as information such as function definitions.
 struct compiler_context
 {
-    struct function_def
-    {
-        int           argc;
-        int           retc;
-        std::intptr_t ptr; // Pointer to the position of this function in the program.
-    };
-
     std::vector<anzu::op> program;
-    std::unordered_map<std::string, function_def> functions;
 };
 
 auto parse(const std::vector<anzu::token>& tokens) -> std::unique_ptr<anzu::node>;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -201,6 +201,7 @@ struct compiler_context
 {
     struct function_def
     {
+        std::vector<std::string> arg_names;
         std::intptr_t ptr;
     };
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -78,15 +78,6 @@ struct node_if_statement : public node
     void print(int indent = 0) override;
 };
 
-struct node_builtin_call : public node
-{
-    std::string name;
-
-    node_builtin_call(const std::string& n) : name(n) {}
-    void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
-};
-
 struct node_break : public node
 {
     void evaluate(compiler_context& ctx) override;
@@ -169,6 +160,15 @@ struct node_function_call : public node
     void print(int indent = 0) override;
 };
 
+struct node_builtin_call : public node
+{
+    std::string                        function_name;
+    std::vector<std::unique_ptr<node>> args;
+
+    void evaluate(compiler_context& ctx) override;
+    void print(int indent = 0) override;
+};
+
 struct node_return : public node
 {
     std::unique_ptr<node> return_value; // Should leave a value on the stack
@@ -184,8 +184,15 @@ using node_ptr       = std::unique_ptr<anzu::node>;
 // tokens as well as keeping track of function names.
 struct parser_context
 {
+    struct function_info
+    {
+        std::int64_t argc;
+    };
+
     token_iterator       curr;
     const token_iterator end;
+
+    std::unordered_map<std::string, function_info> functions;
 };
 
 // Struct used to store information while compiling an AST. Contains the output program
@@ -194,7 +201,6 @@ struct compiler_context
 {
     struct function_def
     {
-        std::string  name;
         std::intptr_t ptr;
     };
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -9,6 +9,11 @@
 namespace anzu {
 namespace {
 
+auto push_null(anzu::context& ctx) -> void
+{
+    ctx.top().push(anzu::object{false});
+}
+
 auto verify(bool condition, std::string_view msg) -> void
 {
     if (!condition) {
@@ -17,16 +22,11 @@ auto verify(bool condition, std::string_view msg) -> void
     }
 }
 
-auto builtin_stack_size(anzu::context& ctx) -> void
-{
-    auto stack_size = static_cast<int>(ctx.top().stack_size());
-    ctx.top().push(stack_size);
-};
-
 auto builtin_print_frame(anzu::context& ctx) -> void
 {
     auto& frame = ctx.top();
     frame.print();
+    push_null(ctx);
 }
 
 auto builtin_list_push(anzu::context& ctx) -> void
@@ -37,6 +37,7 @@ auto builtin_list_push(anzu::context& ctx) -> void
     auto elem = frame.pop();
     auto list = frame.pop();
     list.as<object_list>()->push_back(elem);
+    push_null(ctx);
 }
 
 auto builtin_list_pop(anzu::context& ctx) -> void
@@ -44,6 +45,7 @@ auto builtin_list_pop(anzu::context& ctx) -> void
     auto& frame = ctx.top();
     verify(frame.top().is<object_list>(), "top element on stack must be a list for list_pop\n");
     auto list = frame.pop();
+    frame.push(list.as<object_list>()->back());
     list.as<object_list>()->pop_back();
 }
 
@@ -93,6 +95,7 @@ auto builtin_print(anzu::context& ctx) -> void
     } else {
         anzu::print("{}", obj);
     }
+    push_null(ctx);
 }
 
 auto builtin_println(anzu::context& ctx) -> void
@@ -104,6 +107,7 @@ auto builtin_println(anzu::context& ctx) -> void
     } else {
         anzu::print("{}\n", obj);
     }
+    push_null(ctx);
 }
 
 auto builtin_input(anzu::context& ctx) -> void
@@ -117,13 +121,12 @@ auto builtin_input(anzu::context& ctx) -> void
 }
 
 static const std::unordered_map<std::string, builtin> builtins = {
-    { "stack_size",      builtin{ builtin_stack_size,  0 }},
 
     // List functions
     { "list_push",       builtin{ builtin_list_push,   1 }},
-    { "list_pop",        builtin{ builtin_list_pop,    0 }},
-    { "list_size",       builtin{ builtin_list_size,   0 }},
-    { "list_at",         builtin{ builtin_list_at,     1 }},
+    { "list_pop",        builtin{ builtin_list_pop,    1 }},
+    { "list_size",       builtin{ builtin_list_size,   1 }},
+    { "list_at",         builtin{ builtin_list_at,     2 }},
 
     // Debug functions
     { "__print_frame__", builtin{ builtin_print_frame, 0 }},

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -116,27 +116,27 @@ auto builtin_input(anzu::context& ctx) -> void
 
 }
 
-static const std::unordered_map<std::string, builtin_function> builtins = {
-    { "stack_size",      builtin_stack_size  },
+static const std::unordered_map<std::string, builtin> builtins = {
+    { "stack_size",      builtin{ builtin_stack_size,  0 }},
 
     // List functions
-    { "list_push",       builtin_list_push   },
-    { "list_pop",        builtin_list_pop    },
-    { "list_size",       builtin_list_size   },
-    { "list_at",         builtin_list_at     },
+    { "list_push",       builtin{ builtin_list_push,   1 }},
+    { "list_pop",        builtin{ builtin_list_pop,    0 }},
+    { "list_size",       builtin{ builtin_list_size,   0 }},
+    { "list_at",         builtin{ builtin_list_at,     1 }},
 
     // Debug functions
-    { "__print_frame__", builtin_print_frame },
+    { "__print_frame__", builtin{ builtin_print_frame, 0 }},
 
     // Old Op Codes
-    { "to_int",          builtin_to_int      },
-    { "to_bool",         builtin_to_bool     },
-    { "to_str",          builtin_to_str      },
+    { "to_int",          builtin{ builtin_to_int,      1 }},
+    { "to_bool",         builtin{ builtin_to_bool,     1 }},
+    { "to_str",          builtin{ builtin_to_str,      1 }},
 
     // I/O
-    { "print",           builtin_print       },
-    { "println",         builtin_println     },
-    { "input",           builtin_input       }
+    { "print",           builtin{ builtin_print,       1 }},
+    { "println",         builtin{ builtin_println,     1 }},
+    { "input",           builtin{ builtin_input,       0 }}
 };
 
 auto is_builtin(const std::string& name) -> bool
@@ -146,7 +146,12 @@ auto is_builtin(const std::string& name) -> bool
 
 auto fetch_builtin(const std::string& name) -> builtin_function
 {
-    return builtins.at(name);
+    return builtins.at(name).ptr;
+}
+
+auto fetch_builtin_argc(const std::string& name) -> std::int64_t
+{
+    return builtins.at(name).argc;
 }
 
 }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -123,7 +123,7 @@ auto builtin_input(anzu::context& ctx) -> void
 static const std::unordered_map<std::string, builtin> builtins = {
 
     // List functions
-    { "list_push",       builtin{ builtin_list_push,   1 }},
+    { "list_push",       builtin{ builtin_list_push,   2 }},
     { "list_pop",        builtin{ builtin_list_pop,    1 }},
     { "list_size",       builtin{ builtin_list_size,   1 }},
     { "list_at",         builtin{ builtin_list_at,     2 }},

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -8,7 +8,14 @@ namespace anzu {
 
 using builtin_function = void(*)(anzu::context&);
 
+struct builtin
+{
+    builtin_function ptr;
+    std::int64_t     argc;
+};
+
 auto is_builtin(const std::string& name) -> bool;
 auto fetch_builtin(const std::string& name) -> builtin_function;
+auto fetch_builtin_argc(const std::string& name) -> std::int64_t;
     
 }

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -6,7 +6,6 @@
 namespace anzu {
 
 static const std::unordered_set<std::string_view> keywords = {
-    "function",
     "if",
     "elif",
     "else",

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -50,6 +50,12 @@ void op_push_var::apply(anzu::context& ctx) const
     frame.ptr() += 1;
 }
 
+void op_pop::apply(anzu::context& ctx) const
+{
+    auto& frame = ctx.top();
+    frame.pop();
+}
+
 
 void op_store::apply(anzu::context& ctx) const
 {
@@ -108,6 +114,24 @@ void op_builtin_function_call::apply(anzu::context& ctx) const
 {
     func(ctx);
     ctx.top().ptr() += 1;
+}
+
+void op_function::apply(anzu::context& ctx) const
+{
+    ctx.top().ptr() += jump;
+}
+
+void op_function_end::apply(anzu::context& ctx) const
+{
+    ctx.pop();
+    ctx.top().push(anzu::object{false}); // TODO: Make a null type
+}
+
+void op_return::apply(anzu::context& ctx) const
+{
+    auto return_value = ctx.top().pop();
+    ctx.pop();
+    ctx.top().push(return_value);
 }
 
 template <typename A, typename B>

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -54,6 +54,7 @@ void op_pop::apply(anzu::context& ctx) const
 {
     auto& frame = ctx.top();
     frame.pop();
+    frame.ptr() += 1;
 }
 
 

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -104,34 +104,6 @@ void op_do::apply(anzu::context& ctx) const
     }
 }
 
-void op_function::apply(anzu::context& ctx) const
-{
-    ctx.top().ptr() = jump;
-}
-
-void op_function_call::apply(anzu::context& ctx) const
-{
-    auto& curr = ctx.push({}); // New frame
-    auto& prev = ctx.top(1);   // One under the top
-
-    curr.ptr() = jump; // Jump into the function
-    prev.ptr() += 1;   // The position in the program where it will resume
-
-    transfer_values(prev, curr, argc);
-}
-
-void op_function_end::apply(anzu::context& ctx) const
-{
-    transfer_values(ctx.top(0), ctx.top(1), retc);
-    ctx.pop(); // Remove stack frame
-}
-
-void op_return::apply(anzu::context& ctx) const
-{
-    transfer_values(ctx.top(0), ctx.top(1), retc);
-    ctx.pop(); // Remove stack frame
-}
-
 void op_builtin_function_call::apply(anzu::context& ctx) const
 {
     func(ctx);

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -28,6 +28,12 @@ struct op_push_var
     void apply(anzu::context& ctx) const;
 };
 
+struct op_pop
+{
+    std::string to_string() const { return "OP_POP"; }
+    void apply(anzu::context& ctx) const;
+};
+
 // Store Manipulation
 
 struct op_store
@@ -209,11 +215,33 @@ struct op_and
     void apply(anzu::context& ctx) const;
 };
 
+struct op_function
+{
+    std::string              name;
+    std::vector<std::string> arg_names;
+    std::intptr_t            jump;
+    std::string to_string() const { return std::format("OP_FUNCTION({})", name); }
+    void apply(anzu::context& ctx) const;
+};
+
+struct op_function_end
+{
+    std::string to_string() const { return "OP_FUNCTION_END"; }
+    void apply(anzu::context& ctx) const;
+};
+
+struct op_return
+{
+    std::string to_string() const { return "OP_RETURN"; }
+    void apply(anzu::context& ctx) const;
+};
+
 class op
 {
     using op_type = std::variant<
         op_push_const,
         op_push_var,
+        op_pop,
 
         // Store Manipulation
         op_store,
@@ -228,7 +256,6 @@ class op
         op_continue,
         op_do,
 
-        // Functions
         op_builtin_function_call,
 
         // Numerical Operators
@@ -246,7 +273,11 @@ class op
         op_gt,
         op_ge,
         op_or,
-        op_and
+        op_and,
+
+        op_function,
+        op_function_end,
+        op_return
     >;
 
     op_type d_type;

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -124,6 +124,16 @@ struct op_do
     void apply(anzu::context& ctx) const;
 };
 
+struct op_function_call
+{
+    std::string   name;
+    std::intptr_t ptr;
+    std::vector<std::string> arg_names;
+
+    std::string to_string() const { return std::format("OP_FUNCTION_CALL({})", name); }
+    void apply(anzu::context& ctx) const;
+};
+
 struct op_builtin_function_call
 {
     std::string name;
@@ -220,7 +230,12 @@ struct op_function
     std::string              name;
     std::vector<std::string> arg_names;
     std::intptr_t            jump;
-    std::string to_string() const { return std::format("OP_FUNCTION({})", name); }
+    std::string to_string() const
+    {
+        const auto func_str = std::format("OP_FUNCTION({})", name);
+        const auto jump_str = std::format("JUMP -> {}", jump);
+        return std::format(FORMAT2, func_str, jump_str);
+    }
     void apply(anzu::context& ctx) const;
 };
 
@@ -256,8 +271,6 @@ class op
         op_continue,
         op_do,
 
-        op_builtin_function_call,
-
         // Numerical Operators
         op_add,
         op_sub,
@@ -277,7 +290,9 @@ class op
 
         op_function,
         op_function_end,
-        op_return
+        op_return,
+        op_function_call,
+        op_builtin_function_call
     >;
 
     op_type d_type;

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -118,60 +118,6 @@ struct op_do
     void apply(anzu::context& ctx) const;
 };
 
-struct op_function
-{
-    std::string   name;
-    std::intptr_t jump = -1;  // Jumps to end of function so it isnt invoked when running.
-
-    std::string to_string() const
-    {
-        const auto func_str = std::format("OP_FUNCTION({})", name);
-        const auto jump_str = std::format("JUMP -> {}", jump);
-        return std::format(FORMAT2, func_str, jump_str);
-    }
-    void apply(anzu::context& ctx) const;
-};
-
-struct op_function_end
-{
-    int retc;
-
-    std::string to_string() const
-    {
-        const auto retc_str = std::format("(RETC = {})", retc);
-        return std::format(FORMAT3, "OP_FUNCTION_END", "JUMP -> CALL", retc_str);
-    }
-    void apply(anzu::context& ctx) const;
-};
-
-struct op_function_call
-{
-    std::string   name;
-    int           argc;
-    std::intptr_t jump;
-
-    std::string to_string() const
-    {
-        const auto func_str = std::format("OP_FUNCTION_CALL({})", name);
-        const auto jump_str = std::format("JUMP -> {}", jump);
-        const auto argc_str = std::format("(ARGC = {})", argc);
-        return std::format(FORMAT3, func_str, jump_str, argc_str);
-    }
-    void apply(anzu::context& ctx) const;
-};
-
-struct op_return
-{
-    int retc = -1;
-
-    std::string to_string() const
-    {
-        const auto retc_str = std::format("(RETC = {})", retc);
-        return std::format(FORMAT3, "OP_RETURN", "JUMP -> CALL", retc_str);
-    }
-    void apply(anzu::context& ctx) const;
-};
-
 struct op_builtin_function_call
 {
     std::string name;
@@ -283,10 +229,6 @@ class op
         op_do,
 
         // Functions
-        op_function,
-        op_function_call,
-        op_function_end,
-        op_return,
         op_builtin_function_call,
 
         // Numerical Operators


### PR DESCRIPTION
* Reworked functions, new syntax is `function <name>(<args>) do <body> end`, similar to python.
* Functions now only return a single value, using the familiar `return <value>` syntax in python.
* If no return value is specified, a function returns `false`. This is temporary until a `null` value is added.
* Added the `discard_expression` and `assign_expression` nodes. Discard expressions evaluate the given expression, and then pop the top of the stack. It is currently not enforced that expressions must add a value to the stack, this will require further work. Assign expressions pop the value off the stack and store it.
* The above was to allow functions returning a value. If the function call is in a discard expression, the returned value gets popped. Function calls are another type of factor for expressions.
* The new implementation still has many bugs and needs tidying up, but it works!