### PR TITLE
Type Check Expressions

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,5 @@
 
-x = println("hello world", 2)
+t = 5
+y = (1 + t) * 4 - 4 + 56
+
+x = println("hello world")

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,5 @@
 
-
-function foo(t: str) -> int do
+function foo(t: any) -> int do
     return 2 * t
 end
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,7 +1,7 @@
 
-function foo(t: any) -> int do
+function foo(t: int) -> int do
     return 2 * t
 end
 
 println("hello")
-foo("hello")
+foo(5)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,8 @@
 
-t = 5
-y = (1 + t) * 4 - 4 + 56
 
-x = println("hello world")
+function foo(t: str) -> int do
+    return 2 * t
+end
+
+println("hello")
+foo("hello")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(anzu
                lexer.cpp
                token.cpp
                parser.cpp
+               typecheck.cpp
                optimiser.cpp
                compiler.cpp
                runtime.cpp

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -39,16 +39,18 @@ int main(int argc, char** argv)
         }
     }
 
-    anzu::print("loading file '{}'\n", file);
-
+    anzu::print("Loading file '{}'\n", file);
+    anzu::print("-> Lexing\n");
     const auto tokens = anzu::lex(file);
     if (mode == "lex") {
         print_tokens(tokens);
         return 0;
     }
 
+    anzu::print("-> Parsing\n");
     auto ast = anzu::parse(tokens);
     if (argc == 4) {
+        anzu::print("-> Optimising\n");
         anzu::optimise_ast(*ast);
     }
 
@@ -57,12 +59,14 @@ int main(int argc, char** argv)
         return 0;
     }
 
+    anzu::print("-> Compiling\n");
     const auto program = anzu::compile(ast);
     if (mode == "com") {
         anzu::print_program(program);
         return 0;
     }
 
