### PR TITLE
For Loop

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/feature_test.az", "parse"],
+            "args": ["${workspaceFolder}/examples/test.az", "com"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -70,3 +70,23 @@ end
 x = null
 y = println(x)
 println(y)
+
+# For loops
+println("list test, 3 elements with a break after the second, should only see two")
+println("additionally, there is a while loop with its own break statement which should be fine")
+for x in [1, 2, 3] do
+    println(x)
+    if x == 2 do
+        while true do
+            break # To make sure that this break is not affected by the for
+        end 
+        break
+    end
+end
+
+new_list = [[1, 2, 3, 4]]
+for list in new_list do
+    list_push(list, 5)
+end
+println("new_list should have 5 elements:")
+println(new_list)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,13 @@
 
 
-for x in [1, 2, 3] do
-    println(x)
-    if x == 2 do
-        while true do
-            break # To make sure that this break is not affected by the for
-        end 
-        break
-    end
+x = 1
+y = 2
+z = 3
+l = []
+list_push(l, x)
+list_push(l, y)
+list_push(l, z)
+
+for i in l do
+    println(i)
 end

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,11 @@
 
-list = [1, 2, 3]
 
-for x in ["hello world", 1, 2, 3, null, true, false] do
+for x in [1, 2, 3] do
     println(x)
+    if x == 2 do
+        while true do
+            break # To make sure that this break is not affected by the for
+        end 
+        break
+    end
 end

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,6 @@
 
+list = [1, 2, 3]
 
-
-for x in [1, 2, 3] do
-    print(x)
+for x in ["hello world", 1, 2, 3, null, true, false] do
+    println(x)
 end

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,0 +1,6 @@
+
+
+
+for x in [1, 2, 3] do
+    print(x)
+end

--- a/grammar.txt
+++ b/grammar.txt
@@ -40,9 +40,10 @@ factor:
   | '(' expression ')'
 
 statement:
-  | function_def_stmt
-  | while_stmt
+  | 'function' function_def_body
+  | 'while' while_body
   | 'if' if_body
+  | 'for' for_body
   | 'return'
   | 'break'
   | 'continue'
@@ -60,14 +61,18 @@ function_signature:
   | name ',' function_signature
   | name
 
-function_def_stmt:
-  | 'function' '(' function_signature ')' 'do' statement_list 'end'
-  | 'function' '(' function_signature ')' 'do' 'end'
+function_def_body:
+  | '(' function_signature ')' 'do' statement_list 'end'
+  | '(' function_signature ')' 'do' 'end'
 
-while_stmt:
-  | 'while' statement_list 'do' statement_list 'end'
-  | 'while' statement_list 'do' 'end'
+while_body:
+  | statement_list 'do' statement_list 'end'
+  | statement_list 'do' 'end'
 
 if_body:
   | statement_list 'do' statement_list 'elif' if_body
   | statement_list 'do' statement_list 'end'
+
+for_body:
+  | variable_name 'in' list_literal 'do' statement_list 'end'
+  | variable_name 'in' variable_name 'do' statement_list 'end'

--- a/grammar.txt
+++ b/grammar.txt
@@ -44,7 +44,7 @@ statement:
   | 'while' while_body
   | 'if' if_body
   | 'for' for_body
-  | 'return'
+  | 'return' [expression]
   | 'break'
   | 'continue'
   | function_identifier

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -78,6 +78,15 @@ auto print_node(const anzu::node_stmt& root, int indent) -> void
                 print_node(*node.else_body, indent + 1);
             }
         },
+        [&](const node_for_stmt& node) {
+            anzu::print("{}For:\n", spaces);
+            anzu::print("{}- Bind:\n",spaces);
+            print_node(*node.var, indent + 1);
+            anzu::print("{}- Container:\n",spaces);
+            print_node(*node.container, indent + 1);
+            anzu::print("{}- Body:\n",spaces);
+            print_node(*node.body, indent + 1);
+        },
         [&](const node_break_stmt& node) {
             anzu::print("{}Break\n", spaces);
         },

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -24,6 +24,7 @@ using node_expr_ptr = std::unique_ptr<node_expr>;
 struct node_sequence_stmt;
 struct node_while_stmt;
 struct node_if_stmt;
