### PR TITLE
Vocabulary File

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,15 +1,3 @@
 
 
-x = 1
-y = 2
-z = 3
-l = []
-list_push(l, x)
-list_push(l, y)
-list_push(l, z)
-
-for i in l do
-    println(i)
-end
-
 x = 2 + 3

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(anzu
                stack_frame.cpp
                op_codes.cpp
                object.cpp
-               functions.cpp)
+               functions.cpp
+               vocabulary.cpp)
 
 target_include_directories(anzu PRIVATE .)

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -86,7 +86,7 @@ auto print_node(const anzu::node_stmt& root, int indent) -> void
             anzu::print("{}Continue\n", spaces);
         },
         [&](const node_assignment_stmt& node) {
-            anzu::print("{}Assignment\n", spaces);
+            anzu::print("{}Assignment:\n", spaces);
             anzu::print("{}- Name: {}\n", spaces, node.name);
             anzu::print("{}- Value:\n", spaces);
             print_node(*node.expr, indent + 1);

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -1,8 +1,6 @@
 #pragma once
-#include "op_codes.hpp"
-#include "object.hpp"
-#include "lexer.hpp"
 #include "ast.hpp"
+#include "op_codes.hpp"
 
 #include <memory>
 #include <vector>
@@ -24,6 +22,6 @@ struct compiler_context
     std::unordered_map<std::string, function_def> functions;
 };
 
-auto compile(const std::unique_ptr<node_stmt>& root) -> std::vector<anzu::op>;
+auto compile(const anzu::node_stmt_ptr& root) -> std::vector<anzu::op>;
 
 }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1,6 +1,7 @@
 #include "lexer.hpp"
 #include "object.hpp"
 #include "print.hpp"
+#include "vocabulary.hpp"
 
 #include <algorithm>
 #include <ranges>
