### PR TITLE
Variant-Based AST

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/feature_test.az", "lex"],
+            "args": ["${workspaceFolder}/examples/feature_test.az", "parse"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/grammar.txt
+++ b/grammar.txt
@@ -12,22 +12,27 @@ literal:
   | list_literal
 
 expression:
-  | level_5_expression
+  | disjunction
 
-level_5_expression:
-  | level_4_expression [('*'|'/'|'%') level_5_expression]*
+disjunction:
+  | disjunction '||' conjunction
+  | conjunction
 
-level_4_expression:
-  | level_3_expression [('+'|'-') level_4_expression]*
+conjunction:
+  | conjunction '&&' comparison
+  | comparison
 
-level_3_expression:
-  | level_2_expression [('<'|'<='|'>'|'>='|'=='|'!=') level_3_expression]*
+comparison:
+  | comparison ('<'|'<='|'>'|'>='|'=='|'!=') sum
+  | sum
 
-level_2_expression:
-  | level_1_expression ['&&' level_2_expression]*
+sum:
+  | sum ('+'|'-') term
+  | term
 
-level_1_expression:
-  | factor ['||' level_1_expression]*
+term:
+  | term ('*'|'/'|'%') factor
+  | factor
 
 factor:
   | literal
@@ -35,17 +40,12 @@ factor:
   | '(' expression ')'
 
 statement:
-  | 'function' function_body
-  | 'while' while_body
+  | function_def_stmt
+  | while_stmt
   | 'if' if_body
   | 'return'
   | 'break'
   | 'continue'
-
-  # We will remove the 'expr' token eventually, this is just for during development.
-  # When assignments and function calls can be included, this can be the last thing
-  # that a statement is parsed as, resulting in a failure otherwise.
-  | 'expr' expression
   | function_identifier
   | builtin_identifier
   | op_code  # This is temporary and will be removed
@@ -56,13 +56,17 @@ function_identifier:
 builtin_identifier:
   | string_literal
 
-function_body:
-  | function_identifier int_literal int_literal statement_list 'end'
-  | function_identifier int_literal int_literal 'end'
+function_signature:
+  | name ',' function_signature
+  | name
 
-while_body:
-  | statement_list 'do' statement_list 'end'
-  | statement_list 'do' 'end'
+function_def_stmt:
+  | 'function' '(' function_signature ')' 'do' statement_list 'end'
+  | 'function' '(' function_signature ')' 'do' 'end'
+
+while_stmt:
+  | 'while' statement_list 'do' statement_list 'end'
+  | 'while' statement_list 'do' 'end'
 
 if_body:
   | statement_list 'do' statement_list 'elif' if_body

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,11 +5,12 @@ set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS}")
 
 add_executable(anzu
                anzu.m.cpp
+               ast.cpp
+               lexer.cpp
+               parser.cpp
                compiler.cpp
                stack_frame.cpp
                op_codes.cpp
-               lexer.cpp
-               parser.cpp
                object.cpp
                functions.cpp)
 

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv)
 
     const auto root = anzu::parse(tokens);
     if (mode == "parse") {
-        //root->print();
+        print_node(*root);
         return 0;
     }
 

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -85,20 +85,20 @@ int main(int argc, char** argv)
         return 0;
     }
 
-    //const auto program = anzu::compile(root);
-    //if (mode == "com") {
-    //    print_program(program);
-    //    return 0;
-    //}
+    const auto program = anzu::compile(root);
+    if (mode == "com") {
+        print_program(program);
+        return 0;
+    }
 
-    //if (mode == "run") {
-    //    run_program(program);
-    //    return 0;
-    //}
-    //else if (mode == "debug") {
-    //    run_program_debug(program);
-    //    return 0;
-    //}
+    if (mode == "run") {
+        run_program(program);
+        return 0;
+    }
+    else if (mode == "debug") {
+        run_program_debug(program);
+        return 0;
+    }
 
     anzu::print("unknown mode: '{}'\n", mode);
     print_usage();

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -81,24 +81,24 @@ int main(int argc, char** argv)
 
     const auto root = anzu::parse(tokens);
     if (mode == "parse") {
-        root->print();
+        //root->print();
         return 0;
     }
 
-    const auto program = anzu::compile(root);
-    if (mode == "com") {
-        print_program(program);
-        return 0;
-    }
+    //const auto program = anzu::compile(root);
+    //if (mode == "com") {
+    //    print_program(program);
+    //    return 0;
+    //}
 
-    if (mode == "run") {
-        run_program(program);
-        return 0;
-    }
-    else if (mode == "debug") {
-        run_program_debug(program);
-        return 0;
-    }
+    //if (mode == "run") {
+    //    run_program(program);
+    //    return 0;
+    //}
+    //else if (mode == "debug") {
+    //    run_program_debug(program);
+    //    return 0;
+    //}
 
     anzu::print("unknown mode: '{}'\n", mode);
     print_usage();

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1,0 +1,134 @@
+#pragma once
+#include "object.hpp"
+
+#include <variant>
+#include <vector>
+#include <memory>
+
+namespace anzu {
+
+struct node_literal_expr;
+struct node_variable_expr;
+struct node_bin_op_expr;
+struct node_function_call_expr;
+struct node_builtin_call_expr;
+using node_expr = std::variant<
+    node_literal_expr,
+    node_variable_expr,
+    node_bin_op_expr,
+    node_function_call_expr,
+    node_builtin_call_expr
+>;
+using node_expr_ptr = std::unique_ptr<node_expr>;
+
+struct node_sequence_stmt;
+struct node_while_stmt;
+struct node_if_stmt;
+struct node_break_stmt;
+struct node_continue_stmt;
+struct node_assignment_stmt;
+struct node_function_def_stmt;
+struct node_function_call_stmt;
+struct node_builtin_call_stmt;
+struct node_return_stmt;
+using node_stmt = std::variant<
+    node_sequence_stmt,
+    node_while_stmt,
+    node_if_stmt,
+    node_break_stmt,
+    node_continue_stmt,
+    node_assignment_stmt,
+    node_function_def_stmt,
+    node_function_call_stmt,
+    node_builtin_call_stmt,
+    node_return_stmt,
+    node_expr
+>;
+using node_stmt_ptr = std::unique_ptr<node_stmt>;
+
+struct node_literal_expr
+{
+    anzu::object value;
+};
+
+struct node_variable_expr
+{
+    std::string name;
+};
+
+struct node_bin_op_expr
+{
+    std::string op; // TODO: make into enum
+    node_expr_ptr lhs;
+    node_expr_ptr rhs;
+};
+
+struct node_function_call_expr
+{
+    std::string                function_name;
+    std::vector<node_expr_ptr> args;
+};
+
+struct node_builtin_call_expr
+{
+    std::string                function_name;
+    std::vector<node_expr_ptr> args;
+};
+
+struct node_sequence_stmt
+{
+    std::vector<node_stmt_ptr> sequence;
+};
+
+struct node_while_stmt
+{
+    node_expr_ptr condition;
+    node_stmt_ptr body;
+};
+
+struct node_if_stmt
+{
+    node_expr_ptr condition;
+    node_stmt_ptr body;
+    node_stmt_ptr else_body;
+};
+
+struct node_break_stmt
+{
+};
+
+struct node_continue_stmt
+{
+};
+
+struct node_assignment_stmt
+{
+    std::string   name;
+    node_expr_ptr expr;
+};
+
+struct node_function_def_stmt
+{
+    std::string              name;
+    std::vector<std::string> arg_names;
+    node_stmt_ptr            body;
+};
+
+struct node_function_call_stmt
+{
+    std::string                function_name;
+    std::vector<node_expr_ptr> args;
+};
+
+struct node_builtin_call_stmt
+{
+    std::string                function_name;
+    std::vector<node_expr_ptr> args;
+};
+
+struct node_return_stmt
+{
+    node_expr_ptr return_value;
+};
+
+}

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -131,4 +131,7 @@ struct node_return_stmt
     node_expr_ptr return_value;
 };
 