+struct node_for_stmt;
 struct node_break_stmt;
 struct node_continue_stmt;
 struct node_assignment_stmt;
@@ -35,6 +36,7 @@ using node_stmt = std::variant<
     node_sequence_stmt,
     node_while_stmt,
     node_if_stmt,
+    node_for_stmt,
     node_break_stmt,
     node_continue_stmt,
     node_assignment_stmt,
@@ -91,6 +93,13 @@ struct node_if_stmt
     node_expr_ptr condition;
     node_stmt_ptr body;
     node_stmt_ptr else_body;
+};
+
+struct node_for_stmt
+{
+    node_expr_ptr var;
+    node_expr_ptr container;
+    node_stmt_ptr body;
 };
 
 struct node_break_stmt

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -23,7 +23,7 @@ auto link_up_jumps(
     -> void
 {
     // Jump past the end if false
-    ctx.program[loop_do].as<anzu::op_do>().jump = loop_end + 1;
+    ctx.program[loop_do].as<anzu::op_jump_if_false>().jump = loop_end + 1;
         
     // Only set unset jumps, there may be other already set from nested loops
     for (std::intptr_t idx = loop_do + 1; idx != loop_end; ++idx) {
@@ -118,7 +118,7 @@ void compile_node(const node_while_stmt& node, compiler_context& ctx)
     compile_node(*node.condition, ctx);
     
     const auto do_pos = std::ssize(ctx.program);
-    ctx.program.emplace_back(anzu::op_do{});
+    ctx.program.emplace_back(anzu::op_jump_if_false{});
 
     compile_node(*node.body, ctx);
 
@@ -136,7 +136,7 @@ void compile_node(const node_if_stmt& node, compiler_context& ctx)
     compile_node(*node.condition, ctx);
     
     const auto do_pos = std::ssize(ctx.program);
-    ctx.program.emplace_back(anzu::op_do{});
+    ctx.program.emplace_back(anzu::op_jump_if_false{});
 
     compile_node(*node.body, ctx);
 
@@ -149,9 +149,9 @@ void compile_node(const node_if_stmt& node, compiler_context& ctx)
 
     ctx.program.emplace_back(anzu::op_if_end{});
     if (else_pos == -1) {
-        ctx.program[do_pos].as<anzu::op_do>().jump = std::ssize(ctx.program); // Jump past the end if false
+        ctx.program[do_pos].as<anzu::op_jump_if_false>().jump = std::ssize(ctx.program); // Jump past the end if false
     } else {
-        ctx.program[do_pos].as<anzu::op_do>().jump = else_pos + 1; // Jump into the else block if false
+        ctx.program[do_pos].as<anzu::op_jump_if_false>().jump = else_pos + 1; // Jump into the else block if false
         ctx.program[else_pos].as<anzu::op_else>().jump = std::ssize(ctx.program); // Jump past the end if false
     }
 }
@@ -194,7 +194,7 @@ void compile_node(const node_for_stmt& node, compiler_context& ctx)
     ctx.program.emplace_back(anzu::op_ne{});   // Eval size != index
 
     const auto do_pos = std::ssize(ctx.program);
-    ctx.program.emplace_back(anzu::op_do{});   // If size == index, jump to end
+    ctx.program.emplace_back(anzu::op_jump_if_false{});   // If size == index, jump to end
 
     // Stack: list, size, index(0)
     ctx.program.emplace_back(anzu::op_copy_index{2}); // Push container

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -142,6 +142,10 @@ void compile_node(const node_if_stmt& node, compiler_context& ctx)
     }
 }
 