@@ -89,13 +90,13 @@ auto parse_string_literal(int lineno, line_iterator& iter) -> std::string
 auto try_parse_symbol(line_iterator& iter) -> std::optional<std::string>
 {
     if (iter.has_next()) {
-        if (const auto pair = std::format("{}{}", iter.curr(), iter.next()); symbols.contains(pair)) {
+        if (const auto pair = std::format("{}{}", iter.curr(), iter.next()); anzu::is_symbol(pair)) {
             iter.consume();
             iter.consume();
             return pair;
         }
     }
-    if (const auto single = std::string{iter.curr()}; symbols.contains(single)) {
+    if (const auto single = std::string{iter.curr()}; anzu::is_symbol(single)) {
         iter.consume();
         return single;
     }
@@ -134,7 +135,7 @@ auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const i
 
         const auto token = parse_token(iter);
         if (!token.empty()) {
-            if (keywords.contains(token)) {
+            if (anzu::is_keyword(token)) {
                 push_token(token, col, token_type::keyword);
             }
             else if (anzu::is_int(token)) {

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -1,32 +1,8 @@
 #pragma once
 #include <vector>
 #include <string>
-#include <unordered_set>
 
 namespace anzu {
-
-static const std::unordered_set<std::string_view> keywords = {
-    "break",
-    "continue",
-    "do",
-    "elif",
-    "else",
-    "end",
-    "false",
-    "function",
-    "if",
-    "null",
-    "return",
-    "true",
-    "while",
-    "for",
-    "in"
-};
-
-static const std::unordered_set<std::string_view> symbols = {
-    "+", "-", "*", "/", "%", "=", "(",  ")", ":", "[", "]", ",", ".",
-    "==", "!=", "<", "<=", ">", ">=", "||", "&&"
-};
 
 enum class token_type
 {

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "lexer.hpp"
 #include "ast.hpp"
+#include "vocabulary.hpp"
 
 #include <vector>
 #include <memory>
@@ -8,37 +9,6 @@
 #include <string>
 
 namespace anzu {
-
-constexpr auto IF          = std::string_view{"if"};
-constexpr auto ELIF        = std::string_view{"elif"};
-constexpr auto ELSE        = std::string_view{"else"};
-constexpr auto WHILE       = std::string_view{"while"};
-constexpr auto BREAK       = std::string_view{"break"};
-constexpr auto CONTINUE    = std::string_view{"continue"};
-constexpr auto DO          = std::string_view{"do"};
-constexpr auto END         = std::string_view{"end"};
-constexpr auto TRUE_LIT    = std::string_view{"true"};
-constexpr auto FALSE_LIT   = std::string_view{"false"};
-constexpr auto NULL_LIT    = std::string_view{"null"};
-constexpr auto FOR         = std::string_view{"for"};
-constexpr auto IN          = std::string_view{"in"};
-
-constexpr auto ADD         = std::string_view{"+"};
-constexpr auto SUB         = std::string_view{"-"};
-constexpr auto MUL         = std::string_view{"*"};
-constexpr auto DIV         = std::string_view{"/"};
-constexpr auto MOD         = std::string_view{"%"};
-
-constexpr auto EQ          = std::string_view{"=="};
-constexpr auto NE          = std::string_view{"!="};
-constexpr auto LT          = std::string_view{"<"};
-constexpr auto LE          = std::string_view{"<="};
-constexpr auto GT          = std::string_view{">"};
-constexpr auto GE          = std::string_view{">="};
-constexpr auto OR          = std::string_view{"||"};
-constexpr auto AND         = std::string_view{"&&"};
-
-constexpr auto ASSIGN      = std::string_view{"="};
 
 using token_iterator = std::vector<anzu::token>::const_iterator;
 
@@ -51,12 +21,12 @@ struct parser_context
         std::int64_t argc;
     };
 
-    token_iterator       curr;
-    const token_iterator end;
+    anzu::token_iterator       curr;
+    const anzu::token_iterator end;
 
     std::unordered_map<std::string, function_info> functions;
 };
 
-auto parse(const std::vector<anzu::token>& tokens) -> node_stmt_ptr;
+auto parse(const std::vector<anzu::token>& tokens) -> anzu::node_stmt_ptr;
 
 }

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -1,0 +1,36 @@
+#include "vocabulary.hpp"
+
+#include <string_view>
+#include <unordered_set>
+
+namespace anzu {
+
+auto is_keyword(std::string_view token) -> bool
+{
+    static const std::unordered_set<std::string_view> tokens = {
+        tk_break, tk_continue, tk_do, tk_elif, tk_else, tk_end,
+        tk_false, tk_for, tk_if, tk_in, tk_null, tk_true, tk_while
+    };
+    return tokens.contains(token);
+}
+
+auto is_sentinel(std::string_view token) -> bool
+{
+    static const std::unordered_set<std::string_view> tokens = {
+        tk_do, tk_elif, tk_else, tk_end
+    };
+    return tokens.contains(token);
+}
+
+auto is_symbol(std::string_view token) -> bool
+{
+    static const std::unordered_set<std::string_view> tokens = {
+        tk_add, tk_and, tk_assign, tk_colon, tk_comma,
+        tk_div, tk_eq, tk_ge, tk_gt, tk_lbracket, tk_le,
+        tk_lparen, tk_lt, tk_mod, tk_mul, tk_ne, tk_or,
+        tk_period, tk_rbracket, tk_rparen, tk_sub
+    };
+    return tokens.contains(token);
+}
+
+}

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -1,0 +1,52 @@
+#pragma once
+#include <string_view>
+
+namespace anzu {
+
+using sv = std::string_view;
+
+// Keywords
+constexpr auto tk_break     = sv{"break"};
+constexpr auto tk_continue  = sv{"continue"};
+constexpr auto tk_do        = sv{"do"};
+constexpr auto tk_elif      = sv{"elif"};
+constexpr auto tk_else      = sv{"else"};
+constexpr auto tk_end       = sv{"end"};
+constexpr auto tk_false     = sv{"false"};
+constexpr auto tk_for       = sv{"for"};
+constexpr auto tk_if        = sv{"if"};
+constexpr auto tk_in        = sv{"in"};
+constexpr auto tk_null      = sv{"null"};
+constexpr auto tk_true      = sv{"true"};
+constexpr auto tk_while     = sv{"while"};
+constexpr auto tk_function  = sv{"function"};
+constexpr auto tk_return    = sv{"return"};
+
+// Symbols
+constexpr auto tk_add       = sv{"+"};
+constexpr auto tk_and       = sv{"&&"};
+constexpr auto tk_assign    = sv{"="};
+constexpr auto tk_colon     = sv{":"};
+constexpr auto tk_comma     = sv{","};
+constexpr auto tk_div       = sv{"/"};
+constexpr auto tk_eq        = sv{"=="};
+constexpr auto tk_ge        = sv{">="};
+constexpr auto tk_gt        = sv{">"};
+constexpr auto tk_lbracket  = sv{"["};
+constexpr auto tk_le        = sv{"<="};
+constexpr auto tk_lparen    = sv{"("};
+constexpr auto tk_lt        = sv{"<"};
+constexpr auto tk_mod       = sv{"%"};
+constexpr auto tk_mul       = sv{"*"};
+constexpr auto tk_ne        = sv{"!="};
+constexpr auto tk_or        = sv{"||"};
+constexpr auto tk_period    = sv{"."};
+constexpr auto tk_rbracket  = sv{"]"};
+constexpr auto tk_rparen    = sv{")"};
+constexpr auto tk_sub       = sv{"-"};
+
+auto is_keyword  (std::string_view token) -> bool;
+auto is_sentinel (std::string_view token) -> bool;
+auto is_symbol   (std::string_view token) -> bool;
+
+}


### PR DESCRIPTION
* Move all keyword and symbols used by the language into a separate file, reducing some code duplication.
* Previously the sets defining token types was in the lexer, and the tokens were duplicated in the parser to give them variable names.
* Refer to these keywords via the constants in the new file, rather then copying them all over the place.