+auto print_node(const anzu::node_expr& node, int indent = 0) -> void;
+auto print_node(const anzu::node_stmt& node, int indent = 0) -> void;
+
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -9,25 +9,93 @@
 #include <tuple>
 
 namespace anzu {
+namespace {
 
-void node_sequence::evaluate(compiler_context& ctx)
+auto compile_node(const node_expr& root, compiler_context& ctx) -> void;
+auto compile_node(const node_stmt& root, compiler_context& ctx) -> void;
+
+void compile_node(const node_literal_expr& node, compiler_context& ctx)
 {
-    for (const auto& node : sequence) {
-        node->evaluate(ctx);
+    ctx.program.emplace_back(anzu::op_push_const{ .value=node.value });
+}
+
+void compile_node(const node_variable_expr& node, compiler_context& ctx)
+{
+    ctx.program.emplace_back(anzu::op_push_var{ .name=node.name });
+}
+
+void compile_node(const node_bin_op_expr& node, compiler_context& ctx)
+{
+    compile_node(*node.lhs, ctx);
+    compile_node(*node.rhs, ctx);
+    if      (node.op == "+")  { ctx.program.push_back(anzu::op_add{}); }
+    else if (node.op == "-")  { ctx.program.push_back(anzu::op_sub{}); }
+    else if (node.op == "*")  { ctx.program.push_back(anzu::op_mul{}); }
+    else if (node.op == "/")  { ctx.program.push_back(anzu::op_div{}); }
+    else if (node.op == "%")  { ctx.program.push_back(anzu::op_mod{}); }
+    else if (node.op == "<")  { ctx.program.push_back(anzu::op_lt{}); }
+    else if (node.op == "<=") { ctx.program.push_back(anzu::op_le{}); }
+    else if (node.op == ">")  { ctx.program.push_back(anzu::op_gt{}); }
+    else if (node.op == ">=") { ctx.program.push_back(anzu::op_ge{}); }
+    else if (node.op == "==") { ctx.program.push_back(anzu::op_eq{}); }
+    else if (node.op == "!=") { ctx.program.push_back(anzu::op_ne{}); }
+    else if (node.op == "||") { ctx.program.push_back(anzu::op_or{}); }
+    else if (node.op == "&&") { ctx.program.push_back(anzu::op_and{}); }
+    else {
+        anzu::print("syntax error: unknown binary operator: '{}'\n", node.op);
+        std::exit(1);
     }
 }
 
-void node_while_statement::evaluate(compiler_context& ctx)
+void compile_node(const node_function_call_expr& node, compiler_context& ctx)
+{
+    // Push the args to the stack
+    for (const auto& arg : node.args) {
+        compile_node(*arg, ctx);
+    }
+
+    const auto& function_def = ctx.functions.at(node.function_name);
+
+    // Call the function
+    ctx.program.emplace_back(anzu::op_function_call{
+        .name=node.function_name,
+        .ptr=function_def.ptr + 1, // Jump into the function
+        .arg_names=function_def.arg_names
+    });
+}
+
+void compile_node(const node_builtin_call_expr& node, compiler_context& ctx)
+{
+    // Push the args to the stack
+    for (const auto& arg : node.args) {
+        compile_node(*arg, ctx);
+    }
+
+    // Call the function
+    ctx.program.emplace_back(anzu::op_builtin_function_call{
+        .name=node.function_name,
+        .func=anzu::fetch_builtin(node.function_name)
+    });
+}
+
+void compile_node(const node_sequence_stmt& node, compiler_context& ctx)
+{
+    for (const auto& seq_node : node.sequence) {
+        compile_node(*seq_node, ctx);
+    }
+}
+
+void compile_node(const node_while_stmt& node, compiler_context& ctx)
 {
     const auto while_pos = std::ssize(ctx.program);
     ctx.program.emplace_back(anzu::op_while{});
 
-    condition->evaluate(ctx);
+    compile_node(*node.condition, ctx);
     
     const auto do_pos = std::ssize(ctx.program);
     ctx.program.emplace_back(anzu::op_do{});
 
-    body->evaluate(ctx);
+    compile_node(*node.body, ctx);
 
     const auto end_pos = std::ssize(ctx.program);
     ctx.program.emplace_back(anzu::op_while_end{ .jump=while_pos }); // Jump back to start
@@ -46,22 +114,23 @@ void node_while_statement::evaluate(compiler_context& ctx)
     }
 }
 
-void node_if_statement::evaluate(compiler_context& ctx)
+void compile_node(const node_if_stmt& node, compiler_context& ctx)
 {
     const auto if_pos = std::ssize(ctx.program);
     ctx.program.emplace_back(anzu::op_if{});
 
-    condition->evaluate(ctx);
+    compile_node(*node.condition, ctx);
     
     const auto do_pos = std::ssize(ctx.program);
     ctx.program.emplace_back(anzu::op_do{});
-    body->evaluate(ctx);
+
+    compile_node(*node.body, ctx);
 
     auto else_pos = std::intptr_t{-1};
-    if (else_body) {
+    if (node.else_body) {
         else_pos = std::ssize(ctx.program);
         ctx.program.emplace_back(anzu::op_else{});
-        else_body->evaluate(ctx);
+        compile_node(*node.else_body, ctx);
     }
 
     ctx.program.emplace_back(anzu::op_if_end{});
@@ -73,65 +142,29 @@ void node_if_statement::evaluate(compiler_context& ctx)
     }
 }
 
-void node_literal::evaluate(compiler_context& ctx)
-{
-    ctx.program.emplace_back(anzu::op_push_const{ .value=value });
-}
-
-void node_variable::evaluate(compiler_context& ctx)
-{
-    ctx.program.emplace_back(anzu::op_push_var{ .name=name });
-}
-
-
-void node_break::evaluate(compiler_context& ctx)
+void compile_node(const node_break_stmt&, compiler_context& ctx)
 {
     ctx.program.emplace_back(anzu::op_break{});
 }
 
-
-void node_continue::evaluate(compiler_context& ctx)
+void compile_node(const node_continue_stmt&, compiler_context& ctx)
 {
     ctx.program.emplace_back(anzu::op_continue{});
 }
 
-
-void node_bin_op::evaluate(compiler_context& ctx)
+void compile_node(const node_assignment_stmt& node, compiler_context& ctx)
 {
-    lhs->evaluate(ctx);
-    rhs->evaluate(ctx);
-    if      (op == "+")  { ctx.program.push_back(anzu::op_add{}); }
-    else if (op == "-")  { ctx.program.push_back(anzu::op_sub{}); }
-    else if (op == "*")  { ctx.program.push_back(anzu::op_mul{}); }
-    else if (op == "/")  { ctx.program.push_back(anzu::op_div{}); }
-    else if (op == "%")  { ctx.program.push_back(anzu::op_mod{}); }
-    else if (op == "<")  { ctx.program.push_back(anzu::op_lt{}); }
-    else if (op == "<=") { ctx.program.push_back(anzu::op_le{}); }
-    else if (op == ">")  { ctx.program.push_back(anzu::op_gt{}); }
-    else if (op == ">=") { ctx.program.push_back(anzu::op_ge{}); }
-    else if (op == "==") { ctx.program.push_back(anzu::op_eq{}); }
-    else if (op == "!=") { ctx.program.push_back(anzu::op_ne{}); }
-    else if (op == "||") { ctx.program.push_back(anzu::op_or{}); }
-    else if (op == "&&") { ctx.program.push_back(anzu::op_and{}); }
-    else {
-        anzu::print("syntax error: unknown binary operator: '{}'\n", op);
-        std::exit(1);
-    }
+    compile_node(*node.expr, ctx);
+    ctx.program.emplace_back(anzu::op_store{ .name=node.name });
 }
 
-void node_assignment::evaluate(compiler_context& ctx)
-{
-    expr->evaluate(ctx);
-    ctx.program.emplace_back(anzu::op_store{ .name=name });
-}
-
-void node_function_def::evaluate(compiler_context& ctx)
+void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
 {
     const auto start_pos = std::ssize(ctx.program);
-    ctx.program.emplace_back(anzu::op_function{ .name=name, .arg_names=arg_names });
-    ctx.functions[name] = { .arg_names=arg_names ,.ptr=start_pos };
+    ctx.program.emplace_back(anzu::op_function{ .name=node.name, .arg_names=node.arg_names });
+    ctx.functions[node.name] = { .arg_names=node.arg_names ,.ptr=start_pos };
 
-    body->evaluate(ctx);
+    compile_node(*node.body, ctx);
 
     const auto end_pos = std::ssize(ctx.program);
     ctx.program.emplace_back(anzu::op_function_end{});
@@ -139,80 +172,61 @@ void node_function_def::evaluate(compiler_context& ctx)
     ctx.program[start_pos].as<anzu::op_function>().jump = end_pos + 1;
 }
 
-void node_function_call_expression::evaluate(compiler_context& ctx)
+void compile_node(const node_function_call_stmt& node, compiler_context& ctx)
 {
     // Push the args to the stack
-    for (const auto& arg : args) {
-        arg->evaluate(ctx);
+    for (const auto& arg : node.args) {
+        compile_node(*arg, ctx);
     }
 
-    const auto& function_def = ctx.functions.at(function_name);
+    const auto& function_def = ctx.functions.at(node.function_name);
 
     // Call the function
     ctx.program.emplace_back(anzu::op_function_call{
-        .name=function_name,
+        .name=node.function_name,
         .ptr=function_def.ptr + 1, // Jump into the function
         .arg_names=function_def.arg_names
-    });
-}
-
-void node_function_call_statement::evaluate(compiler_context& ctx)
-{
-    // Push the args to the stack
-    for (const auto& arg : args) {
-        arg->evaluate(ctx);
-    }
-
-    const auto& function_def = ctx.functions.at(function_name);
-
-    // Call the function
-    ctx.program.emplace_back(anzu::op_function_call{
-        .name=function_name,
-        .ptr=function_def.ptr + 1, // Jump into the function
-        .arg_names=function_def.arg_names
-    });
-}
-
-void node_builtin_call::evaluate(compiler_context& ctx)
-{
-    // Push the args to the stack
-    for (const auto& arg : args) {
-        arg->evaluate(ctx);
-    }
-
-    // Call the function
-    ctx.program.emplace_back(anzu::op_builtin_function_call{
-        .name=function_name,
-        .func=anzu::fetch_builtin(function_name)
     });
     ctx.program.emplace_back(anzu::op_pop{});
 }
 
-void node_builtin_call_statement::evaluate(compiler_context& ctx)
+void compile_node(const node_builtin_call_stmt& node, compiler_context& ctx)
 {
     // Push the args to the stack
-    for (const auto& arg : args) {
-        arg->evaluate(ctx);
+    for (const auto& arg : node.args) {
+        compile_node(*arg, ctx);
     }
 
     // Call the function
     ctx.program.emplace_back(anzu::op_builtin_function_call{
-        .name=function_name,
-        .func=anzu::fetch_builtin(function_name)
+        .name=node.function_name,
+        .func=anzu::fetch_builtin(node.function_name)
     });
     ctx.program.emplace_back(anzu::op_pop{});
 }
 
-void node_return::evaluate(compiler_context& ctx)
+void compile_node(const node_return_stmt& node, compiler_context& ctx)
 {
-    return_value->evaluate(ctx);
+    compile_node(*node.return_value, ctx);
     ctx.program.emplace_back(anzu::op_return{});
 }
 
-auto compile(const std::unique_ptr<anzu::node>& root) -> std::vector<anzu::op>
+auto compile_node(const node_expr& root, compiler_context& ctx) -> void
+{
+    std::visit([&](const auto& node) { compile_node(node, ctx); }, root);
+}
+
+auto compile_node(const node_stmt& root, compiler_context& ctx) -> void
+{
+    std::visit([&](const auto& node) { compile_node(node, ctx); }, root);
+}
+
+}
+
+auto compile(const std::unique_ptr<node_stmt>& root) -> std::vector<anzu::op>
 {
     anzu::compiler_context ctx;
-    root->evaluate(ctx);
+    compile_node(*root, ctx);
     return ctx.program;
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -17,15 +17,6 @@ void node_sequence::evaluate(compiler_context& ctx)
     }
 }
 
-void node_sequence::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}Sequence:\n", spaces);
-    for (const auto& node : sequence) {
-        node->print(indent + 1);
-    }
-}
-
 void node_while_statement::evaluate(compiler_context& ctx)
 {
     const auto while_pos = std::ssize(ctx.program);
@@ -55,16 +46,6 @@ void node_while_statement::evaluate(compiler_context& ctx)
     }
 }
 