+    anzu::print("-> Running\n\n");
     if (mode == "run") {
         anzu::run_program(program);
         return 0;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -30,13 +30,13 @@ auto print_node(const anzu::node_expr& root, int indent) -> void
     const auto spaces = std::string(4 * indent, ' ');
     std::visit(overloaded {
         [&](const node_literal_expr& node) {
-            anzu::print("{}Literal: {} ({})\n", spaces, node.value.to_repr(), root.type);
+            anzu::print("{}Literal: {}\n", spaces, node.value.to_repr());
         },
         [&](const node_variable_expr& node) {
-            anzu::print("{}Variable: {} ({})\n", spaces, node.name, root.type);
+            anzu::print("{}Variable: {}\n", spaces, node.name);
         },
         [&](const node_bin_op_expr& node) {
-            anzu::print("{}BinOp ({})\n", spaces, root.type);
+            anzu::print("{}BinOp:\n", spaces);
             anzu::print("{}- Op: {}\n", spaces, node.op);
             anzu::print("{}- Lhs:\n", spaces);
             print_node(*node.lhs, indent + 1);
@@ -44,7 +44,7 @@ auto print_node(const anzu::node_expr& root, int indent) -> void
             print_node(*node.rhs, indent + 1);
         },
         [&](const node_function_call_expr& node) {
-            anzu::print("{}FunctionCall (Expr) ({}): {}\n", spaces, node.function_name, root.type);
+            anzu::print("{}FunctionCall (Expr): {}\n", spaces, node.function_name);
             anzu::print("{}- Args:\n", spaces);
             for (const auto& arg : node.args) {
                 print_node(*arg, indent + 1);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -8,6 +8,14 @@ namespace {
 
 template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 
+auto verify(bool cond, std::string_view message)
+{
+    if (!cond) {
+        anzu::print(message);
+        std::exit(1);
+    }
+}
+
 template <typename T, typename Func>
 auto print_comma_separated(
     const std::vector<T>& values, Func&& formatter
@@ -36,11 +44,19 @@ auto print_node(const anzu::node_expr& root, int indent) -> void
             anzu::print("{}Variable: {}\n", spaces, node.name);
         },
         [&](const node_bin_op_expr& node) {
-            anzu::print("{}BinOp:\n", spaces);
+            anzu::print("{}BinOp\n", spaces);
             anzu::print("{}- Op: {}\n", spaces, node.op);
             anzu::print("{}- Lhs:\n", spaces);
+            if (!node.lhs) {
+                anzu::print("bin op has no lhs\n");
+                std::exit(1);
+            }
             print_node(*node.lhs, indent + 1);
             anzu::print("{}- Rhs:\n", spaces);
+            if (!node.rhs) {
+                anzu::print("bin op has no rhs\n");
+                std::exit(1);
+            }
             print_node(*node.rhs, indent + 1);
         },
         [&](const node_function_call_expr& node) {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -37,7 +37,7 @@ auto print_node(const anzu::node_expr& root, int indent) -> void
         },
         [&](const node_bin_op_expr& node) {
             anzu::print("{}BinOp\n", spaces);
-            anzu::print("{}- Op: {}\n", spaces, node.op);
+            anzu::print("{}- Op: {}\n", spaces, node.op.text);
             anzu::print("{}- Lhs:\n", spaces);
             if (!node.lhs) {
                 anzu::print("bin op has no lhs\n");

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -30,29 +30,21 @@ auto print_node(const anzu::node_expr& root, int indent) -> void
     const auto spaces = std::string(4 * indent, ' ');
     std::visit(overloaded {
         [&](const node_literal_expr& node) {
-            anzu::print("{}Literal: {}\n", spaces, node.value.to_repr());
+            anzu::print("{}Literal: {} ({})\n", spaces, node.value.to_repr(), root.type);
         },
         [&](const node_variable_expr& node) {
-            anzu::print("{}Variable: {}\n", spaces, node.name);
+            anzu::print("{}Variable: {} ({})\n", spaces, node.name, root.type);
         },
         [&](const node_bin_op_expr& node) {
-            anzu::print("{}BinOp\n", spaces);
+            anzu::print("{}BinOp ({})\n", spaces, root.type);
             anzu::print("{}- Op: {}\n", spaces, node.op);
             anzu::print("{}- Lhs:\n", spaces);
-            if (!node.lhs) {
-                anzu::print("bin op has no lhs\n");
-                std::exit(1);
-            }
             print_node(*node.lhs, indent + 1);
             anzu::print("{}- Rhs:\n", spaces);
-            if (!node.rhs) {
-                anzu::print("bin op has no rhs\n");
-                std::exit(1);
-            }
             print_node(*node.rhs, indent + 1);
         },
         [&](const node_function_call_expr& node) {
-            anzu::print("{}FunctionCall (Expr): {}\n", spaces, node.function_name);
+            anzu::print("{}FunctionCall (Expr) ({}): {}\n", spaces, node.function_name, root.type);
             anzu::print("{}- Args:\n", spaces);
             for (const auto& arg : node.args) {
                 print_node(*arg, indent + 1);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -8,14 +8,6 @@ namespace {
 
 template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 
-auto verify(bool cond, std::string_view message)
-{
-    if (!cond) {
-        anzu::print(message);
-        std::exit(1);
-    }
-}
-
 template <typename T, typename Func>
 auto print_comma_separated(
     const std::vector<T>& values, Func&& formatter

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -44,7 +44,6 @@ struct node_expr : std::variant<
     node_bin_op_expr,
     node_function_call_expr>
 {
-    std::string type = std::string{tk_any};
 };
 
 struct node_stmt;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2,6 +2,7 @@
 #include "object.hpp"
 #include "functions.hpp"
 #include "vocabulary.hpp"
+#include "token.hpp"
 
 #include <variant>
 #include <vector>
@@ -27,6 +28,8 @@ struct node_bin_op_expr
     std::string op; // TODO: make into enum
     node_expr_ptr lhs;
     node_expr_ptr rhs;
+
+    anzu::token op_token; // For debugging
 };
 
 struct node_function_call_expr

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "object.hpp"
 #include "functions.hpp"
+#include "vocabulary.hpp"
 
 #include <variant>
 #include <vector>
@@ -40,6 +41,7 @@ struct node_expr : std::variant<
     node_bin_op_expr,
     node_function_call_expr>
 {
+    std::string_view type = tk_any;
 };
 
 struct node_stmt;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -24,11 +24,9 @@ struct node_variable_expr
 
 struct node_bin_op_expr
 {
-    std::string op; // TODO: make into enum
+    anzu::token   op; // Keep as token for debugging info
     node_expr_ptr lhs;
     node_expr_ptr rhs;
-
-    anzu::token op_token; // For debugging
 };
 
 struct node_function_call_expr

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -41,7 +41,7 @@ struct node_expr : std::variant<
     node_bin_op_expr,
     node_function_call_expr>
 {
-    std::string_view type = tk_any;
+    std::string type = std::string{tk_any};
 };
 
 struct node_stmt;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include "object.hpp"
 #include "functions.hpp"
-#include "vocabulary.hpp"
 #include "token.hpp"
 
 #include <variant>

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -99,21 +99,21 @@ void compile_node(const node_bin_op_expr& node, compiler_context& ctx)
 {
     compile_node(*node.lhs, ctx);
     compile_node(*node.rhs, ctx);
-    if      (node.op == "+")  { ctx.program.emplace_back(anzu::op_add{}); }
-    else if (node.op == "-")  { ctx.program.emplace_back(anzu::op_sub{}); }
-    else if (node.op == "*")  { ctx.program.emplace_back(anzu::op_mul{}); }
-    else if (node.op == "/")  { ctx.program.emplace_back(anzu::op_div{}); }
-    else if (node.op == "%")  { ctx.program.emplace_back(anzu::op_mod{}); }
-    else if (node.op == "<")  { ctx.program.emplace_back(anzu::op_lt{}); }
-    else if (node.op == "<=") { ctx.program.emplace_back(anzu::op_le{}); }
-    else if (node.op == ">")  { ctx.program.emplace_back(anzu::op_gt{}); }
-    else if (node.op == ">=") { ctx.program.emplace_back(anzu::op_ge{}); }
-    else if (node.op == "==") { ctx.program.emplace_back(anzu::op_eq{}); }
-    else if (node.op == "!=") { ctx.program.emplace_back(anzu::op_ne{}); }
-    else if (node.op == "||") { ctx.program.emplace_back(anzu::op_or{}); }
-    else if (node.op == "&&") { ctx.program.emplace_back(anzu::op_and{}); }
+    if      (node.op.text == "+")  { ctx.program.emplace_back(anzu::op_add{}); }
+    else if (node.op.text == "-")  { ctx.program.emplace_back(anzu::op_sub{}); }
+    else if (node.op.text == "*")  { ctx.program.emplace_back(anzu::op_mul{}); }
+    else if (node.op.text == "/")  { ctx.program.emplace_back(anzu::op_div{}); }
+    else if (node.op.text == "%")  { ctx.program.emplace_back(anzu::op_mod{}); }
+    else if (node.op.text == "<")  { ctx.program.emplace_back(anzu::op_lt{}); }
+    else if (node.op.text == "<=") { ctx.program.emplace_back(anzu::op_le{}); }
+    else if (node.op.text == ">")  { ctx.program.emplace_back(anzu::op_gt{}); }
+    else if (node.op.text == ">=") { ctx.program.emplace_back(anzu::op_ge{}); }
+    else if (node.op.text == "==") { ctx.program.emplace_back(anzu::op_eq{}); }
+    else if (node.op.text == "!=") { ctx.program.emplace_back(anzu::op_ne{}); }
+    else if (node.op.text == "||") { ctx.program.emplace_back(anzu::op_or{}); }
+    else if (node.op.text == "&&") { ctx.program.emplace_back(anzu::op_and{}); }
     else {
-        anzu::print("syntax error: unknown binary operator: '{}'\n", node.op);
+        anzu::print("syntax error: unknown binary operator: '{}'\n", node.op.text);
         std::exit(1);
     }
 }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -10,19 +10,6 @@
 namespace anzu {
 namespace {
 
-auto push_null(anzu::runtime_context& ctx) -> void
-{
-    ctx.push_value(anzu::null_object());
-}
-
-auto verify(bool condition, std::string_view msg) -> void
-{
-    if (!condition) {
-        anzu::print(msg);
-        std::exit(1);
-    }
-}
-
 auto builtin_list_push(std::span<const object> args) -> object
 {
     auto& list = args[0].as<object_list>();

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -30,7 +30,7 @@ template <typename... Args>
 [[noreturn]] void lexer_error(int lineno, int col, std::string_view msg, Args&&... args)
 {
     const auto formatted_msg = std::format(msg, std::forward<Args>(args)...);
-    anzu::print("[Lexer] ({}:{}) ERROR: {}\n", lineno, col, formatted_msg);
+    anzu::print("[ERROR] ({}:{}) {}\n", lineno, col, formatted_msg);
     std::exit(1);
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -12,7 +12,7 @@ template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 
 auto type_error(const anzu::object& lhs, const anzu::object& rhs, std::string_view op) -> void
 {
-    anzu::print("type error: cannot evaluate {} {} {}\n", lhs.to_repr(), rhs.to_repr(), op);
+    anzu::print("type error: cannot evaluate {} {} {}\n", lhs.to_repr(), op, rhs.to_repr());
     std::exit(1);
 }
 

--- a/src/optimiser.cpp
+++ b/src/optimiser.cpp
@@ -49,7 +49,7 @@ auto evaluate_const_expressions_recurse(node_expr& expr) -> std::optional<anzu::
             auto lhs = evaluate_const_expressions_recurse(*node.lhs);
             auto rhs = evaluate_const_expressions_recurse(*node.rhs);
             if (lhs.has_value() && rhs.has_value()) {
-                auto val = evaluate_bin_op(lhs.value(), rhs.value(), node.op);
+                auto val = evaluate_bin_op(lhs.value(), rhs.value(), node.op.text);
                 expr.emplace<anzu::node_literal_expr>(val);
                 return val;
             }

--- a/src/optimiser.cpp
+++ b/src/optimiser.cpp
@@ -32,7 +32,7 @@ auto evaluate_bin_op(
     }
 }
 
-auto evaluate_const_expressions_recurse(const node_expr& expr) -> std::optional<anzu::object>
+auto evaluate_const_expressions_recurse(node_expr& expr) -> std::optional<anzu::object>
 {
     using return_type = std::optional<anzu::object>;
     return std::visit(overloaded {
@@ -45,11 +45,13 @@ auto evaluate_const_expressions_recurse(const node_expr& expr) -> std::optional<
         [](const node_function_call_expr& node) -> return_type {
             return std::nullopt;
         },
-        [](const node_bin_op_expr& node) -> return_type {
+        [&](const node_bin_op_expr& node) -> return_type {
             auto lhs = evaluate_const_expressions_recurse(*node.lhs);
             auto rhs = evaluate_const_expressions_recurse(*node.rhs);
             if (lhs.has_value() && rhs.has_value()) {
-                return evaluate_bin_op(lhs.value(), rhs.value(), node.op);
+                auto val = evaluate_bin_op(lhs.value(), rhs.value(), node.op);
+                expr.emplace<anzu::node_literal_expr>(val);
+                return val;
             }
             return std::nullopt;
         }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -343,7 +343,7 @@ auto parse_function_call(parser_context& ctx) -> std::unique_ptr<NodeVariant>
     for (std::size_t idx = 0; idx != sig.args.size(); ++idx) {
         const auto& expected = sig.args.at(idx).type;
         const auto& actual = type_of_expr(ctx, *out.args.at(idx));
-        if (expected != tk_any && expected != actual) {
+        if (expected != tk_any && actual != tk_any && expected != actual) {
             parser_error(
                 token, "invalid function call, arg {} expects type {}, got {}\n", idx, expected, actual
             );

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -160,15 +160,13 @@ auto parse_compound_factor(parser_context& ctx, std::int64_t level) -> node_expr
 
     auto left = parse_compound_factor(ctx, level - 1);
     while (ctx.tokens.valid() && bin_ops_table[level].contains(ctx.tokens.curr().text)) {
-        auto op_token = ctx.tokens.consume();
-        auto op = op_token.text;
+        auto op = ctx.tokens.consume();
 
         auto node = std::make_unique<anzu::node_expr>();
         auto& expr = node->emplace<anzu::node_bin_op_expr>();
         expr.lhs = std::move(left);
         expr.op = op;
         expr.rhs = parse_compound_factor(ctx, level - 1);
-        expr.op_token = op_token;
 
         left = std::move(node);
     }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -2,7 +2,18 @@
 #include "token.hpp"
 #include "ast.hpp"
 
+#include <unordered_map>
+#include <string>
+#include <stack>
+
 namespace anzu {
+
+struct parser_context
+{
+    anzu::tokenstream tokens;
+    std::unordered_map<std::string, function_signature> functions;
+    std::stack<std::unordered_map<std::string, std::string>> object_types;
+};
 
 auto parse(const std::vector<anzu::token>& tokens) -> anzu::node_stmt_ptr;
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -1,5 +1,6 @@
 #include "typecheck.hpp"
 #include "parser.hpp"
+#include "vocabulary.hpp"
 
 namespace anzu {
 namespace {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -1,0 +1,120 @@
+#include "typecheck.hpp"
+#include "parser.hpp"
+
+namespace anzu {
+namespace {
+
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+
+template <typename... Args>
+[[noreturn]] void type_error(const token& tok, std::string_view msg, Args&&... args)
+{
+    const auto formatted_msg = std::format(msg, std::forward<Args>(args)...);
+    anzu::print("[ERROR] ({}:{}) {}\n", tok.line, tok.col, formatted_msg);
+    std::exit(1);
+}
+
+auto type_of(const anzu::object& object) -> std::string
+{
+    if (object.is<int>()) {
+        return std::string{tk_int};
+    }
+    if (object.is<bool>()) {
+        return std::string{tk_bool};
+    }
+    if (object.is<std::string>()) {
+        return std::string{tk_str};
+    }
+    if (object.is<object_list>()) {
+        return std::string{tk_list};
+    }
+    if (object.is<object_null>()) {
+        return std::string{tk_null_type};
+    }
+    return std::string{tk_any};
+}
+
+auto type_of_bin_op(
+    std::string_view lhs, std::string_view rhs, const token& op_token
+)
+    -> std::string
+{
+    const auto op = op_token.text;
+    const auto invalid_expr = [=]() {
+        type_error(op_token, "could not evaluate '{} {} {}'", lhs, op, rhs);
+    };
+
+    if (lhs == tk_any || rhs == tk_any) {
+        return std::string{tk_any};
+    }
+
+    if (lhs != rhs) {
+        invalid_expr();
+    }
+
+    if (lhs == tk_list || lhs == tk_null_type) { // No support for having these in binary ops.
+        invalid_expr();
+    }
+
+    if (lhs == tk_str) {
+        if (op == tk_add) { // String concatenation
+            return std::string{tk_str};
+        }
+        invalid_expr();
+    }
+
+    if (lhs == tk_bool) {
+        if (op == tk_or || op == tk_and) {
+            return std::string{tk_bool};
+        }
+        invalid_expr();
+    }
+
+    if (is_comparison(op)) {
+        return std::string{tk_bool};
+    }
+    return std::string{tk_int};
+}
+
+}
+
+auto fetch_function_signature(
+    const parser_context& ctx, const std::string& function_name
+)
+    -> function_signature
+{
+    if (auto it = ctx.functions.find(function_name); it != ctx.functions.end()) {
+        return it->second;
+    }
+
+    if (anzu::is_builtin(function_name)) {
+        return anzu::fetch_builtin(function_name).sig;
+    }
+
+    type_error(ctx.tokens.curr(), "could not find function '{}'", function_name);
+}
+
+auto type_of_expr(const parser_context& ctx, const node_expr& expr) -> std::string
+{
+    return std::visit(overloaded {
+        [&](const node_literal_expr& node) {
+            return type_of(node.value);
+        },
+        [&](const node_variable_expr& node) {
+            return ctx.object_types.top().at(node.name);
+        },
+        [&](const node_function_call_expr& node) {
+            const auto& func_def = fetch_function_signature(ctx, node.function_name);
+            return func_def.return_type;
+        },
+        [&](const node_bin_op_expr& node) {
+            return type_of_bin_op(
+                type_of_expr(ctx, *node.lhs),
+                type_of_expr(ctx, *node.rhs),
+                node.op_token
+            );
+        }
+    }, expr);
+};
+
+}

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -112,7 +112,7 @@ auto type_of_expr(const parser_context& ctx, const node_expr& expr) -> std::stri
             return type_of_bin_op(
                 type_of_expr(ctx, *node.lhs),
                 type_of_expr(ctx, *node.rhs),
-                node.op_token
+                node.op
             );
         }
     }, expr);

--- a/src/typecheck.hpp
+++ b/src/typecheck.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include "ast.hpp"
+#include "functions.hpp"
+
+namespace anzu {
+
+struct parser_context;
+
+auto fetch_function_signature(
+    const parser_context& ctx, const std::string& function_name
+) -> function_signature;
+
+// Evaluates a given expression node with the given context. Produces an error if the
+// expression is invalid, otherwise the returns the type of the expression.
+auto type_of_expr(const parser_context& ctx, const node_expr& node) -> std::string;
+
+}

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -34,6 +34,14 @@ auto is_symbol(std::string_view token) -> bool
     return tokens.contains(token);
 }
 
+auto is_comparison(sv token) -> bool
+{
+    static const std::unordered_set<std::string_view> tokens = {
+        tk_lt, tk_le, tk_gt, tk_ge, tk_eq, tk_ne
+    };
+    return tokens.contains(token);
+}
+
 auto is_type(std::string_view token) -> bool
 {
     static const std::unordered_set<std::string_view> tokens = {

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -54,9 +54,10 @@ constexpr auto tk_rparen    = sv{")"};
 constexpr auto tk_sub       = sv{"-"};
 constexpr auto tk_rarrow    = sv{"->"};
 
-auto is_keyword  (sv token) -> bool;
-auto is_sentinel (sv token) -> bool;
-auto is_symbol   (sv token) -> bool;
-auto is_type     (sv token) -> bool;
+auto is_keyword    (sv token) -> bool;
+auto is_sentinel   (sv token) -> bool;
+auto is_symbol     (sv token) -> bool;
+auto is_comparison (sv token) -> bool;
+auto is_type       (sv token) -> bool;
 
 }


### PR DESCRIPTION
* Add `typecheck.hpp`, with functionality for evaluating the type of an expression.
* When parsing an expression, the type is also evaluated, which will cause a bad exit if there is a type error.
* Types of variables are stored in the `parser_context`. New symbols are created via assignment statements, for loops and as function arguments, and all of these add type info into the context.
* At function call sites, the types of the expressions passed in are checked with the function signature.
* Returns values are currently not checked and require more work.
* This is a bit of a mess and needs a cleanup.
* Fix a bug in the optimiser where sub expressions that were known at compile time would not get replaced. Now, whenever a bin op with two constant children are found, it is substituted in place.
* Removed some now-unused verification functions from `functions.cpp`.
* `node_bin_op_expr` now contains the token for the op code to help with debugging.