+void compile_node(const node_for_stmt& node, compiler_context& ctx)
+{
+}
+
 void compile_node(const node_break_stmt&, compiler_context& ctx)
 {
     ctx.program.emplace_back(anzu::op_break{});

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -149,12 +149,22 @@ auto is_builtin(const std::string& name) -> bool
 
 auto fetch_builtin(const std::string& name) -> builtin_function
 {
-    return builtins.at(name).ptr;
+    auto it = builtins.find(name);
+    if (it == builtins.end()) {
+        anzu::print("builtin error: could not find function '{}'\n", name);
+        std::exit(1);
+    }
+    return it->second.ptr;
 }
 
 auto fetch_builtin_argc(const std::string& name) -> std::int64_t
 {
-    return builtins.at(name).argc;
+    auto it = builtins.find(name);
+    if (it == builtins.end()) {
+        anzu::print("builtin error: could not find function '{}'\n", name);
+        std::exit(1);
+    }
+    return it->second.argc;
 }
 
 }

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -18,7 +18,9 @@ static const std::unordered_set<std::string_view> keywords = {
     "null",
     "return",
     "true",
-    "while"
+    "while",
+    "for",
+    "in"
 };
 
 static const std::unordered_set<std::string_view> symbols = {

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -57,6 +57,13 @@ void op_pop::apply(anzu::context& ctx) const
     frame.ptr() += 1;
 }
 
+void op_dup::apply(anzu::context& ctx) const
+{
+    auto& frame = ctx.top();
+    frame.push(frame.top());
+    frame.ptr() += 1;
+}
+
 
 void op_store::apply(anzu::context& ctx) const
 {

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -58,27 +58,11 @@ void op_pop::apply(anzu::context& ctx) const
     frame.ptr() += 1;
 }
 
-void op_dup::apply(anzu::context& ctx) const
+void op_copy_index::apply(anzu::context& ctx) const
 {
     auto& frame = ctx.top();
-    verify_stack(frame, 1, "dup");
-    frame.push(frame.top());
-    frame.ptr() += 1;
-}
-
-void op_over::apply(anzu::context& ctx) const
-{
-    auto& frame = ctx.top();
-    verify_stack(frame, 2, "over");
-    frame.push(frame.top(1));
-    frame.ptr() += 1;
-}
-
-void op_2over::apply(anzu::context& ctx) const
-{
-    auto& frame = ctx.top();
-    verify_stack(frame, 3, "2over");
-    frame.push(frame.top(2));
+    verify_stack(frame, index + 1, "copy_index");
+    frame.push(frame.top(index));
     frame.ptr() += 1;
 }
 
@@ -178,7 +162,7 @@ void op_function_call::apply(anzu::context& ctx) const
     }
 }
 
-void op_builtin_function_call::apply(anzu::context& ctx) const
+void op_builtin_call::apply(anzu::context& ctx) const
 {
     func(ctx);
     ctx.top().ptr() += 1;

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -120,7 +120,7 @@ void op_continue::apply(anzu::context& ctx) const
     ctx.top().ptr() = jump;
 }
 
-void op_do::apply(anzu::context& ctx) const
+void op_jump_if_false::apply(anzu::context& ctx) const
 {
     auto& frame = ctx.top();
     if (frame.pop().to_bool()) {

--- a/src/op_codes.cpp
+++ b/src/op_codes.cpp
@@ -53,6 +53,7 @@ void op_push_var::apply(anzu::context& ctx) const
 void op_pop::apply(anzu::context& ctx) const
 {
     auto& frame = ctx.top();
+    verify_stack(frame, 1, "pop");
     frame.pop();
     frame.ptr() += 1;
 }
@@ -60,7 +61,24 @@ void op_pop::apply(anzu::context& ctx) const
 void op_dup::apply(anzu::context& ctx) const
 {
     auto& frame = ctx.top();
+    verify_stack(frame, 1, "dup");
     frame.push(frame.top());
+    frame.ptr() += 1;
+}
+
+void op_over::apply(anzu::context& ctx) const
+{
+    auto& frame = ctx.top();
+    verify_stack(frame, 2, "over");
+    frame.push(frame.top(1));
+    frame.ptr() += 1;
+}
+
+void op_2over::apply(anzu::context& ctx) const
+{
+    auto& frame = ctx.top();
+    verify_stack(frame, 3, "2over");
+    frame.push(frame.top(2));
     frame.ptr() += 1;
 }
 
@@ -94,6 +112,16 @@ void op_while::apply(anzu::context& ctx) const
 }
 
 void op_while_end::apply(anzu::context& ctx) const
+{
+    ctx.top().ptr() = jump;
+}
+
+void op_for::apply(anzu::context& ctx) const
+{
+    ctx.top().ptr() += 1;
+}
+
+void op_for_end::apply(anzu::context& ctx) const
 {
     ctx.top().ptr() = jump;
 }

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -34,6 +34,12 @@ struct op_pop
     void apply(anzu::context& ctx) const;
 };
 