-void node_while_statement::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}While:\n", spaces);
-    anzu::print("{}- Condition:\n", spaces);
-    condition->print(indent + 1);
-    anzu::print("{}- Body:\n", spaces);
-    body->print(indent + 1);
-}
-
 void node_if_statement::evaluate(compiler_context& ctx)
 {
     const auto if_pos = std::ssize(ctx.program);
@@ -92,29 +73,9 @@ void node_if_statement::evaluate(compiler_context& ctx)
     }
 }
 
-void node_if_statement::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}If:\n", spaces);
-    anzu::print("{}- Condition:\n", spaces);
-    condition->print(indent + 1);
-    anzu::print("{}- Body:\n", spaces);
-    body->print(indent + 1);
-    if (else_body) {
-        anzu::print("{}- Else:\n", spaces);
-        else_body->print(indent + 1);
-    }
-}
-
 void node_literal::evaluate(compiler_context& ctx)
 {
     ctx.program.emplace_back(anzu::op_push_const{ .value=value });
-}
-
-void node_literal::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}Literal: {}\n", spaces, value.to_repr());
 }
 
 void node_variable::evaluate(compiler_context& ctx)
@@ -122,33 +83,18 @@ void node_variable::evaluate(compiler_context& ctx)
     ctx.program.emplace_back(anzu::op_push_var{ .name=name });
 }
 
-void node_variable::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}Variable: {}\n", spaces, name);
-}
 
 void node_break::evaluate(compiler_context& ctx)
 {
     ctx.program.emplace_back(anzu::op_break{});
 }
 
-void node_break::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}Break\n", spaces);
-}
 
 void node_continue::evaluate(compiler_context& ctx)
 {
     ctx.program.emplace_back(anzu::op_continue{});
 }
 
-void node_continue::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}Continue\n", spaces);
-}
 
 void node_bin_op::evaluate(compiler_context& ctx)
 {
@@ -173,38 +119,10 @@ void node_bin_op::evaluate(compiler_context& ctx)
     }
 }
 
-void node_bin_op::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}BinOp\n", spaces);
-    anzu::print("{}- Op: {}\n", spaces, op);
-    anzu::print("{}- Lhs:\n", spaces);
-    if (!lhs) {
-        anzu::print("bin op has no lhs\n");
-        std::exit(1);
-    }
-    lhs->print(indent + 1);
-    anzu::print("{}- Rhs:\n", spaces);
-    if (!rhs) {
-        anzu::print("bin op has no rhs\n");
-        std::exit(1);
-    }
-    rhs->print(indent + 1);
-}
-
 void node_assignment::evaluate(compiler_context& ctx)
 {
     expr->evaluate(ctx);
     ctx.program.emplace_back(anzu::op_store{ .name=name });
-}
-
-void node_assignment::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}AssignExpr\n", spaces);
-    anzu::print("{}- Name: {}\n", spaces, name);
-    anzu::print("{}- Value:\n", spaces);
-    expr->print(indent + 1);
 }
 
 void node_function_def::evaluate(compiler_context& ctx)
@@ -219,17 +137,6 @@ void node_function_def::evaluate(compiler_context& ctx)
     ctx.program.emplace_back(anzu::op_function_end{});
 
     ctx.program[start_pos].as<anzu::op_function>().jump = end_pos + 1;
-}
-
-void node_function_def::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}Function: {}", spaces, name);
-    for (const auto& arg : arg_names) {
-        anzu::print(" {}", arg);
-    }
-    anzu::print("\n");
-    body->print(indent + 1);
 }
 
 void node_function_call_expression::evaluate(compiler_context& ctx)
@@ -249,16 +156,6 @@ void node_function_call_expression::evaluate(compiler_context& ctx)
     });
 }
 
-void node_function_call_expression::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}FunctionCall: {}\n", spaces, function_name);
-    anzu::print("{}- Args:\n", spaces);
-    for (const auto& arg : args) {
-        arg->print(indent + 1);
-    }
-}
-
 void node_function_call_statement::evaluate(compiler_context& ctx)
 {
     // Push the args to the stack
@@ -276,16 +173,6 @@ void node_function_call_statement::evaluate(compiler_context& ctx)
     });
 }
 
-void node_function_call_statement::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}FunctionCall: {}\n", spaces, function_name);
-    anzu::print("{}- Args:\n", spaces);
-    for (const auto& arg : args) {
-        arg->print(indent + 1);
-    }
-}
-
 void node_builtin_call::evaluate(compiler_context& ctx)
 {
     // Push the args to the stack
@@ -299,17 +186,6 @@ void node_builtin_call::evaluate(compiler_context& ctx)
         .func=anzu::fetch_builtin(function_name)
     });
     ctx.program.emplace_back(anzu::op_pop{});
