### PR TITLE
Function Expressions vs Statements

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -192,31 +192,19 @@ void node_bin_op::print(int indent)
     rhs->print(indent + 1);
 }
 
-void node_assign_expression::evaluate(compiler_context& ctx)
+void node_assignment::evaluate(compiler_context& ctx)
 {
     expr->evaluate(ctx);
     ctx.program.emplace_back(anzu::op_store{ .name=name });
 }
 
-void node_assign_expression::print(int indent)
+void node_assignment::print(int indent)
 {
     const auto spaces = std::string(4 * indent, ' ');
     anzu::print("{}AssignExpr\n", spaces);
     anzu::print("{}- Name: {}\n", spaces, name);
     anzu::print("{}- Value:\n", spaces);
     expr->print(indent + 1);
-}
-
-void node_discard_expression::evaluate(compiler_context& ctx)
-{
-    expr->evaluate(ctx);
-    ctx.program.emplace_back(anzu::op_pop{});
-}
-
-void node_discard_expression::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    expr->print(indent);
 }
 
 void node_function_def::evaluate(compiler_context& ctx)
@@ -244,7 +232,7 @@ void node_function_def::print(int indent)
     body->print(indent + 1);
 }
 
-void node_function_call::evaluate(compiler_context& ctx)
+void node_function_call_expression::evaluate(compiler_context& ctx)
 {
     // Push the args to the stack
     for (const auto& arg : args) {
@@ -261,7 +249,7 @@ void node_function_call::evaluate(compiler_context& ctx)
     });
 }
 
