### PR TITLE
Optimising Const Expressions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/feature_test.az", "run"],
+            "args": ["${workspaceFolder}/examples/test.az", "run"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -76,6 +76,8 @@
         "variant": "cpp",
         "iostream": "cpp",
         "unordered_set": "cpp",
-        "*.rh": "cpp"
+        "*.rh": "cpp",
+        "memory_resource": "cpp",
+        "mutex": "cpp"
     }
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,2 @@
 
-
-if input() == 2 do
-    println("hello")
-end
+x = 2 * (3 + 1) / 2 + 10

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(anzu
                lexer.cpp
                token.cpp
                parser.cpp
+               optimiser.cpp
                compiler.cpp
                runtime.cpp
                program.cpp

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -1,5 +1,6 @@
 #include "lexer.hpp"
 #include "parser.hpp"
+#include "optimiser.hpp"
 #include "compiler.hpp"
 #include "runtime.hpp"
 #include "utility/print.hpp"
@@ -8,7 +9,7 @@
 
 void print_usage()
 {
-    anzu::print("usage: anzu.exe <program_file> (lex|parse|com|debug|run)\n\n");
+    anzu::print("usage: anzu.exe <program_file> (lex|parse|com|debug|run) [-o]\n\n");
     anzu::print("The Anzu Programming Language\n\n");
     anzu::print("options:\n");
     anzu::print("    lex   - runs the lexer and prints the tokens\n");
@@ -16,6 +17,8 @@ void print_usage()
     anzu::print("    com   - runs the compiler and prints the bytecode\n");
     anzu::print("    debug - runs the program and prints each op code executed\n");
     anzu::print("    run   - runs the program\n");
+    anzu::print("flags:\n");
+    anzu::print("    -o    - optimises the AST before compiling\n");
 }
 
 int main(int argc, char** argv)
@@ -28,6 +31,14 @@ int main(int argc, char** argv)
     const auto file = std::string{argv[1]};
     const auto mode = std::string{argv[2]};
 
+    if (argc == 4) {
+        const auto flag = std::string{argv[3]};
+        if (flag != "-o") {
+            print_usage();
+            return 1;
+        }
+    }
+
     anzu::print("loading file '{}'\n", file);
 
     const auto tokens = anzu::lex(file);
@@ -36,7 +47,11 @@ int main(int argc, char** argv)
         return 0;
     }
 