-}
-
-
-void node_builtin_call::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}BuiltinCall: {}\n", spaces, function_name);
-    anzu::print("{}- Args:\n", spaces);
-    for (const auto& arg : args) {
-        arg->print(indent + 1);
-    }
 }
 
 void node_builtin_call_statement::evaluate(compiler_context& ctx)
@@ -327,28 +203,10 @@ void node_builtin_call_statement::evaluate(compiler_context& ctx)
     ctx.program.emplace_back(anzu::op_pop{});
 }
 
-
-void node_builtin_call_statement::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}BuiltinCall: {}\n", spaces, function_name);
-    anzu::print("{}- Args:\n", spaces);
-    for (const auto& arg : args) {
-        arg->print(indent + 1);
-    }
-}
-
 void node_return::evaluate(compiler_context& ctx)
 {
     return_value->evaluate(ctx);
     ctx.program.emplace_back(anzu::op_return{});
-}
-
-void node_return::print(int indent)
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    anzu::print("{}Return:\n", spaces);
-    return_value->print(indent + 1);
 }
 
 auto compile(const std::unique_ptr<anzu::node>& root) -> std::vector<anzu::op>

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -2,172 +2,13 @@
 #include "op_codes.hpp"
 #include "object.hpp"
 #include "lexer.hpp"
+#include "ast.hpp"
 
 #include <memory>
 #include <vector>
+#include <string_view>
 
 namespace anzu {
-
-struct parser_context;
-struct compiler_context;
-
-constexpr auto IF          = std::string_view{"if"};
-constexpr auto ELIF        = std::string_view{"elif"};
-constexpr auto ELSE        = std::string_view{"else"};
-constexpr auto WHILE       = std::string_view{"while"};
-constexpr auto BREAK       = std::string_view{"break"};
-constexpr auto CONTINUE    = std::string_view{"continue"};
-constexpr auto DO          = std::string_view{"do"};
-constexpr auto END         = std::string_view{"end"};
-constexpr auto TRUE_LIT    = std::string_view{"true"};
-constexpr auto FALSE_LIT   = std::string_view{"false"};
-constexpr auto NULL_LIT    = std::string_view{"null"};
-
-constexpr auto ADD         = std::string_view{"+"};
-constexpr auto SUB         = std::string_view{"-"};
-constexpr auto MUL         = std::string_view{"*"};
-constexpr auto DIV         = std::string_view{"/"};
-constexpr auto MOD         = std::string_view{"%"};
-
-constexpr auto EQ          = std::string_view{"=="};
-constexpr auto NE          = std::string_view{"!="};
-constexpr auto LT          = std::string_view{"<"};
-constexpr auto LE          = std::string_view{"<="};
-constexpr auto GT          = std::string_view{">"};
-constexpr auto GE          = std::string_view{">="};
-constexpr auto OR          = std::string_view{"||"};
-constexpr auto AND         = std::string_view{"&&"};
-
-constexpr auto ASSIGN      = std::string_view{"="};
-
-
-// I normally avoid inheritance trees, however dealing with variants here was a bit
-// cumbersome and required wrapping the variant in a struct to allow recusrion (due
-// to the variant needing to be defined after the nodes that contained them). Given
-// that this will be a shall tree of types (depth of 1) I feel it's fine to use here.
-struct node
-{
-    virtual ~node() {}
-    virtual void evaluate(compiler_context& ctx) = 0;
-};
-
-struct node_sequence : public node
-{
-    std::vector<std::unique_ptr<node>> sequence;
-
-    void evaluate(compiler_context& ctx) override;
-};
-
-struct node_while_statement : public node
-{
-    std::unique_ptr<node> condition;
-    std::unique_ptr<node> body;
-
-    void evaluate(compiler_context& ctx) override;
-};
-
-struct node_if_statement : public node
-{
-    std::unique_ptr<node> condition;
-    std::unique_ptr<node> body;
-    std::unique_ptr<node> else_body;
-
-    void evaluate(compiler_context& ctx) override;
-};
-
-struct node_break : public node
-{
-    void evaluate(compiler_context& ctx) override;
-};
-
-struct node_continue : public node
-{
-    void evaluate(compiler_context& ctx) override;
-};
-
-struct node_literal : public node
-{
-    anzu::object value;
-
-    node_literal(const anzu::object& v) : value(v) {}
-    void evaluate(compiler_context& ctx) override;
-};
-
-struct node_variable : public node
-{
-    std::string name;
-
-    node_variable(const std::string& n) : name(n) {}
-    void evaluate(compiler_context& ctx) override;
-};
-
-struct node_bin_op : public node
-{
-    std::string op; // TODO: make into enum
-    std::unique_ptr<node> lhs;
-    std::unique_ptr<node> rhs;
-
-    void evaluate(compiler_context& ctx) override;
-};
-
-// Evaluates the child node and assigns the result to the given name.
-// Currently assuming that the child node results in a value being pushed
-// to the stack, will enforce this in the code later on.
-struct node_assignment : public node
-{
-    std::string name;
-    std::unique_ptr<node> expr;
-
-    void evaluate(compiler_context& ctx) override;
-};
-
-struct node_function_def : public node
-{
-    std::string              name;
-    std::vector<std::string> arg_names;
-    std::unique_ptr<node>    body;
-
-    void evaluate(compiler_context& ctx) override;
-};
-
-struct node_function_call_expression : public node
-{
-    std::string                        function_name;
-    std::vector<std::unique_ptr<node>> args;
-
-    void evaluate(compiler_context& ctx) override;
-};
-
-struct node_function_call_statement : public node
-{
-    std::string                        function_name;
-    std::vector<std::unique_ptr<node>> args;
-
-    void evaluate(compiler_context& ctx) override;
-};
-
-struct node_builtin_call : public node
-{
-    std::string                        function_name;
-    std::vector<std::unique_ptr<node>> args;
-
-    void evaluate(compiler_context& ctx) override;
-};
-
-struct node_builtin_call_statement : public node
-{
-    std::string                        function_name;
-    std::vector<std::unique_ptr<node>> args;
-
-    void evaluate(compiler_context& ctx) override;
-};
-
-struct node_return : public node
-{
-    std::unique_ptr<node> return_value; // Should leave a value on the stack
-
-    void evaluate(compiler_context& ctx) override;
-};
 
 // Struct used to store information while compiling an AST. Contains the output program
 // as well as information such as function definitions.
@@ -183,6 +24,6 @@ struct compiler_context
     std::unordered_map<std::string, function_def> functions;
 };
 
-auto compile(const std::unique_ptr<anzu::node>& root) -> std::vector<anzu::op>;
+auto compile(const std::unique_ptr<node_stmt>& root) -> std::vector<anzu::op>;
 
 }

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -49,7 +49,6 @@ struct node
 {
     virtual ~node() {}
     virtual void evaluate(compiler_context& ctx) = 0;
-    virtual void print(int indent = 0) = 0;
 };
 
 struct node_sequence : public node
@@ -57,7 +56,6 @@ struct node_sequence : public node
     std::vector<std::unique_ptr<node>> sequence;
 
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 struct node_while_statement : public node
@@ -66,7 +64,6 @@ struct node_while_statement : public node
     std::unique_ptr<node> body;
 
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 struct node_if_statement : public node
@@ -76,19 +73,16 @@ struct node_if_statement : public node
     std::unique_ptr<node> else_body;
 
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 struct node_break : public node
 {
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 struct node_continue : public node
 {
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 struct node_literal : public node
@@ -97,7 +91,6 @@ struct node_literal : public node
 
     node_literal(const anzu::object& v) : value(v) {}
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 struct node_variable : public node
@@ -106,7 +99,6 @@ struct node_variable : public node
 
     node_variable(const std::string& n) : name(n) {}
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 struct node_bin_op : public node
@@ -116,7 +108,6 @@ struct node_bin_op : public node
     std::unique_ptr<node> rhs;
 
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 // Evaluates the child node and assigns the result to the given name.
@@ -128,7 +119,6 @@ struct node_assignment : public node
     std::unique_ptr<node> expr;
 
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 struct node_function_def : public node
@@ -138,7 +128,6 @@ struct node_function_def : public node
     std::unique_ptr<node>    body;
 
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 struct node_function_call_expression : public node
@@ -147,7 +136,6 @@ struct node_function_call_expression : public node
     std::vector<std::unique_ptr<node>> args;
 
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 struct node_function_call_statement : public node
@@ -156,7 +144,6 @@ struct node_function_call_statement : public node
     std::vector<std::unique_ptr<node>> args;
 
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 struct node_builtin_call : public node
@@ -165,7 +152,6 @@ struct node_builtin_call : public node
     std::vector<std::unique_ptr<node>> args;
 
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 struct node_builtin_call_statement : public node
@@ -174,7 +160,6 @@ struct node_builtin_call_statement : public node
     std::vector<std::unique_ptr<node>> args;
 
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 struct node_return : public node
@@ -182,7 +167,6 @@ struct node_return : public node
     std::unique_ptr<node> return_value; // Should leave a value on the stack
 
     void evaluate(compiler_context& ctx) override;
-    void print(int indent = 0) override;
 };
 
 // Struct used to store information while compiling an AST. Contains the output program

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -399,7 +399,7 @@ auto parse_function_call_stmt(parser_context& ctx) -> node_ptr
     return node;
 }
 