+struct op_dup
+{
+    std::string to_string() const { return "OP_DUP"; }
+    void apply(anzu::context& ctx) const;
+};
+
 // Store Manipulation
 
 struct op_store
@@ -257,6 +263,7 @@ class op
         op_push_const,
         op_push_var,
         op_pop,
+        op_dup,
 
         // Store Manipulation
         op_store,

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -40,6 +40,18 @@ struct op_dup
     void apply(anzu::context& ctx) const;
 };
 
+struct op_over
+{
+    std::string to_string() const { return "OP_OVER"; }
+    void apply(anzu::context& ctx) const;
+};
+
+struct op_2over
+{
+    std::string to_string() const { return "OP_2OVER"; }
+    void apply(anzu::context& ctx) const;
+};
+
 // Store Manipulation
 
 struct op_store
@@ -90,6 +102,24 @@ struct op_while_end
     {
         const auto jump_str = std::format("JUMP -> {}", jump);
         return std::format(FORMAT2, "OP_END_WHILE", jump_str);
+    }
+    void apply(anzu::context& ctx) const;
+};
+
+struct op_for
+{
+    std::string to_string() const { return "OP_FOR"; }
+    void apply(anzu::context& ctx) const;
+};
+
+struct op_for_end
+{
+    std::intptr_t jump = -1;
+
+    std::string to_string() const
+    {
+        const auto jump_str = std::format("JUMP -> {}", jump);
+        return std::format(FORMAT2, "OP_END_FOR", jump_str);
     }
     void apply(anzu::context& ctx) const;
 };
@@ -264,6 +294,8 @@ class op
         op_push_var,
         op_pop,
         op_dup,
+        op_over,
+        op_2over,
 
         // Store Manipulation
         op_store,
@@ -274,6 +306,8 @@ class op
         op_else,
         op_while,
         op_while_end,
+        op_for,
+        op_for_end,
         op_break,
         op_continue,
         op_do,

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -34,21 +34,12 @@ struct op_pop
     void apply(anzu::context& ctx) const;
 };
 
-struct op_dup
+// 0 == OP_DUP, 1 == OP_OVER, ...
+struct op_copy_index
 {
-    std::string to_string() const { return "OP_DUP"; }
-    void apply(anzu::context& ctx) const;
-};
+    int index;
 
-struct op_over
-{
-    std::string to_string() const { return "OP_OVER"; }
-    void apply(anzu::context& ctx) const;
-};
-
-struct op_2over
-{
-    std::string to_string() const { return "OP_2OVER"; }
+    std::string to_string() const { return std::format("OP_COPY_INDEX({})", index); }
     void apply(anzu::context& ctx) const;
 };
 
@@ -170,12 +161,12 @@ struct op_function_call
     void apply(anzu::context& ctx) const;
 };
 
-struct op_builtin_function_call
+struct op_builtin_call
 {
     std::string name;
     anzu::builtin_function func;
 
-    std::string to_string() const { return std::format("OP_BUILTIN_FUNCTION_CALL({})", name); }
+    std::string to_string() const { return std::format("OP_BUILTIN_CALL({})", name); }
     void apply(anzu::context& ctx) const;
 };
 
@@ -293,9 +284,7 @@ class op
         op_push_const,
         op_push_var,
         op_pop,
-        op_dup,
-        op_over,
-        op_2over,
+        op_copy_index,
 
         // Store Manipulation
         op_store,
@@ -333,7 +322,7 @@ class op
         op_function_end,
         op_return,
         op_function_call,
-        op_builtin_function_call
+        op_builtin_call
     >;
 
     op_type d_type;

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -133,20 +133,20 @@ struct op_continue
 
     std::string to_string() const
     {
-        const auto jump_str = std::format("JUMP -> {}", jump);
+        const auto jump_str = std::format("JUMP -> {} IF FALSE", jump);
         return std::format(FORMAT2, "OP_CONTINUE", jump_str);
     }
     void apply(anzu::context& ctx) const;
 };
 