-    const auto ast = anzu::parse(tokens);
+    auto ast = anzu::parse(tokens);
+    if (argc == 4) {
+        anzu::optimise_ast(*ast);
+    }
+
     if (mode == "parse") {
         print_node(*ast);
         return 0;

--- a/src/optimiser.cpp
+++ b/src/optimiser.cpp
@@ -1,0 +1,116 @@
+#include "optimiser.hpp"
+#include "object.hpp"
+
+#include <optional>
+
+namespace anzu {
+namespace {
+
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+
+auto evaluate_bin_op(
+    const anzu::object& lhs, const anzu::object& rhs, std::string_view op
+)
+    -> anzu::object
+{
+    if      (op == "+")  { return lhs + rhs; }
+    else if (op == "-")  { return lhs - rhs; }
+    else if (op == "*")  { return lhs * rhs; }
+    else if (op == "/")  { return lhs / rhs; }
+    else if (op == "%")  { return lhs % rhs; }
+    else if (op == "<")  { return lhs < rhs; }
+    else if (op == "<=") { return lhs <= rhs; }
+    else if (op == ">")  { return lhs > rhs; }
+    else if (op == ">=") { return lhs >= rhs; }
+    else if (op == "==") { return lhs == rhs; }
+    else if (op == "!=") { return lhs != rhs; }
+    else if (op == "||") { return lhs || rhs; }
+    else if (op == "&&") { return lhs && rhs; }
+    else {
+        anzu::print("syntax error: unknown binary operator: '{}'\n", op);
+        std::exit(1);
+    }
+}
+
+auto evaluate_const_expressions_recurse(const node_expr& expr) -> std::optional<anzu::object>
+{
+    using return_type = std::optional<anzu::object>;
+    return std::visit(overloaded {
+        [](const node_literal_expr& node) -> return_type {
+            return node.value;
+        },
+        [](const node_variable_expr& node) -> return_type {
+            return std::nullopt;
+        },
+        [](const node_function_call_expr& node) -> return_type {
+            return std::nullopt;
+        },
+        [](const node_bin_op_expr& node) -> return_type {
+            auto lhs = evaluate_const_expressions_recurse(*node.lhs);
+            auto rhs = evaluate_const_expressions_recurse(*node.rhs);
+            if (lhs.has_value() && rhs.has_value()) {
+                return evaluate_bin_op(lhs.value(), rhs.value(), node.op);
+            }
+            return std::nullopt;
+        }
+    }, expr);
+}
+
+auto evaluate_const_expressions(node_expr& expr) -> void
+{
+    auto obj = evaluate_const_expressions_recurse(expr);
+    if (obj.has_value()) {
+        expr.emplace<anzu::node_literal_expr>(obj.value());
+    }
+}
+
+auto evaluate_const_expressions(node_stmt& tree) -> void
+{
+    std::visit(overloaded {
+        [](node_sequence_stmt& stmt) {
+            for (auto& sub_stmt : stmt.sequence) {
+                evaluate_const_expressions(*sub_stmt);
+            }
+        },
+        [](node_while_stmt& stmt) {
+            evaluate_const_expressions(*stmt.condition);
+            evaluate_const_expressions(*stmt.body);
+        },
+        [](node_if_stmt& stmt) {
+            evaluate_const_expressions(*stmt.condition);
+            evaluate_const_expressions(*stmt.body);
+            if (stmt.else_body) {
+                evaluate_const_expressions(*stmt.else_body);
+            }
+        },
+        [](node_for_stmt& stmt) {
+            evaluate_const_expressions(*stmt.container);
+            evaluate_const_expressions(*stmt.body);
+        },
+        [](node_break_stmt&) {},
+        [](node_continue_stmt&) {},
+        [](node_assignment_stmt& stmt) {
+            evaluate_const_expressions(*stmt.expr);
+        },
+        [](node_function_def_stmt& stmt) {
+            evaluate_const_expressions(*stmt.body);
+        },
+        [](node_function_call_stmt& stmt) {
+            for (auto& arg : stmt.args) {
+                evaluate_const_expressions(*arg);
+            }
+        },
+        [](node_return_stmt& stmt) {
+            evaluate_const_expressions(*stmt.return_value);
+        }
+    }, tree);
+}
+
+}
+
+auto optimise_ast(node_stmt& tree) -> void
+{
+    evaluate_const_expressions(tree);
+}
+
+}

--- a/src/optimiser.hpp
+++ b/src/optimiser.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include "ast.hpp"
+
+namespace anzu {
+
+auto optimise_ast(node_stmt& tree) -> void;
+
+}


### PR DESCRIPTION
* Add a flag `-o` which enabled optimisations.
* This PR adds an optimisation for const expressions. After constructing the AST, it is scanned to see if any expressions are made up of just literals and binary ops. If any are found, it is evaluated and replaced with a single `op_push_const`. For example, the anzu program `x = 2 * (3 + 1) / 2 + 10`, produces the following op codes:

```
   0 - OP_PUSH_CONST(2)
   1 - OP_PUSH_CONST(3)
   2 - OP_PUSH_CONST(1)
   3 - OP_ADD
   4 - OP_MUL
   5 - OP_PUSH_CONST(2)
   6 - OP_DIV
   7 - OP_PUSH_CONST(10)
   8 - OP_ADD
   9 - OP_STORE(x)
```

With optimisations turn on, this becomes:

```
   0 - OP_PUSH_CONST(14)
   1 - OP_STORE(x)
```

This has the added benefit binary operations between incompatible types being caught at compile time rather than runtime.