-auto parse_statement(parser_context& ctx) -> node_ptr
+auto parse_statement(parser_context& ctx) -> node_stmt_ptr
 {
     if (consume_maybe(ctx.curr, "function")) {
         return parse_function(ctx);
@@ -414,12 +414,15 @@ auto parse_statement(parser_context& ctx) -> node_ptr
         return parse_if_body(ctx);
     }
     else if (consume_maybe(ctx.curr, "break")) {
-        return std::make_unique<anzu::node_break>(); 
+        auto node = std::make_unique<anzu::node_stmt>();
+        node->emplace<anzu::node_break_stmt>();
+        return node;
     }
     else if (consume_maybe(ctx.curr, "continue")) {
-        return std::make_unique<anzu::node_continue>(); 
+        auto node = std::make_unique<anzu::node_stmt>();
+        node->emplace<anzu::node_continue_stmt>();
+        return node;
     }
-
     else if (auto next = std::next(ctx.curr); next != ctx.end && next->text == "=") {
         return parse_assign_expression(ctx);
     }
@@ -439,15 +442,16 @@ auto parse_statement(parser_context& ctx) -> node_ptr
 
 }
 
-auto parse(const std::vector<anzu::token>& tokens) -> node_ptr
+auto parse(const std::vector<anzu::token>& tokens) -> node_stmt_ptr
 {
     auto ctx = anzu::parser_context{
         .curr = tokens.begin(), .end = tokens.end()
     };
 
-    auto root = std::make_unique<anzu::node_sequence>();
+    auto root = std::make_unique<anzu::node_stmt>();
+    auto& seq = root->emplace<anzu::node_sequence_stmt>();
     while (ctx.curr != ctx.end) {
-        root->sequence.push_back(parse_statement(ctx));
+        seq.sequence.push_back(parse_statement(ctx));
     }
     return root;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -6,6 +6,8 @@ namespace anzu {
 
 namespace {
 
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+
 auto consume_maybe(token_iterator& it, std::string_view tok) -> bool
 {
     if (it->text == tok) {
@@ -472,6 +474,121 @@ auto parse(const std::vector<anzu::token>& tokens) -> node_stmt_ptr
         seq.sequence.push_back(parse_statement(ctx));
     }
     return root;
+}
+
+auto print_node(const anzu::node_expr& root, int indent) -> void
+{
+    const auto spaces = std::string(4 * indent, ' ');
+    std::visit(overloaded {
+        [=, &spaces](const node_literal_expr& node) {
+            anzu::print("{}Literal: {}\n", spaces, node.value.to_repr());
+        },
+        [=, &spaces](const node_variable_expr& node) {
+            anzu::print("{}Variable: {}\n", spaces, node.name);
+        },
+        [=, &spaces](const node_bin_op_expr& node) {
+            anzu::print("{}BinOp\n", spaces);
+            anzu::print("{}- Op: {}\n", spaces, node.op);
+            anzu::print("{}- Lhs:\n", spaces);
+            if (!node.lhs) {
+                anzu::print("bin op has no lhs\n");
+                std::exit(1);
+            }
+            print_node(*node.lhs, indent + 1);
+            anzu::print("{}- Rhs:\n", spaces);
+            if (!node.rhs) {
+                anzu::print("bin op has no rhs\n");
+                std::exit(1);
+            }
+            print_node(*node.rhs, indent + 1);
+        },
+        [=, &spaces](const node_function_call_expr& node) {
+            anzu::print("{}FunctionCall (Expr): {}\n", spaces, node.function_name);
+            anzu::print("{}- Args:\n", spaces);
+            for (const auto& arg : node.args) {
+                print_node(*arg, indent + 1);
+            }
+        },
+        [=, &spaces](const node_builtin_call_expr& node) {
+            anzu::print("{}BuiltinCall (Expr): {}\n", spaces, node.function_name);
+            anzu::print("{}- Args:\n", spaces);
+            for (const auto& arg : node.args) {
+                print_node(*arg, indent + 1);
+            }
+        }
+    }, root);
+}
+
+auto print_node(const anzu::node_stmt& root, int indent) -> void
+{
+    const auto spaces = std::string(4 * indent, ' ');
+    std::visit(overloaded {
+        [=, &spaces](const node_sequence_stmt& node) {
+            anzu::print("{}Sequence:\n", spaces);
+            for (const auto& seq_node : node.sequence) {
+                print_node(*seq_node, indent + 1);
+            }
+        },
+        [=, &spaces](const node_while_stmt& node) {
+            anzu::print("{}While:\n", spaces);
+            anzu::print("{}- Condition:\n", spaces);
+            print_node(*node.condition, indent + 1);
+            anzu::print("{}- Body:\n", spaces);
+            print_node(*node.body, indent + 1);
+        },
+        [=, &spaces](const node_if_stmt& node) {
+            anzu::print("{}If:\n", spaces);
+            anzu::print("{}- Condition:\n", spaces);
+            print_node(*node.condition, indent + 1);
+            anzu::print("{}- Body:\n", spaces);
+            print_node(*node.body, indent + 1);
+            if (node.else_body) {
+                anzu::print("{}- Else:\n", spaces);
+                print_node(*node.else_body, indent + 1);
+            }
+        },
+        [=, &spaces](const node_break_stmt& node) {
+            anzu::print("{}Break\n", spaces);
+        },
+        [=, &spaces](const node_continue_stmt& node) {
+            anzu::print("{}Continue\n", spaces);
+        },
+        [=, &spaces](const node_assignment_stmt& node) {
+            anzu::print("{}AssignExpr\n", spaces);
+            anzu::print("{}- Name: {}\n", spaces, node.name);
+            anzu::print("{}- Value:\n", spaces);
+            print_node(*node.expr, indent + 1);
+        },
+        [=, &spaces](const node_function_def_stmt& node) {
+            anzu::print("{}Function: {}", spaces, node.name);
+            for (const auto& arg : node.arg_names) {
+                anzu::print(" {}", arg);
+            }
+            anzu::print("\n");
+            print_node(*node.body, indent + 1);
+        },
+        [=, &spaces](const node_function_call_stmt& node) {
+            anzu::print("{}FunctionCall (Stmt): {}\n", spaces, node.function_name);
+            anzu::print("{}- Args:\n", spaces);
+            for (const auto& arg : node.args) {
+                print_node(*arg, indent + 1);
+            }
+        },
+        [=, &spaces](const node_builtin_call_stmt& node) {
+            anzu::print("{}BuiltinCall (Stmt): {}\n", spaces, node.function_name);
+            anzu::print("{}- Args:\n", spaces);
+            for (const auto& arg : node.args) {
+                print_node(*arg, indent + 1);
+            }
+        },
+        [=, &spaces](const node_return_stmt& node) {
+            anzu::print("{}Return:\n", spaces);
+            print_node(*node.return_value, indent + 1);
+        },
+        [=, &spaces](const node_expr& node) {
+            print_node(node, indent + 1);
+        }
+    }, root);
 }
 
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,12 +1,11 @@
 #include "parser.hpp"
+#include "functions.hpp"
 
 #include <optional>
 
 namespace anzu {
 
 namespace {
-
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 
 auto consume_maybe(token_iterator& it, std::string_view tok) -> bool
 {
@@ -186,6 +185,11 @@ auto parse_statement_list(parser_context& ctx) -> node_stmt_ptr
     auto& stmt = node->emplace<anzu::node_sequence_stmt>();
     while (ctx.curr != ctx.end && !sentinel.contains(ctx.curr->text)) {
         stmt.sequence.push_back(parse_statement(ctx));
+    }
+
+    // If there is only one element in the sequence, return that directly
+    if (stmt.sequence.size() == 1) {
+        node = std::move(stmt.sequence.back());
     }
     return node;
 }
@@ -454,7 +458,7 @@ auto parse_statement(parser_context& ctx) -> node_stmt_ptr
     else {
         auto expression = parse_expression(ctx);
         anzu::print("error: unused statement\n");
-        //expression->print();
+        print_node(*expression);
         std::exit(1);
     }
 }
@@ -473,121 +477,6 @@ auto parse(const std::vector<anzu::token>& tokens) -> node_stmt_ptr
         seq.sequence.push_back(parse_statement(ctx));
     }
     return root;
-}
-
-auto print_node(const anzu::node_expr& root, int indent) -> void
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    std::visit(overloaded {
-        [=](const node_literal_expr& node) {
-            anzu::print("{}Literal: {}\n", spaces, node.value.to_repr());
-        },
-        [=](const node_variable_expr& node) {
-            anzu::print("{}Variable: {}\n", spaces, node.name);
-        },
-        [=](const node_bin_op_expr& node) {
-            anzu::print("{}BinOp\n", spaces);
-            anzu::print("{}- Op: {}\n", spaces, node.op);
-            anzu::print("{}- Lhs:\n", spaces);
-            if (!node.lhs) {
-                anzu::print("bin op has no lhs\n");
-                std::exit(1);
-            }
-            print_node(*node.lhs, indent + 1);
-            anzu::print("{}- Rhs:\n", spaces);
-            if (!node.rhs) {
-                anzu::print("bin op has no rhs\n");
-                std::exit(1);
-            }
-            print_node(*node.rhs, indent + 1);
-        },
-        [=](const node_function_call_expr& node) {
-            anzu::print("{}FunctionCall (Expr): {}\n", spaces, node.function_name);
-            anzu::print("{}- Args:\n", spaces);
-            for (const auto& arg : node.args) {
-                print_node(*arg, indent + 1);
-            }
-        },
-        [=](const node_builtin_call_expr& node) {
-            anzu::print("{}BuiltinCall (Expr): {}\n", spaces, node.function_name);
-            anzu::print("{}- Args:\n", spaces);
-            for (const auto& arg : node.args) {
-                print_node(*arg, indent + 1);
-            }
-        }
-    }, root);
-}
-
-auto print_node(const anzu::node_stmt& root, int indent) -> void
-{
-    const auto spaces = std::string(4 * indent, ' ');
-    std::visit(overloaded {
-        [=](const node_sequence_stmt& node) {
-            anzu::print("{}Sequence:\n", spaces);
-            for (const auto& seq_node : node.sequence) {
-                print_node(*seq_node, indent + 1);
-            }
-        },
-        [=](const node_while_stmt& node) {
-            anzu::print("{}While:\n", spaces);
-            anzu::print("{}- Condition:\n", spaces);
-            print_node(*node.condition, indent + 1);
-            anzu::print("{}- Body:\n", spaces);
-            print_node(*node.body, indent + 1);
-        },
-        [=](const node_if_stmt& node) {
-            anzu::print("{}If:\n", spaces);
-            anzu::print("{}- Condition:\n", spaces);
-            print_node(*node.condition, indent + 1);
-            anzu::print("{}- Body:\n", spaces);
-            print_node(*node.body, indent + 1);
-            if (node.else_body) {
-                anzu::print("{}- Else:\n", spaces);
-                print_node(*node.else_body, indent + 1);
-            }
-        },
-        [=](const node_break_stmt& node) {
-            anzu::print("{}Break\n", spaces);
-        },
-        [=](const node_continue_stmt& node) {
-            anzu::print("{}Continue\n", spaces);
-        },
-        [=](const node_assignment_stmt& node) {
-            anzu::print("{}AssignExpr\n", spaces);
-            anzu::print("{}- Name: {}\n", spaces, node.name);
-            anzu::print("{}- Value:\n", spaces);
-            print_node(*node.expr, indent + 1);
-        },
-        [=](const node_function_def_stmt& node) {
-            anzu::print("{}Function: {}", spaces, node.name);
-            for (const auto& arg : node.arg_names) {
-                anzu::print(" {}", arg);
-            }
-            anzu::print("\n");
-            print_node(*node.body, indent + 1);
-        },
-        [=](const node_function_call_stmt& node) {
-            anzu::print("{}FunctionCall (Stmt): {}\n", spaces, node.function_name);
-            anzu::print("{}- Args:\n", spaces);
-            for (const auto& arg : node.args) {
-                print_node(*arg, indent + 1);
-            }
-        },
-        [=](const node_builtin_call_stmt& node) {
-            anzu::print("{}BuiltinCall (Stmt): {}\n", spaces, node.function_name);
-            anzu::print("{}- Args:\n", spaces);
-            for (const auto& arg : node.args) {
-                print_node(*arg, indent + 1);
-            }
-        },
-        [=](const node_return_stmt& node) {
-            anzu::print("{}Return:\n", spaces);
-            print_node(*node.return_value, indent + 1);
-        },
-        [=](const node_expr& node) {
-            print_node(node, indent + 1);
-        }
-    }, root);
 }
 
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -95,11 +95,11 @@ auto precedence_table()
 }
 static const auto bin_ops_table = precedence_table();
 