-struct op_do
+struct op_jump_if_false
 {
     std::intptr_t jump = -1;
 
     std::string to_string() const
     {
-        const auto jump_str = std::format("JUMP -> {} IF FALSE", jump);
-        return std::format(FORMAT2, "OP_DO", jump_str);
+        const auto jump_str = std::format("JUMP -> {}", jump);
+        return std::format(FORMAT2, "OP_JUMP_IF_FALSE", jump_str);
     }
     void apply(anzu::context& ctx) const;
 };
@@ -299,7 +299,7 @@ class op
         op_for_end,
         op_break,
         op_continue,
-        op_do,
+        op_jump_if_false,
 
         // Numerical Operators
         op_add,

--- a/src/op_codes.hpp
+++ b/src/op_codes.hpp
@@ -133,7 +133,7 @@ struct op_continue
 
     std::string to_string() const
     {
-        const auto jump_str = std::format("JUMP -> {} IF FALSE", jump);
+        const auto jump_str = std::format("JUMP -> {}", jump);
         return std::format(FORMAT2, "OP_CONTINUE", jump_str);
     }
     void apply(anzu::context& ctx) const;
@@ -145,7 +145,7 @@ struct op_jump_if_false
 
     std::string to_string() const
     {
-        const auto jump_str = std::format("JUMP -> {}", jump);
+        const auto jump_str = std::format("JUMP -> {} IF FALSE", jump);
         return std::format(FORMAT2, "OP_JUMP_IF_FALSE", jump_str);
     }
     void apply(anzu::context& ctx) const;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -227,6 +227,23 @@ auto parse_if_body(parser_context& ctx) -> node_stmt_ptr
     return node;
 }
 
+auto parse_for_body(parser_context& ctx) -> node_stmt_ptr
+{
+    auto node = std::make_unique<anzu::node_stmt>();
+    auto& stmt = node->emplace<anzu::node_for_stmt>();
+    stmt.var = parse_expression(ctx);
+    if (!std::holds_alternative<anzu::node_variable_expr>(*stmt.var)) {
+        anzu::print("invalid for loop, invalid expression for bind target\n");
+        std::exit(1);
+    }
+    consume_only(ctx.curr, "in");
+    stmt.container = parse_expression(ctx); // TODO: When we have static typing, check this is a list
+    consume_only(ctx.curr, "do");
+    stmt.body = parse_statement_list(ctx);
+    consume_only(ctx.curr, "end");
+    return node;
+}
+
 auto parse_function_def(parser_context& ctx) -> node_stmt_ptr
 {
     auto node = std::make_unique<anzu::node_stmt>();
@@ -435,6 +452,9 @@ auto parse_statement(parser_context& ctx) -> node_stmt_ptr
     }
     else if (consume_maybe(ctx.curr, "if")) {
         return parse_if_body(ctx);
+    }
+    else if (consume_maybe(ctx.curr, "for")) {
+        return parse_for_body(ctx);
     }
     else if (consume_maybe(ctx.curr, "break")) {
         auto node = std::make_unique<anzu::node_stmt>();

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -20,6 +20,8 @@ constexpr auto END         = std::string_view{"end"};
 constexpr auto TRUE_LIT    = std::string_view{"true"};
 constexpr auto FALSE_LIT   = std::string_view{"false"};
 constexpr auto NULL_LIT    = std::string_view{"null"};
+constexpr auto FOR         = std::string_view{"for"};
+constexpr auto IN          = std::string_view{"in"};
 
 constexpr auto ADD         = std::string_view{"+"};
 constexpr auto SUB         = std::string_view{"-"};


### PR DESCRIPTION
* Implement a python style for loop for iterating lists.
* In the lexer, make `for` and `in` keywords.
* Add `anzu::node_for_stmt` for use within an AST.
* Add `anzu::op_for`, `anzu::op_for_end` and `anzu::op_copy_index(n)` for use within a program.
* `anzu::op_copy_index(n)`, takes the element from the n-th position in the stack, where 0 is the top, and copies it into the top of the stack. Thus `op_copy_index(0)` is equivalent to the old `op_dup`, and `op_copy_index(1)` is equivalent to the old `op_over`.
* Since `OP_DO` op codes are no longer added to the program via the parser encountering a "do" token, the op code has been renamed to `OP_JUMP_IF_FALSE`.
* Added error checking when trying to call an invalid builtin. Previously interpreter would segfault.