### PR TITLE
Simplify Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ print(4 + 5)
 * Supports `ints`, `bools`, `floats`, `null` and `string-literals`.
 * Assignment to variable names in the expected way: `x = 5`.
 * `if` statements (with optional `else` and `elif` too).
+
     ```
     if <condition> do
         ...
@@ -30,18 +31,21 @@ print(4 + 5)
     end
     ```
 * `while` loops (with optional `break` and `continue`):
+
     ```
     while <condition> do
         ...
     end
     ```
 * `for` loops (with optional `break` and `continue`):
+
     ```
     for <variable_name> in <list_object> do
         ...
     end
     ```
 * `function` statements (with optional `return`):
+
     ```
     function <name>(<args>) do
         ...

--- a/examples/test.az
+++ b/examples/test.az
@@ -11,6 +11,3 @@ list_push(l, z)
 for i in l do
     println(i)
 end
-
-
-2 + 3

--- a/examples/test.az
+++ b/examples/test.az
@@ -11,3 +11,5 @@ list_push(l, z)
 for i in l do
     println(i)
 end
+
+x = 2 + 3

--- a/examples/test.az
+++ b/examples/test.az
@@ -11,3 +11,6 @@ list_push(l, z)
 for i in l do
     println(i)
 end
+
+
+2 + 3

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -124,9 +124,6 @@ auto print_node(const anzu::node_stmt& root, int indent) -> void
         [&](const node_return_stmt& node) {
             anzu::print("{}Return:\n", spaces);
             print_node(*node.return_value, indent + 1);
-        },
-        [&](const node_expr& node) {
-            print_node(node, indent + 1);
         }
     }, root);
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -39,13 +39,6 @@ auto print_node(const anzu::node_expr& root, int indent) -> void
             for (const auto& arg : node.args) {
                 print_node(*arg, indent + 1);
             }
-        },
-        [&](const node_builtin_call_expr& node) {
-            anzu::print("{}BuiltinCall (Expr): {}\n", spaces, node.function_name);
-            anzu::print("{}- Args:\n", spaces);
-            for (const auto& arg : node.args) {
-                print_node(*arg, indent + 1);
-            }
         }
     }, root);
 }
@@ -108,13 +101,6 @@ auto print_node(const anzu::node_stmt& root, int indent) -> void
         },
         [&](const node_function_call_stmt& node) {
             anzu::print("{}FunctionCall (Stmt): {}\n", spaces, node.function_name);
-            anzu::print("{}- Args:\n", spaces);
-            for (const auto& arg : node.args) {
-                print_node(*arg, indent + 1);
-            }
-        },
-        [&](const node_builtin_call_stmt& node) {
-            anzu::print("{}BuiltinCall (Stmt): {}\n", spaces, node.function_name);
             anzu::print("{}- Args:\n", spaces);
             for (const auto& arg : node.args) {
                 print_node(*arg, indent + 1);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -80,8 +80,7 @@ auto print_node(const anzu::node_stmt& root, int indent) -> void
         },
         [&](const node_for_stmt& node) {
             anzu::print("{}For:\n", spaces);
-            anzu::print("{}- Bind:\n",spaces);
-            print_node(*node.var, indent + 1);
+            anzu::print("{}- Bind: {}\n",spaces, node.var);
             anzu::print("{}- Container:\n",spaces);
             print_node(*node.container, indent + 1);
             anzu::print("{}- Body:\n",spaces);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -71,7 +71,7 @@ struct node_if_stmt
 
 struct node_for_stmt
 {
-    node_expr_ptr var;
+    std::string   var;
     node_expr_ptr container;
     node_stmt_ptr body;
 };

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -43,8 +43,7 @@ using node_stmt = std::variant<
     node_function_def_stmt,
     node_function_call_stmt,
     node_builtin_call_stmt,
-    node_return_stmt,
-    node_expr
+    node_return_stmt
 >;
 using node_stmt_ptr = std::unique_ptr<node_stmt>;
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -115,7 +115,6 @@ struct node_stmt : std::variant<
 {
 };
 
-
 auto print_node(const anzu::node_expr& node, int indent = 0) -> void;
 auto print_node(const anzu::node_stmt& node, int indent = 0) -> void;
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -7,45 +7,8 @@
 
 namespace anzu {
 
-struct node_literal_expr;
-struct node_variable_expr;
-struct node_bin_op_expr;
-struct node_function_call_expr;
-struct node_builtin_call_expr;
-using node_expr = std::variant<
-    node_literal_expr,
-    node_variable_expr,
-    node_bin_op_expr,
-    node_function_call_expr,
-    node_builtin_call_expr
->;
+struct node_expr;
 using node_expr_ptr = std::unique_ptr<node_expr>;
-
-struct node_sequence_stmt;
-struct node_while_stmt;
-struct node_if_stmt;
-struct node_for_stmt;
-struct node_break_stmt;
-struct node_continue_stmt;
-struct node_assignment_stmt;
-struct node_function_def_stmt;
-struct node_function_call_stmt;
-struct node_builtin_call_stmt;
-struct node_return_stmt;
-using node_stmt = std::variant<
-    node_sequence_stmt,
-    node_while_stmt,
-    node_if_stmt,
-    node_for_stmt,
-    node_break_stmt,
-    node_continue_stmt,
-    node_assignment_stmt,
-    node_function_def_stmt,
-    node_function_call_stmt,
-    node_builtin_call_stmt,
-    node_return_stmt
->;
-using node_stmt_ptr = std::unique_ptr<node_stmt>;
 
 struct node_literal_expr
 {
@@ -75,6 +38,18 @@ struct node_builtin_call_expr
     std::string                function_name;
     std::vector<node_expr_ptr> args;
 };
+
+struct node_expr : std::variant<
+    node_literal_expr,
+    node_variable_expr,
+    node_bin_op_expr,
+    node_function_call_expr,
+    node_builtin_call_expr>
+{
+};
+
+struct node_stmt;
+using node_stmt_ptr = std::unique_ptr<node_stmt>;
 
 struct node_sequence_stmt
 {
@@ -138,6 +113,22 @@ struct node_return_stmt
 {
     node_expr_ptr return_value;
 };
+
+struct node_stmt : std::variant<
+    node_sequence_stmt,
+    node_while_stmt,
+    node_if_stmt,
+    node_for_stmt,
+    node_break_stmt,
+    node_continue_stmt,
+    node_assignment_stmt,
+    node_function_def_stmt,
+    node_function_call_stmt,
+    node_builtin_call_stmt,
+    node_return_stmt>
+{
+};
+
 
 auto print_node(const anzu::node_expr& node, int indent = 0) -> void;
 auto print_node(const anzu::node_stmt& node, int indent = 0) -> void;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -33,18 +33,11 @@ struct node_function_call_expr
     std::vector<node_expr_ptr> args;
 };
 
-struct node_builtin_call_expr
-{
-    std::string                function_name;
-    std::vector<node_expr_ptr> args;
-};
-
 struct node_expr : std::variant<
     node_literal_expr,
     node_variable_expr,
     node_bin_op_expr,
-    node_function_call_expr,
-    node_builtin_call_expr>
+    node_function_call_expr>
 {
 };
 
@@ -103,12 +96,6 @@ struct node_function_call_stmt
     std::vector<node_expr_ptr> args;
 };
 
-struct node_builtin_call_stmt
-{
-    std::string                function_name;
-    std::vector<node_expr_ptr> args;
-};
-
 struct node_return_stmt
 {
     node_expr_ptr return_value;
@@ -124,7 +111,6 @@ struct node_stmt : std::variant<
     node_assignment_stmt,
     node_function_def_stmt,
     node_function_call_stmt,
-    node_builtin_call_stmt,
     node_return_stmt>
 {
 };

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -79,28 +79,21 @@ void compile_node(const node_function_call_expr& node, compiler_context& ctx)
         compile_node(*arg, ctx);
     }
 
-    const auto& function_def = ctx.functions.at(node.function_name);
+    const auto& name = node.function_name;
 
-    // Call the function
-    ctx.program.emplace_back(anzu::op_function_call{
-        .name=node.function_name,
-        .ptr=function_def.ptr + 1, // Jump into the function
-        .arg_names=function_def.arg_names
-    });
-}
-
-void compile_node(const node_builtin_call_expr& node, compiler_context& ctx)
-{
-    // Push the args to the stack
-    for (const auto& arg : node.args) {
-        compile_node(*arg, ctx);
+    if (const auto it = ctx.functions.find(name); it != ctx.functions.end()) {
+        const auto& function_def = it->second;
+        ctx.program.emplace_back(anzu::op_function_call{
+            .name=name,
+            .ptr=function_def.ptr + 1, // Jump into the function
+            .arg_names=function_def.arg_names
+        });
+    } else {
+        ctx.program.emplace_back(anzu::op_builtin_call{
+            .name=name,
+            .func=anzu::fetch_builtin(name)
+        });
     }
-
-    // Call the function
-    ctx.program.emplace_back(anzu::op_builtin_call{
-        .name=node.function_name,
-        .func=anzu::fetch_builtin(node.function_name)
-    });
 }
 
 void compile_node(const node_sequence_stmt& node, compiler_context& ctx)
@@ -256,29 +249,23 @@ void compile_node(const node_function_call_stmt& node, compiler_context& ctx)
         compile_node(*arg, ctx);
     }
 
-    const auto& function_def = ctx.functions.at(node.function_name);
+    const auto& name = node.function_name;
 
-    // Call the function
-    ctx.program.emplace_back(anzu::op_function_call{
-        .name=node.function_name,
-        .ptr=function_def.ptr + 1, // Jump into the function
-        .arg_names=function_def.arg_names
-    });
-    ctx.program.emplace_back(anzu::op_pop{});
-}
-
-void compile_node(const node_builtin_call_stmt& node, compiler_context& ctx)
-{
-    // Push the args to the stack
-    for (const auto& arg : node.args) {
-        compile_node(*arg, ctx);
+    if (const auto it = ctx.functions.find(name); it != ctx.functions.end()) {
+        const auto& function_def = it->second;
+        ctx.program.emplace_back(anzu::op_function_call{
+            .name=name,
+            .ptr=function_def.ptr + 1, // Jump into the function
+            .arg_names=function_def.arg_names
+        });
+    }
+    else {
+        ctx.program.emplace_back(anzu::op_builtin_call{
+            .name=name,
+            .func=anzu::fetch_builtin(name)
+        });
     }
 
-    // Call the function
-    ctx.program.emplace_back(anzu::op_builtin_call{
-        .name=node.function_name,
-        .func=anzu::fetch_builtin(node.function_name)
-    });
     ctx.program.emplace_back(anzu::op_pop{});
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -158,8 +158,6 @@ void compile_node(const node_if_stmt& node, compiler_context& ctx)
 
 void compile_node(const node_for_stmt& node, compiler_context& ctx)
 {
-    const auto var = std::get<anzu::node_variable_expr>(*node.var).name;
-
     // Push the container to the stack
     if (std::holds_alternative<anzu::node_variable_expr>(*node.container)) {
         const auto& cont = std::get<anzu::node_variable_expr>(*node.container).name;
@@ -203,7 +201,7 @@ void compile_node(const node_for_stmt& node, compiler_context& ctx)
         .name="list_at",
         .func=anzu::fetch_builtin("list_at")
     });
-    ctx.program.emplace_back(anzu::op_store{ .name=var }); // Store in var
+    ctx.program.emplace_back(anzu::op_store{ .name=node.var }); // Store in var
 
     compile_node(*node.body, ctx);
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -63,10 +63,10 @@ public:
 
 
 template <typename... Args>
-auto lexer_error(int lineno, int col, std::string_view msg, Args&&... args) -> void
+[[noreturn]] void lexer_error(int lineno, int col, std::string_view msg, Args&&... args)
 {
     const auto formatted_msg = std::format(msg, std::forward<Args>(args)...);
-    anzu::print("[Lexer Error {}:{}] {}\n", lineno, col, formatted_msg);
+    anzu::print("[Lexer] ({}:{}) ERROR: {}\n", lineno, col, formatted_msg);
     std::exit(1);
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -476,9 +476,7 @@ auto parse_statement(parser_context& ctx) -> node_stmt_ptr
         return parse_builtin_call_stmt(ctx);
     }
     else {
-        auto expression = parse_expression(ctx);
-        anzu::print("error: unused statement\n");
-        print_node(*expression);
+        anzu::print("parser error: unknown statement '{}'\n", ctx.curr->text);
         std::exit(1);
     }
 }


### PR DESCRIPTION
* Remove `node_expr` from the `node_stmt` variant. A standalone expression is not a valid statement and causes a parser error anyway, expressions can only appear as child nodes of statements.
* Change the definition of the AST nodes to require fewer declarations. Now, the variant nodes are forward declared, followed by the node types, then the node variants are defined as subclasses of `std::variant`. This just results in fewer lines of code. Note: using `std::visit` on `std::variant` subclasses may not actually be guaranteed by the standard to work, but it does on MSVC at least. This is going to be fixed in C++23.
* The AST doesn't need to care about the differences between function calls and builtin calls, so the builtin nodes have been removed. Now when the compiler encounters a function expression or statement, it first checks if the function name is user defined, then checks if it is builtin, and acts accordingly.
* The compiler logic for function call statements vs expressions is very similar, the only different being that the statement also inserts an OP_POP after. This has been refactored into a single function called from both places. This together with the removal of builtin nodes has essentially reduced four functions down to one.
* In `node_for_stmt`, the bind variable is now simply stored as a `std::string`, just like in assignment expressions.
* Better error messages in the parser. All `exit(1)` calls have been replaced by `parser_error`, which will also print the line and column where the error was found.