-auto parse_expression(parser_context& ctx) -> node_ptr;
-auto parse_function_call(parser_context& ctx) -> node_ptr;
-auto parse_builtin_call(parser_context& ctx) -> node_ptr;
+auto parse_expression(parser_context& ctx) -> node_expr_ptr;
+auto parse_function_call_expr(parser_context& ctx) -> node_expr_ptr;
+auto parse_builtin_call_expr(parser_context& ctx) -> node_expr_ptr;
 
-auto parse_single_factor(parser_context& ctx) -> node_ptr
+auto parse_single_factor(parser_context& ctx) -> node_expr_ptr
 {
     if (consume_maybe(ctx.curr, "(")) {
         auto expr = parse_expression(ctx);
@@ -107,25 +107,30 @@ auto parse_single_factor(parser_context& ctx) -> node_ptr
         return expr;
     }  
     else if (auto factor = anzu::try_parse_literal(ctx); factor.has_value()) {
-        return std::make_unique<anzu::node_literal>(*factor);
+        auto node = std::make_unique<anzu::node_expr>();
+        auto& expr = node->emplace<anzu::node_literal_expr>();
+        expr.value = *factor;
     }
     else if (ctx.functions.contains(ctx.curr->text)) {
-        return parse_function_call(ctx);
+        return parse_function_call_expr(ctx);
     }
     else if (anzu::is_builtin(ctx.curr->text)) {
-        return parse_builtin_call(ctx);
+        return parse_builtin_call_expr(ctx);
     }
     else if (ctx.curr->type != token_type::name) {
         anzu::print("syntax error: '{}' is not a name, cannot be a factor\n", ctx.curr->text);
         std::exit(1);
     }
     else {
-        return std::make_unique<anzu::node_variable>((ctx.curr++)->text);
+        auto node = std::make_unique<anzu::node_expr>();
+        auto& expr = node->emplace<anzu::node_variable_expr>();
+        expr.name = (ctx.curr++)->text;
+        return node;
     }
 }
 
 // Level is the precendence level, the lower the number, the tighter the factors bind.