-void node_function_call::print(int indent)
+void node_function_call_expression::print(int indent)
 {
     const auto spaces = std::string(4 * indent, ' ');
     anzu::print("{}FunctionCall: {}\n", spaces, function_name);

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -122,20 +122,9 @@ struct node_bin_op : public node
 // Evaluates the child node and assigns the result to the given name.
 // Currently assuming that the child node results in a value being pushed
 // to the stack, will enforce this in the code later on.
-struct node_assign_expression : public node
+struct node_assignment : public node
 {
     std::string name;
-    std::unique_ptr<node> expr;
-
-    void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
-};
-
-// Evaluates the child node and then inserts an OP_POP to ignore the
-// returned value. Currently assuming that the child node results in a
-// value being pushed to the stack, will enforce this in the code later on.
-struct node_discard_expression : public node
-{
     std::unique_ptr<node> expr;
 
     void evaluate(compiler_context& ctx) override;
@@ -152,7 +141,7 @@ struct node_function_def : public node
     void print(int indent = 0) override;
 };
 
-struct node_function_call : public node
+struct node_function_call_expression : public node
 {
     std::string                        function_name;
     std::vector<std::unique_ptr<node>> args;

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -161,7 +161,25 @@ struct node_function_call : public node
     void print(int indent = 0) override;
 };
 
+struct node_function_call_statement : public node
+{
+    std::string                        function_name;
+    std::vector<std::unique_ptr<node>> args;
+
+    void evaluate(compiler_context& ctx) override;
+    void print(int indent = 0) override;
+};
+
 struct node_builtin_call : public node
+{
+    std::string                        function_name;
+    std::vector<std::unique_ptr<node>> args;
+
+    void evaluate(compiler_context& ctx) override;
+    void print(int indent = 0) override;
+};
+
+struct node_builtin_call_statement : public node
 {
     std::string                        function_name;
     std::vector<std::unique_ptr<node>> args;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -304,9 +304,77 @@ auto parse_builtin_call(parser_context& ctx) -> node_ptr
     return node;
 }
 
+auto parse_builtin_call_stmt(parser_context& ctx) -> node_ptr
+{
+    auto node = std::make_unique<anzu::node_builtin_call_statement>();
+    node->function_name = (ctx.curr++)->text;
+
+    consume_only(ctx.curr, "(");
+    bool expect_comma = false;
+    while (ctx.curr != ctx.end && ctx.curr->text != ")") {
+        if (expect_comma) {
+            if (ctx.curr->text != ",") { // skip commas, enforce later
+                anzu::print("syntax error: expected comma in function call arg list\n");
+                std::exit(1);
+            }
+            ++ctx.curr;
+        }
+        else {
+            node->args.push_back(parse_expression(ctx));
+        }
+        expect_comma = !expect_comma;
+    }
+    consume_only(ctx.curr, ")");
+
+    const auto argc = anzu::fetch_builtin_argc(node->function_name);
+    if (argc != std::ssize(node->args)) {
+        anzu::print(
+            "error: function '{}' expected {} args, got {}\n",
+            node->function_name, argc, std::ssize(node->args)
+        );
+        std::exit(1);
+    }
+
+    return node;
+}
+
 auto parse_function_call(parser_context& ctx) -> node_ptr
 {
     auto node = std::make_unique<anzu::node_function_call>();
+    node->function_name = (ctx.curr++)->text;
+
+    consume_only(ctx.curr, "(");
+    bool expect_comma = false;
+    while (ctx.curr != ctx.end && ctx.curr->text != ")") {
+        if (expect_comma) {
+            if (ctx.curr->text != ",") { // skip commas, enforce later
+                anzu::print("syntax error: expected comma in function call arg list\n");
+                std::exit(1);
+            }
+            ++ctx.curr;
+        }
+        else {
+            node->args.push_back(parse_expression(ctx));
+        }
+        expect_comma = !expect_comma;
+    }
+    consume_only(ctx.curr, ")");
+
+    const auto argc = ctx.functions.at(node->function_name).argc;
+    if (argc != std::ssize(node->args)) {
+        anzu::print(
+            "error: function '{}' expected {} args, got {}\n",
+            node->function_name, argc, std::ssize(node->args)
+        );
+        std::exit(1);
+    }
+
+    return node;
+}
+
+auto parse_function_call_stmt(parser_context& ctx) -> node_ptr
+{
+    auto node = std::make_unique<anzu::node_function_call_statement>();
     node->function_name = (ctx.curr++)->text;
 
     consume_only(ctx.curr, "(");
@@ -362,10 +430,18 @@ auto parse_statement(parser_context& ctx) -> node_ptr
     else if (auto next = std::next(ctx.curr); next != ctx.end && next->text == "=") {
         return parse_assign_expression(ctx);
     }
-    else if (ctx.curr != ctx.end) {
-        return parse_discard_expression(ctx);
+    else if (ctx.functions.contains(ctx.curr->text)) {
+        return parse_function_call_stmt(ctx);
     }
-    return nullptr;
+    else if (anzu::is_builtin(ctx.curr->text)) {
+        return parse_builtin_call_stmt(ctx);
+    }
+    else {
+        auto expression = parse_expression(ctx);
+        anzu::print("error: unused statement\n");
+        expression->print();
+        std::exit(1);
+    }
 }
 
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -159,15 +159,8 @@ auto parse_assign_expression(parser_context& ctx) -> node_ptr
     auto name = (ctx.curr++)->text;
     consume_only(ctx.curr, "=");
 
-    auto assign = std::make_unique<anzu::node_assign_expression>();
+    auto assign = std::make_unique<anzu::node_assignment>();
     assign->name = name;
-    assign->expr = parse_expression(ctx);
-    return assign;
-}
-
-auto parse_discard_expression(parser_context& ctx) -> node_ptr
-{
-    auto assign = std::make_unique<anzu::node_discard_expression>();
     assign->expr = parse_expression(ctx);
     return assign;
 }
@@ -340,7 +333,7 @@ auto parse_builtin_call_stmt(parser_context& ctx) -> node_ptr
 
 auto parse_function_call(parser_context& ctx) -> node_ptr
 {
-    auto node = std::make_unique<anzu::node_function_call>();
+    auto node = std::make_unique<anzu::node_function_call_expression>();
     node->function_name = (ctx.curr++)->text;
 
     consume_only(ctx.curr, "(");


### PR DESCRIPTION
* Renamed `node_function_call` to `node_function_call_expression` and added `node_function_call_statement`. Similarly for the `builtin` variants.
* The statement node adds in a `OP_POP` after when parsing, and is intended to be used whenever a function is called on its own with the return value discarded.
* The expression node is the version which is used when evaluating arithmetic/logical statements which is the current behaviour.
* If an expression is parsed now but not as part of an assignment, function call, return statement, while condition or if condition, the parsing fails.
* There is code duplication here, but I'll remove that when I switch to a variant implementation of the parse tree. The goal here is to make expressions a distinct type so that I can enforce that expressions are only made up of expression types. Currently it would be possible to put a different statement type (like a while loop) in place of a factor. It will still probably error but not for the expected reason.