-auto parse_compound_factor(parser_context& ctx, std::int64_t level) -> node_ptr
+auto parse_compound_factor(parser_context& ctx, std::int64_t level) -> node_expr_ptr
 {
     if (level == 0) {
         return parse_single_factor(ctx);
@@ -135,22 +140,23 @@ auto parse_compound_factor(parser_context& ctx, std::int64_t level) -> node_ptr
     while (ctx.curr != ctx.end && bin_ops_table[level].contains(ctx.curr->text)) {
         auto op = (ctx.curr++)->text;
 
-        auto new_left = std::make_unique<anzu::node_bin_op>();
-        new_left->lhs = std::move(left);
-        new_left->op = op;
-        new_left->rhs = parse_compound_factor(ctx, level - 1);
+        auto node = std::make_unique<anzu::node_expr>();
+        auto& expr = node->emplace<anzu::node_bin_op_expr>();
+        expr.lhs = std::move(left);
+        expr.op = op;
+        expr.rhs = parse_compound_factor(ctx, level - 1);
 
-        left = std::move(new_left);
+        left = std::move(node);
     }
     return left;
 }
 
-auto parse_expression(parser_context& ctx) -> node_ptr
+auto parse_expression(parser_context& ctx) -> node_expr_ptr
 {
     return parse_compound_factor(ctx, std::ssize(bin_ops_table) - 1i64);
 }
 
-auto parse_assign_expression(parser_context& ctx) -> node_ptr
+auto parse_assign_expression(parser_context& ctx) -> node_stmt_ptr
 {
     if (ctx.curr->type != token_type::name) {
         anzu::print("syntax error: cannot assign to '{}'\n", ctx.curr->text);
@@ -159,67 +165,72 @@ auto parse_assign_expression(parser_context& ctx) -> node_ptr
     auto name = (ctx.curr++)->text;
     consume_only(ctx.curr, "=");
 
-    auto assign = std::make_unique<anzu::node_assignment>();
-    assign->name = name;
-    assign->expr = parse_expression(ctx);
-    return assign;
+    auto node = std::make_unique<anzu::node_stmt>();
+    auto& stmt = node->emplace<anzu::node_assignment_stmt>();
+    stmt.name = name;
+    stmt.expr = parse_expression(ctx);
+    return node;
 }
 
-auto parse_statement(parser_context& ctx) -> node_ptr;
+auto parse_statement(parser_context& ctx) -> node_stmt_ptr;
 
 // statement_list:
 //     | statement
 //     | statement statement_list
-auto parse_statement_list(parser_context& ctx) -> node_ptr
+auto parse_statement_list(parser_context& ctx) -> node_stmt_ptr
 {
     static const auto sentinel = std::unordered_set<std::string_view>{"end", "elif", "do", "else"};
 
-    auto stmt = std::make_unique<node_sequence>();
+    auto node = std::make_unique<anzu::node_stmt>();
+    auto& stmt = node->emplace<anzu::node_sequence_stmt>();
     while (ctx.curr != ctx.end && !sentinel.contains(ctx.curr->text)) {
-        stmt->sequence.push_back(parse_statement(ctx));
+        stmt.sequence.push_back(parse_statement(ctx));
     }
-    return stmt;
+    return node;
 }
 
-auto parse_while_body(parser_context& ctx) -> node_ptr
+auto parse_while_body(parser_context& ctx) -> node_stmt_ptr
 {
-    auto stmt = std::make_unique<anzu::node_while_statement>();
-    stmt->condition = parse_expression(ctx);
+    auto node = std::make_unique<anzu::node_stmt>();
+    auto& stmt = node->emplace<anzu::node_while_stmt>();
+    stmt.condition = parse_expression(ctx);
     consume_only(ctx.curr, "do");
-    stmt->body = parse_statement_list(ctx);
+    stmt.body = parse_statement_list(ctx);
     consume_only(ctx.curr, "end");
-    return stmt;
+    return node;
 }
 
-auto parse_if_body(parser_context& ctx) -> node_ptr
+auto parse_if_body(parser_context& ctx) -> node_stmt_ptr
 {
-    auto stmt = std::make_unique<node_if_statement>();
-    stmt->condition = parse_expression(ctx);
+    auto node = std::make_unique<anzu::node_stmt>();
+    auto& stmt = node->emplace<anzu::node_if_stmt>();
+    stmt.condition = parse_expression(ctx);
     consume_only(ctx.curr, "do");
-    stmt->body = parse_statement_list(ctx);
+    stmt.body = parse_statement_list(ctx);
 
     if (consume_maybe(ctx.curr, "elif")) {
-        stmt->else_body = parse_if_body(ctx);
+        stmt.else_body = parse_if_body(ctx);
     }
     else if (consume_maybe(ctx.curr, "else")) {
-        stmt->else_body = parse_statement_list(ctx);
+        stmt.else_body = parse_statement_list(ctx);
         consume_only(ctx.curr, "end");
     }
     else {
         consume_only(ctx.curr, "end");
     }
     
-    return stmt;
+    return node;
 }
 
-auto parse_function(parser_context& ctx) -> node_ptr
+auto parse_function_def(parser_context& ctx) -> node_stmt_ptr
 {
-    auto ret = std::make_unique<node_function_def>();
+    auto node = std::make_unique<anzu::node_stmt>();
+    auto& stmt = node->emplace<anzu::node_function_def_stmt>();
     if (ctx.curr->type != token_type::name) {
         anzu::print("syntax error: expected function name\n");
         std::exit(1);
     }
-    ret->name = (ctx.curr++)->text;
+    stmt.name = (ctx.curr++)->text;
     consume_only(ctx.curr, "(");
     bool expect_comma = false;
     while (ctx.curr != ctx.end && ctx.curr->text != ")") {
@@ -232,7 +243,7 @@ auto parse_function(parser_context& ctx) -> node_ptr
         }
         else {
             if (ctx.curr->type == token_type::name) {
-                ret->arg_names.push_back(ctx.curr->text);
+                stmt.arg_names.push_back(ctx.curr->text);
                 ++ctx.curr;          
             }
             else {
@@ -242,31 +253,35 @@ auto parse_function(parser_context& ctx) -> node_ptr
         }
         expect_comma = !expect_comma;
     }
-    ctx.functions[ret->name] = { .argc=std::ssize(ret->arg_names) };
+    ctx.functions[stmt.name] = { .argc=std::ssize(stmt.arg_names) };
     consume_only(ctx.curr, ")");
     consume_only(ctx.curr, "do");
-    ret->body = parse_statement_list(ctx);
+    stmt.body = parse_statement_list(ctx);
     consume_only(ctx.curr, "end");
-    return ret;
+    return node;
 }
 
-auto parse_return(parser_context& ctx) -> node_ptr
+auto parse_return(parser_context& ctx) -> node_stmt_ptr
 {
     static const auto sentinel = std::unordered_set<std::string_view>{"end", "elif", "do", "else"};
 
-    auto ret_node = std::make_unique<anzu::node_return>();
+    auto node = std::make_unique<anzu::node_stmt>();
+    auto& stmt = node->emplace<anzu::node_return_stmt>();
+    
     if (!sentinel.contains(ctx.curr->text)) {
-        ret_node->return_value = parse_expression(ctx);
+        stmt.return_value = parse_expression(ctx);
     } else {
-        ret_node->return_value = std::make_unique<anzu::node_literal>(anzu::null_object());
+        stmt.return_value = std::make_unique<anzu::node_expr>();
+        stmt.return_value->emplace<anzu::node_literal_expr>().value = anzu::null_object();
     }
-    return ret_node;
+    return node;
 }
 
-auto parse_builtin_call(parser_context& ctx) -> node_ptr
+auto parse_builtin_call_expr(parser_context& ctx) -> node_expr_ptr
 {
-    auto node = std::make_unique<anzu::node_builtin_call>();
-    node->function_name = (ctx.curr++)->text;
+    auto node = std::make_unique<anzu::node_expr>();
+    auto& expr = node->emplace<anzu::node_builtin_call_expr>();
+    expr.function_name = (ctx.curr++)->text;
 
     consume_only(ctx.curr, "(");
     bool expect_comma = false;
@@ -279,17 +294,17 @@ auto parse_builtin_call(parser_context& ctx) -> node_ptr
             ++ctx.curr;
         }
         else {
-            node->args.push_back(parse_expression(ctx));
+            expr.args.push_back(parse_expression(ctx));
         }
         expect_comma = !expect_comma;
     }
     consume_only(ctx.curr, ")");
 
-    const auto argc = anzu::fetch_builtin_argc(node->function_name);
-    if (argc != std::ssize(node->args)) {
+    const auto argc = anzu::fetch_builtin_argc(expr.function_name);
+    if (argc != std::ssize(expr.args)) {
         anzu::print(
             "error: function '{}' expected {} args, got {}\n",
-            node->function_name, argc, std::ssize(node->args)
+            expr.function_name, argc, std::ssize(expr.args)
         );
         std::exit(1);
     }
@@ -297,10 +312,11 @@ auto parse_builtin_call(parser_context& ctx) -> node_ptr
     return node;
 }
 
-auto parse_builtin_call_stmt(parser_context& ctx) -> node_ptr
+auto parse_builtin_call_stmt(parser_context& ctx) -> node_stmt_ptr
 {
-    auto node = std::make_unique<anzu::node_builtin_call_statement>();
-    node->function_name = (ctx.curr++)->text;
+    auto node = std::make_unique<anzu::node_stmt>();
+    auto& stmt = node->emplace<anzu::node_builtin_call_stmt>();
+    stmt.function_name = (ctx.curr++)->text;
 
     consume_only(ctx.curr, "(");
     bool expect_comma = false;
@@ -313,17 +329,17 @@ auto parse_builtin_call_stmt(parser_context& ctx) -> node_ptr
             ++ctx.curr;
         }
         else {
-            node->args.push_back(parse_expression(ctx));
+            stmt.args.push_back(parse_expression(ctx));
         }
         expect_comma = !expect_comma;
     }
     consume_only(ctx.curr, ")");
 
-    const auto argc = anzu::fetch_builtin_argc(node->function_name);
-    if (argc != std::ssize(node->args)) {
+    const auto argc = anzu::fetch_builtin_argc(stmt.function_name);
+    if (argc != std::ssize(stmt.args)) {
         anzu::print(
             "error: function '{}' expected {} args, got {}\n",
-            node->function_name, argc, std::ssize(node->args)
+            stmt.function_name, argc, std::ssize(stmt.args)
         );
         std::exit(1);
     }
@@ -331,10 +347,11 @@ auto parse_builtin_call_stmt(parser_context& ctx) -> node_ptr
     return node;
 }
 
-auto parse_function_call(parser_context& ctx) -> node_ptr
+auto parse_function_call_expr(parser_context& ctx) -> node_expr_ptr
 {
-    auto node = std::make_unique<anzu::node_function_call_expression>();
-    node->function_name = (ctx.curr++)->text;
+    auto node = std::make_unique<anzu::node_expr>();
+    auto& expr = node->emplace<anzu::node_function_call_expr>();
+    expr.function_name = (ctx.curr++)->text;
 
     consume_only(ctx.curr, "(");
     bool expect_comma = false;
@@ -347,17 +364,17 @@ auto parse_function_call(parser_context& ctx) -> node_ptr
             ++ctx.curr;
         }
         else {
-            node->args.push_back(parse_expression(ctx));
+            expr.args.push_back(parse_expression(ctx));
         }
         expect_comma = !expect_comma;
     }
     consume_only(ctx.curr, ")");
 
-    const auto argc = ctx.functions.at(node->function_name).argc;
-    if (argc != std::ssize(node->args)) {
+    const auto argc = ctx.functions.at(expr.function_name).argc;
+    if (argc != std::ssize(expr.args)) {
         anzu::print(
             "error: function '{}' expected {} args, got {}\n",
-            node->function_name, argc, std::ssize(node->args)
+            expr.function_name, argc, std::ssize(expr.args)
         );
         std::exit(1);
     }
@@ -365,10 +382,11 @@ auto parse_function_call(parser_context& ctx) -> node_ptr
     return node;
 }
 
-auto parse_function_call_stmt(parser_context& ctx) -> node_ptr
+auto parse_function_call_stmt(parser_context& ctx) -> node_stmt_ptr
 {
-    auto node = std::make_unique<anzu::node_function_call_statement>();
-    node->function_name = (ctx.curr++)->text;
+    auto node = std::make_unique<anzu::node_stmt>();
+    auto& stmt = node->emplace<anzu::node_function_call_stmt>();
+    stmt.function_name = (ctx.curr++)->text;
 
     consume_only(ctx.curr, "(");
     bool expect_comma = false;
@@ -381,17 +399,17 @@ auto parse_function_call_stmt(parser_context& ctx) -> node_ptr
             ++ctx.curr;
         }
         else {
-            node->args.push_back(parse_expression(ctx));
+            stmt.args.push_back(parse_expression(ctx));
         }
         expect_comma = !expect_comma;
     }
     consume_only(ctx.curr, ")");
 
-    const auto argc = ctx.functions.at(node->function_name).argc;
-    if (argc != std::ssize(node->args)) {
+    const auto argc = ctx.functions.at(stmt.function_name).argc;
+    if (argc != std::ssize(stmt.args)) {
         anzu::print(
             "error: function '{}' expected {} args, got {}\n",
-            node->function_name, argc, std::ssize(node->args)
+            stmt.function_name, argc, std::ssize(stmt.args)
         );
         std::exit(1);
     }
@@ -402,7 +420,7 @@ auto parse_function_call_stmt(parser_context& ctx) -> node_ptr
 auto parse_statement(parser_context& ctx) -> node_stmt_ptr
 {
     if (consume_maybe(ctx.curr, "function")) {
-        return parse_function(ctx);
+        return parse_function_def(ctx);
     }
     else if (consume_maybe(ctx.curr, "return")) {
         return parse_return(ctx);
@@ -435,7 +453,7 @@ auto parse_statement(parser_context& ctx) -> node_stmt_ptr
     else {
         auto expression = parse_expression(ctx);
         anzu::print("error: unused statement\n");
-        expression->print();
+        //expression->print();
         std::exit(1);
     }
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -30,4 +30,7 @@ struct parser_context
 
 auto parse(const std::vector<anzu::token>& tokens) -> node_stmt_ptr;
 
+auto print_node(const anzu::node_expr& node, int indent = 0) -> void;
+auto print_node(const anzu::node_stmt& node, int indent = 0) -> void;
+
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include "lexer.hpp"
 #include "ast.hpp"
-#include "compiler.hpp"
 
 #include <vector>
 #include <memory>
@@ -10,8 +9,36 @@
 
 namespace anzu {
 
+constexpr auto IF          = std::string_view{"if"};
+constexpr auto ELIF        = std::string_view{"elif"};
+constexpr auto ELSE        = std::string_view{"else"};
+constexpr auto WHILE       = std::string_view{"while"};
+constexpr auto BREAK       = std::string_view{"break"};
+constexpr auto CONTINUE    = std::string_view{"continue"};
+constexpr auto DO          = std::string_view{"do"};
+constexpr auto END         = std::string_view{"end"};
+constexpr auto TRUE_LIT    = std::string_view{"true"};
+constexpr auto FALSE_LIT   = std::string_view{"false"};
+constexpr auto NULL_LIT    = std::string_view{"null"};
+
+constexpr auto ADD         = std::string_view{"+"};
+constexpr auto SUB         = std::string_view{"-"};
+constexpr auto MUL         = std::string_view{"*"};
+constexpr auto DIV         = std::string_view{"/"};
+constexpr auto MOD         = std::string_view{"%"};
+
+constexpr auto EQ          = std::string_view{"=="};
+constexpr auto NE          = std::string_view{"!="};
+constexpr auto LT          = std::string_view{"<"};
+constexpr auto LE          = std::string_view{"<="};
+constexpr auto GT          = std::string_view{">"};
+constexpr auto GE          = std::string_view{">="};
+constexpr auto OR          = std::string_view{"||"};
+constexpr auto AND         = std::string_view{"&&"};
+
+constexpr auto ASSIGN      = std::string_view{"="};
+
 using token_iterator = std::vector<anzu::token>::const_iterator;
-using node_ptr       = std::unique_ptr<anzu::node>;
 
 // Context used while constructing an AST. Has non-owning pointers into the
 // tokens as well as keeping track of function names.
@@ -29,8 +56,5 @@ struct parser_context
 };
 
 auto parse(const std::vector<anzu::token>& tokens) -> node_stmt_ptr;
-
-auto print_node(const anzu::node_expr& node, int indent = 0) -> void;
-auto print_node(const anzu::node_stmt& node, int indent = 0) -> void;
 
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "lexer.hpp"
+#include "ast.hpp"
 #include "compiler.hpp"
 
 #include <vector>
@@ -26,6 +27,7 @@ struct parser_context
 
     std::unordered_map<std::string, function_info> functions;
 };
-auto parse(const std::vector<anzu::token>& tokens) -> std::unique_ptr<anzu::node>;
+
+auto parse(const std::vector<anzu::token>& tokens) -> node_stmt_ptr;
 
 }


### PR DESCRIPTION
* Switched to a variant-based AST rather than an inheritance based one. This will allow us to implement more algorithms that operate on the tree, such as optimisations where the visitor needs to know the type of each node.
* This also allows us to implement "expression" nodes and "statement" nodes in the code. Now, `if` statements, `while` statements, `function/builtin` calls, assignments and `return` statements take expressions as arguments rather than statements, meaning it is not possible to create an AST where a `while` loop is passed as function argument (for example).
* Cleaned up the grammar file but it still needs work.
* All nodes are stored in `ast.hpp`, which also holds the print function. Now the `parser` module only contains the parsing code to create an AST and the `compiler` now only contains the evaluation logic the create a program. Much better separation.
* When creating the AST in the parser, if a `node_sequence_stmt` only has a single statement, the single statement is returned instead. This doesn't optimise the output program, but does simplify the AST.