### PR TITLE
Cleanup Parser

### DIFF
--- a/examples/euler.az
+++ b/examples/euler.az
@@ -3,13 +3,13 @@
 count = 0
 i = 0
 
-while i < 1000 do
+while i < 1000 {
     if i % 3 == 0 {
         count = count + i
     } else if i % 5 == 0 {
         count = count + i
     }
     i = i + 1
-end
+}
 
 println(count)

--- a/examples/euler.az
+++ b/examples/euler.az
@@ -4,11 +4,11 @@ count = 0
 i = 0
 
 while i < 1000 do
-    if i % 3 == 0 do
+    if i % 3 == 0 {
         count = count + i
-    elif i % 5 == 0 do
+    } else if i % 5 == 0 {
         count = count + i
-    end
+    }
     i = i + 1
 end
 

--- a/examples/euler.az
+++ b/examples/euler.az
@@ -12,4 +12,4 @@ while i < 1000 do
     i = i + 1
 end
 
-count print
+println(count)

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -20,32 +20,32 @@ println("")
 
 # if-statements
 # basic if
-if true do
+if true {
     print("in true block\n")
-end
+}
 
 # if with else
-if 2 < 1 do
+if 2 < 1 {
     # never entered
-else
+} else {
     println("in else block")
-end
+}
 
 # if with elif
-if 1 > 3 do
+if 1 > 3 {
     # not entered
-elif 2 == 1 + 1 do  # also testing an expression
+} else if 2 == 1 + 1 {  # also testing an expression
     println("i just evaluated 2 == 1 + 1")
-end
+}
 
 # if with elif and else
-if false do
+if false {
     # nah
-elif false do
+} else if false {
     # also nah
-else
+} else {
     println("in else after skipping the if and elif")
-end
+}
 
 # simple expressions
 println(2 + 2)
@@ -60,11 +60,11 @@ function adder(a: int, b: int, c: int) -> int do
 end
 
 print("Does adder(1, 2, 3) == 6? ")
-if to_bool(adder(1, 2, 3) == 6) do
+if to_bool(adder(1, 2, 3) == 6) {
     println("yes")
-else
+} else {
     println("no")
-end
+}
 
 # printing null and showing functions with no return value return null
 x = null
@@ -87,12 +87,12 @@ println("list test, 3 elements with a break after the second, should only see tw
 println("additionally, there is a while loop with its own break statement which should be fine")
 for x in [1, 2, 3] do
     println(x)
-    if to_int(x) == 2 do
+    if to_int(x) == 2 {
         while true do
             break # To make sure that this break is not affected by the for
         end 
         break
-    end
+    }
 end
 
 new_list = [[1, 2, 3, 4]]

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -11,11 +11,11 @@ e = a
 
 # while-statements
 idx = 0
-while idx < 10 do
+while idx < 10 {
     print(idx)
     print(", ")
     idx = idx + 1
-end
+}
 println("")
 
 # if-statements
@@ -88,9 +88,9 @@ println("additionally, there is a while loop with its own break statement which 
 for x in [1, 2, 3] do
     println(x)
     if to_int(x) == 2 {
-        while true do
+        while true {
             break # To make sure that this break is not affected by the for
-        end 
+        }
         break
     }
 end

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -55,9 +55,10 @@ println(true && false)
 println(true || false)
 
 # functions
-function adder(a: int, b: int, c: int) -> int do
+function adder(a: int, b: int, c: int) -> int
+{
     return a + b + c
-end
+}
 
 print("Does adder(1, 2, 3) == 6? ")
 if to_bool(adder(1, 2, 3) == 6) {
@@ -72,14 +73,15 @@ y = println(x)
 println(y)
 
 # Nested functions
-function outer(a: int, b: int) -> int do
-    
-    function nested(c: int) -> int do
+function outer(a: int, b: int) -> int
+{   
+    function nested(c: int) -> int
+    {
         return c
-    end
+    }
 
     return nested(a + b)
-end
+}
 println(outer(1, 2))
 
 # For loops

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -85,7 +85,7 @@ println(outer(1, 2))
 # For loops
 println("list test, 3 elements with a break after the second, should only see two")
 println("additionally, there is a while loop with its own break statement which should be fine")
-for x in [1, 2, 3] do
+for x in [1, 2, 3] {
     println(x)
     if to_int(x) == 2 {
         while true {
@@ -93,11 +93,11 @@ for x in [1, 2, 3] do
         }
         break
     }
-end
+}
 
 new_list = [[1, 2, 3, 4]]
-for l in new_list do
+for l in new_list {
     list_push(l, 5)
-end
+}
 println("new_list should have 5 elements:")
 println(new_list)

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -71,6 +71,17 @@ x = null
 y = println(x)
 println(y)
 
+# Nested functions
+function outer(a: int, b: int) -> int do
+    
+    function nested(c: int) -> int do
+        return c
+    end
+
+    return nested(a + b)
+end
+println(outer(1, 2))
+
 # For loops
 println("list test, 3 elements with a break after the second, should only see two")
 println("additionally, there is a while loop with its own break statement which should be fine")

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -55,12 +55,12 @@ println(true && false)
 println(true || false)
 
 # functions
-function adder(a, b, c) do
+function adder(a: int, b: int, c: int) -> int do
     return a + b + c
 end
 
 print("Does adder(1, 2, 3) == 6? ")
-if adder(1, 2, 3) == 6 do
+if to_bool(adder(1, 2, 3) == 6) do
     println("yes")
 else
     println("no")
@@ -76,7 +76,7 @@ println("list test, 3 elements with a break after the second, should only see tw
 println("additionally, there is a while loop with its own break statement which should be fine")
 for x in [1, 2, 3] do
     println(x)
-    if x == 2 do
+    if to_int(x) == 2 do
         while true do
             break # To make sure that this break is not affected by the for
         end 

--- a/examples/recursion.az
+++ b/examples/recursion.az
@@ -11,7 +11,7 @@ function fibb(n: int) -> int do
 end
 
 i = 0
-while i < 10 do
+while i < 10 {
     println(fibb(i))
     i = i + 1
-end
+}

--- a/examples/recursion.az
+++ b/examples/recursion.az
@@ -1,11 +1,11 @@
 # fibbonacci to demonstrate functions and recursion
 
 function fibb(n: int) -> int do
-    if n == 0 do
+    if n == 0 {
         return 0
-    elif n == 1 do
+    } else if n == 1 {
         return 1
-    end
+    }
 
     return fibb(n - 1) + fibb(n - 2)
 end

--- a/examples/recursion.az
+++ b/examples/recursion.az
@@ -1,6 +1,6 @@
 # fibbonacci to demonstrate functions and recursion
 
-function fibb(n) do
+function fibb(n: int) -> int do
     if n == 0 do
         return 0
     elif n == 1 do

--- a/examples/recursion.az
+++ b/examples/recursion.az
@@ -11,8 +11,6 @@ function fibb(n: int) -> int
     return fibb(n - 1) + fibb(n - 2)
 }
 
-i = 0
-while i < 10 {
+for i in range(10) {
     println(fibb(i))
-    i = i + 1
 }

--- a/examples/recursion.az
+++ b/examples/recursion.az
@@ -1,6 +1,7 @@
 # fibbonacci to demonstrate functions and recursion
 
-function fibb(n: int) -> int do
+function fibb(n: int) -> int
+{
     if n == 0 {
         return 0
     } else if n == 1 {
@@ -8,7 +9,7 @@ function fibb(n: int) -> int do
     }
 
     return fibb(n - 1) + fibb(n - 2)
-end
+}
 
 i = 0
 while i < 10 {

--- a/examples/test.az
+++ b/examples/test.az
@@ -8,6 +8,6 @@ function foo(a: int, b: int) -> int do
     return nested(a + b)
 end
 
-x = nested(2, 3)
+x = foo(2, 3)
 
 println(x)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,10 +1,7 @@
 
-x = to_int(input())
-
-if x == 2 {
-    println("equals two")
-} else if x == 3 {
-    println("equals three")
-} else {
-    println("does not equal two or three")
+function foo(a: int, b: int) -> int
+{
+    return "hello"
 }
+
+println(foo(a, b))

--- a/examples/test.az
+++ b/examples/test.az
@@ -5,6 +5,9 @@ function foo(a: int, b: int) -> int do
         return c
     end
 
+    x = nested(a + b)
+    println(typeof(x))
+
     return nested(a + b)
 end
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,7 +1,8 @@
 
-function foo(t: int) -> int do
-    return 2 * t
+if input() == "2" do
+    function foo(a, b) do
+        return a + b
+    end
 end
 
-println("hello")
-foo(5)
+println(foo(2, 5))

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,13 @@
 
-if input() == "2" do
-    function foo(a, b) do
-        return a + b
+function foo(a: int, b: int) -> int do
+    
+    function nested(c: int) -> int do
+        return c
     end
+
+    return nested(a + b)
 end
 
-println(foo(2, 5))
+x = nested(2, 3)
+
+println(x)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,16 +1,10 @@
 
-function foo(a: int, b: int) -> int do
-    
-    function nested(c: int) -> int do
-        return c
-    end
+x = to_int(input())
 
-    x = nested(a + b)
-    println(typeof(x))
-
-    return nested(a + b)
-end
-
-x = foo(2, 3)
-
-println(x)
+if x == 2 {
+    println("equals two")
+} else if x == 3 {
+    println("equals three")
+} else {
+    println("does not equal two or three")
+}

--- a/grammar.txt
+++ b/grammar.txt
@@ -1,9 +1,5 @@
 program:
-  | statement_list
-
-statement_list:
-  | statement
-  | statement statement_list
+  | [statement]*
 
 literal:
   | int_literal
@@ -40,10 +36,10 @@ factor:
   | '(' expression ')'
 
 statement:
-  | 'function' function_def_body
-  | 'while' while_body
-  | 'if' if_body
-  | 'for' for_body
+  | function-def-stmt
+  | while-stmt
+  | if-stmt
+  | for-stmt
   | 'return' [expression]
   | 'break'
   | 'continue'
@@ -57,22 +53,17 @@ function_identifier:
 builtin_identifier:
   | string_literal
 
-function_signature:
-  | name ',' function_signature
-  | name
+function-def-stmt:
+  | 'function' '(' function-sig ')' ['->' type] statement
 
-function_def_body:
-  | '(' function_signature ')' 'do' statement_list 'end'
-  | '(' function_signature ')' 'do' 'end'
+function-sig:
+  | name [':' type] [',' name [':' type]]*
 
-while_body:
-  | statement_list 'do' statement_list 'end'
-  | statement_list 'do' 'end'
+while-stmt:
+  | 'while' expression statement
 
-if_body:
-  | statement_list 'do' statement_list 'elif' if_body
-  | statement_list 'do' statement_list 'end'
+if-stmt:
+  | 'if' expression statement 'else' statement
 
-for_body:
-  | variable_name 'in' list_literal 'do' statement_list 'end'
-  | variable_name 'in' variable_name 'do' statement_list 'end'
+for-stmt:
+  | 'for' variable_name 'in' expression statement

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -178,19 +178,7 @@ void compile_node(const node_if_stmt& node, compiler_context& ctx)
 
 void compile_node(const node_for_stmt& node, compiler_context& ctx)
 {
-    // Push the container to the stack
-    if (std::holds_alternative<anzu::node_variable_expr>(*node.container)) {
-        const auto& cont = std::get<anzu::node_variable_expr>(*node.container).name;
-        ctx.program.emplace_back(anzu::op_push_var{ .name=cont });
-    }
-    else if (std::holds_alternative<anzu::node_literal_expr>(*node.container)) {
-        const auto& cont = std::get<anzu::node_literal_expr>(*node.container).value;
-        ctx.program.emplace_back(anzu::op_push_const{ .value=cont });
-    }
-    else {
-        anzu::print("unknown container for a for-loop\n");
-        std::exit(1);
-    }
+    compile_node(*node.container, ctx);
 
     // Push the container size to the stack
     ctx.program.emplace_back(anzu::op_copy_index{0});

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -189,7 +189,7 @@ auto construct_builtin_map() -> std::unordered_map<std::string, builtin>
     });
 
     builtins.emplace("input", builtin{
-        .ptr = builtin_println,
+        .ptr = builtin_input,
         .sig = {
             .args = {},
             .return_type = "str"

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1,6 +1,7 @@
 #include "functions.hpp"
 #include "object.hpp"
 #include "runtime.hpp"
+#include "typecheck.hpp"
 #include "utility/print.hpp"
 
 #include <unordered_map>
@@ -81,6 +82,12 @@ auto builtin_input(std::span<const object> args) -> object
     std::string in;
     std::cin >> in;
     return in;
+}
+
+auto builtin_typeof(std::span<const object> args) -> object
+{
+    const auto& obj = args[0];
+    return type_of(obj);
 }
 
 }
@@ -185,6 +192,16 @@ auto construct_builtin_map() -> std::unordered_map<std::string, builtin>
         .ptr = builtin_println,
         .sig = {
             .args = {},
+            .return_type = "str"
+        }
+    });
+
+    builtins.emplace("typeof", builtin{
+        .ptr = builtin_typeof,
+        .sig = {
+            .args = {
+                { .name = "obj", .type = "any" }
+            },
             .return_type = "str"
         }
     });

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -90,6 +90,16 @@ auto builtin_typeof(std::span<const object> args) -> object
     return type_of(obj);
 }
 
+auto builtin_range(std::span<const object> args) -> object
+{
+    const auto& max = args[0].as<int>();
+    auto list = std::make_shared<std::vector<object>>();
+    for (int i = 0; i != max; ++i) {
+        list->push_back(i);
+    }
+    return list;
+}
+
 }
 
 auto construct_builtin_map() -> std::unordered_map<std::string, builtin>
@@ -203,6 +213,16 @@ auto construct_builtin_map() -> std::unordered_map<std::string, builtin>
                 { .name = "obj", .type = "any" }
             },
             .return_type = "str"
+        }
+    });
+
+    builtins.emplace("range", builtin{
+        .ptr = builtin_range,
+        .sig = {
+            .args = {
+                { .name = "max", .type = "int" }
+            },
+            .return_type = "list"
         }
     });
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -95,22 +95,24 @@ auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const i
         else if (const auto symbol = try_parse_symbol(iter); symbol.has_value()) {
             push_token(*symbol, col, token_type::symbol);
         }
-
-        const auto token = parse_token(iter);
-        if (!token.empty()) {
-            if (anzu::is_keyword(token)) {
-                push_token(token, col, token_type::keyword);
-            }
-            else if (anzu::is_int(token)) {
-                push_token(token, col, token_type::number);
-            }
-            else if (!std::isdigit(token[0])) {
-                push_token(token, col, token_type::name);
-            }
-            else {
-                lexer_error(lineno, col, "invalid name '{}' - names cannot start with a digit", token);
+        else {
+            const auto token = parse_token(iter);
+            if (!token.empty()) {
+                if (anzu::is_keyword(token)) {
+                    push_token(token, col, token_type::keyword);
+                }
+                else if (anzu::is_int(token)) {
+                    push_token(token, col, token_type::number);
+                }
+                else if (!std::isdigit(token[0])) {
+                    push_token(token, col, token_type::name);
+                }
+                else {
+                    lexer_error(lineno, col, "invalid name '{}' - names cannot start with a digit", token);
+                }
             }
         }
+
     }
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -322,6 +322,10 @@ auto parse_function_def(parser_context& ctx) -> node_stmt_ptr
     ctx.scopes.top().functions[stmt.name] = stmt.sig;
     
     ctx.scopes.emplace();
+
+    // Add the function to its own scope to allow for recursion
+    ctx.scopes.top().functions[stmt.name] = stmt.sig;
+
     for (const auto& arg : stmt.sig.args) {
         add_variable(ctx, arg.name, arg.type);
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -425,10 +425,10 @@ auto parse_statement(parser_context& ctx) -> node_stmt_ptr
         node->emplace<anzu::node_continue_stmt>();
         return node;
     }
-    else if (tokens.peek_next(tk_assign)) {
+    else if (tokens.peek_next(tk_assign)) { // <name> '='
         return parse_assigment_stmt(ctx);
     }
-    else if (tokens.peek_next(tk_lparen)) {
+    else if (tokens.peek_next(tk_lparen)) { // <name> '('
         return parse_function_call_stmt(ctx);
     }
     else {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -53,12 +53,6 @@ auto comma_separated_list(
     ctx.tokens.consume_only(sentinel);
 }
 
-auto is_function(const parser_context& ctx) -> bool
-{
-    const auto& name = ctx.tokens.curr().text;
-    return ctx.current_scope().functions.contains(name) || is_builtin(name);
-}
-
 auto check_argc(
     const token& tok, std::string_view func, std::int64_t expected, std::int64_t actual
 )
@@ -152,7 +146,7 @@ auto parse_single_factor(parser_context& ctx) -> node_expr_ptr
         expr.value = *factor;
         return node;
     }
-    else if (is_function(ctx)) {
+    else if (tokens.peek_next(tk_lparen)) {
         return parse_function_call_expr(ctx);
     }
     else if (tokens.curr().type != token_type::name) {
@@ -431,10 +425,10 @@ auto parse_statement(parser_context& ctx) -> node_stmt_ptr
         node->emplace<anzu::node_continue_stmt>();
         return node;
     }
-    else if (tokens.has_next() && tokens.next().text == tk_assign) {
+    else if (tokens.peek_next(tk_assign)) {
         return parse_assigment_stmt(ctx);
     }
-    else if (is_function(ctx)) {
+    else if (tokens.peek_next(tk_lparen)) {
         return parse_function_call_stmt(ctx);
     }
     else {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -3,7 +3,6 @@
 #include "typecheck.hpp"
 #include "vocabulary.hpp"
 
-#include <optional>
 #include <unordered_set>
 #include <string_view>
 #include <vector>
@@ -225,15 +224,16 @@ auto parse_return_stmt(parser_context& ctx) -> node_stmt_ptr
     auto& stmt = node->emplace<anzu::node_return_stmt>();
     
     ctx.tokens.consume_only(tk_return);
+
+    // TODO: Make return statements mandatory and check the expr type
+    // against the function signature
     if (!anzu::is_sentinel(ctx.tokens.curr().text)) {
         auto expr = parse_expression(ctx);
         auto type = type_of_expr(ctx, *expr);
         stmt.return_value = std::move(expr);
-        // TODO: Check type against function signature.
     } else {
         stmt.return_value = std::make_unique<anzu::node_expr>();
         stmt.return_value->emplace<anzu::node_literal_expr>().value = anzu::null_object();
-        // TODO: Disallow, always require a return statement.
     }
     return node;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -186,21 +186,23 @@ auto parse_statement_list(parser_context& ctx) -> node_stmt_ptr
     return node;
 }
 
-auto parse_while_body(parser_context& ctx) -> node_stmt_ptr
+auto parse_while_stmt(parser_context& ctx) -> node_stmt_ptr
 {
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_while_stmt>();
+
+    ctx.tokens.consume_only(tk_while);
     stmt.condition = parse_expression_type_checked(ctx, tk_bool);
-    ctx.tokens.consume_only(tk_do);
-    stmt.body = parse_statement_list(ctx);
-    ctx.tokens.consume_only(tk_end);
+    stmt.body = parse_statement(ctx);
     return node;
 }
 
-auto parse_if_body(parser_context& ctx) -> node_stmt_ptr
+auto parse_if_stmt(parser_context& ctx) -> node_stmt_ptr
 {
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_if_stmt>();
+
+    ctx.tokens.consume_only(tk_if);
     stmt.condition = parse_expression_type_checked(ctx, tk_bool);
     stmt.body = parse_statement(ctx);
     if (ctx.tokens.consume_maybe(tk_else)) {
@@ -338,11 +340,11 @@ auto parse_statement(parser_context& ctx) -> node_stmt_ptr
     else if (tokens.consume_maybe(tk_return)) {
         return parse_return(ctx);
     }
-    else if (tokens.consume_maybe(tk_while)) {
-        return parse_while_body(ctx);
+    else if (tokens.peek(tk_while)) {
+        return parse_while_stmt(ctx);
     }
-    else if (tokens.consume_maybe(tk_if)) {
-        return parse_if_body(ctx);
+    else if (tokens.peek(tk_if)) {
+        return parse_if_stmt(ctx);
     }
     else if (tokens.consume_maybe(tk_for)) {
         return parse_for_body(ctx);

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -8,11 +8,20 @@
 
 namespace anzu {
 
+// A new scope is currently only entered when parsing a function body.
+struct scope
+{
+    std::unordered_map<std::string, function_signature> functions;
+    std::unordered_map<std::string, std::string>        variables;
+};
+
 struct parser_context
 {
     anzu::tokenstream tokens;
-    std::unordered_map<std::string, function_signature> functions;
-    std::stack<std::unordered_map<std::string, std::string>> object_types;
+    std::stack<scope> scopes;
+
+    auto current_scope() -> scope& { return scopes.top(); }
+    auto current_scope() const -> const scope& { return scopes.top(); }
 };
 
 auto parse(const std::vector<anzu::token>& tokens) -> anzu::node_stmt_ptr;

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -79,7 +79,9 @@ auto to_string(const op& op_code) -> std::string
             return std::string{"OP_RETURN"};
         },
         [&](const op_function_call& op) {
-            return std::format("OP_FUNCTION_CALL({})", op.name);
+            const auto func_str = std::format("OP_FUNCTION_CALL({})", op.name);
+            const auto jump_str = std::format("JUMP -> {}", op.ptr);
+            return std::format(FORMAT2, func_str, jump_str);
         },
         [&](const op_builtin_call& op) {
             return std::format("OP_BUILTIN_CALL({})", op.name);

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -39,13 +39,32 @@ auto tokenstream::consume_maybe(std::string_view text) -> bool
     return false;
 }
 
-auto tokenstream::consume_only(std::string_view text) -> void
+auto tokenstream::consume_only(std::string_view text) -> token
 {
-    if (!consume_maybe(text)) {
-        const auto& [tok_text, line, col, type] = curr();
-        anzu::print("[ERROR] ({}:{}) expected '{}', got '{}\n", line, col, text, tok_text);
+    if (!valid()) {
+        anzu::print("[ERROR] (EOF) expected '{}'\n", text);
         std::exit(1);
     }
+    if (!peek(text)) {
+        const auto& [tok_text, line, col, type] = curr();
+        anzu::print("[ERROR] ({}:{}}) expected '{}', got '{}\n", line, col, text, tok_text);
+        std::exit(1);
+    }
+    return consume();
+}
+
+auto tokenstream::consume_only(token_type type) -> token
+{
+    if (!valid()) {
+        anzu::print("[ERROR] (EOF) expected a type\n");
+        std::exit(1);
+    }
+    if (curr().type != type) {
+        const auto& [tok_text, line, col, type] = curr();
+        anzu::print("[ERROR] ({}:{}}) expected  a type, got '{}\n", line, col, tok_text);
+        std::exit(1);
+    }
+    return consume();
 }
 
 auto tokenstream::peek(std::string_view text) -> bool

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -48,4 +48,9 @@ auto tokenstream::consume_only(std::string_view text) -> void
     }
 }
 
+auto tokenstream::peek(std::string_view text) -> bool
+{
+    return curr().text == text;
+}
+
 }

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -50,7 +50,12 @@ auto tokenstream::consume_only(std::string_view text) -> void
 
 auto tokenstream::peek(std::string_view text) -> bool
 {
-    return curr().text == text;
+    return valid() && curr().text == text;
+}
+
+auto tokenstream::peek_next(std::string_view text) -> bool
+{
+    return has_next() && curr().text == text;
 }
 
 }

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -55,7 +55,7 @@ auto tokenstream::peek(std::string_view text) -> bool
 
 auto tokenstream::peek_next(std::string_view text) -> bool
 {
-    return has_next() && curr().text == text;
+    return has_next() && next().text == text;
 }
 
 }

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -33,6 +33,7 @@ public:
     tokenstream(const std::vector<token>& tokens);
     auto consume_maybe(std::string_view text) -> bool;
     auto consume_only(std::string_view text) -> token;
+    auto consume_only(token_type type) -> token;
 
     template <typename Func>
     auto consume_comma_separated_list(std::string_view sentinel, Func&& callback) -> void

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -32,7 +32,7 @@ class tokenstream : public anzu::peekstream<std::vector<token>>
 public:
     tokenstream(const std::vector<token>& tokens);
     auto consume_maybe(std::string_view text) -> bool;
-    auto consume_only(std::string_view text) -> void;
+    auto consume_only(std::string_view text) -> token;
 
     template <typename Func>
     auto consume_comma_separated_list(std::string_view sentinel, Func&& callback) -> void

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "vocabulary.hpp"
 #include "utility/peekstream.hpp"
 
 #include <string>
@@ -32,6 +33,20 @@ public:
     tokenstream(const std::vector<token>& tokens);
     auto consume_maybe(std::string_view text) -> bool;
     auto consume_only(std::string_view text) -> void;
+
+    template <typename Func>
+    auto consume_comma_separated_list(std::string_view sentinel, Func&& callback) -> void
+    {
+        if (consume_maybe(sentinel)) { // Empty list
+            return;
+        }
+        callback(); // Parse first
+        while (!peek(sentinel)) {
+            consume_only(tk_comma);
+            callback();
+        }
+        consume_only(sentinel);
+    }
 
     // TODO: Rename these and the peekstream functions to be more consistent
     auto peek(std::string_view text) -> bool;

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -32,6 +32,7 @@ public:
     tokenstream(const std::vector<token>& tokens);
     auto consume_maybe(std::string_view text) -> bool;
     auto consume_only(std::string_view text) -> void;
+    auto peek(std::string_view text) -> bool;
 };
     
 }

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -32,7 +32,10 @@ public:
     tokenstream(const std::vector<token>& tokens);
     auto consume_maybe(std::string_view text) -> bool;
     auto consume_only(std::string_view text) -> void;
+
+    // TODO: Rename these and the peekstream functions to be more consistent
     auto peek(std::string_view text) -> bool;
+    auto peek_next(std::string_view text) -> bool;
 };
     
 }

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -23,26 +23,6 @@ template <typename... Args>
     type_error(ctx.tokens.curr(), msg, std::forward<Args>(args)...);
 }
 
-auto type_of(const anzu::object& object) -> std::string
-{
-    if (object.is<int>()) {
-        return std::string{tk_int};
-    }
-    if (object.is<bool>()) {
-        return std::string{tk_bool};
-    }
-    if (object.is<std::string>()) {
-        return std::string{tk_str};
-    }
-    if (object.is<object_list>()) {
-        return std::string{tk_list};
-    }
-    if (object.is<object_null>()) {
-        return std::string{tk_null_type};
-    }
-    return std::string{tk_any};
-}
-
 auto type_of_bin_op(
     std::string_view lhs, std::string_view rhs, const token& op_token
 )
@@ -89,8 +69,6 @@ auto type_of_bin_op(
     return std::string{tk_int};
 }
 
-}
-
 auto fetch_function_signature(
     const parser_context& ctx, const std::string& function_name
 )
@@ -106,6 +84,28 @@ auto fetch_function_signature(
     }
 
     type_error(ctx, "could not find function '{}'", function_name);
+}
+
+}
+
+auto type_of(const anzu::object& object) -> std::string
+{
+    if (object.is<int>()) {
+        return std::string{tk_int};
+    }
+    if (object.is<bool>()) {
+        return std::string{tk_bool};
+    }
+    if (object.is<std::string>()) {
+        return std::string{tk_str};
+    }
+    if (object.is<object_list>()) {
+        return std::string{tk_list};
+    }
+    if (object.is<object_null>()) {
+        return std::string{tk_null_type};
+    }
+    return std::string{tk_any};
 }
 
 auto type_check_function_call(

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -107,7 +107,6 @@ auto type_of_expr(const parser_context& ctx, const node_expr& expr) -> std::stri
             return type_of(node.value);
         },
         [&](const node_variable_expr& node) {
-            anzu::print("looking for {}\n", node.name);
             const auto& top = ctx.scopes.top();
             return top.variables.at(node.name);
         },

--- a/src/typecheck.hpp
+++ b/src/typecheck.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "ast.hpp"
 #include "functions.hpp"
+#include "object.hpp"
 
 namespace anzu {
 
@@ -17,5 +18,7 @@ auto type_check_function_call(
 // Evaluates a given expression node with the given context. Produces an error if the
 // expression is invalid, otherwise the returns the type of the expression.
 auto type_of_expr(const parser_context& ctx, const node_expr& node) -> std::string;
+
+auto type_of(const anzu::object& object) -> std::string;
 
 }

--- a/src/typecheck.hpp
+++ b/src/typecheck.hpp
@@ -6,9 +6,13 @@ namespace anzu {
 
 struct parser_context;
 
-auto fetch_function_signature(
-    const parser_context& ctx, const std::string& function_name
-) -> function_signature;
+// Given a context and function name along with a set of arguments, verify that the
+// arguments match the function signature.
+auto type_check_function_call(
+    const parser_context& ctx,
+    const std::string& function_name,
+    std::span<const node_expr_ptr> args
+) -> void;
 
 // Evaluates a given expression node with the given context. Produces an error if the
 // expression is invalid, otherwise the returns the type of the expression.

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -18,7 +18,7 @@ auto is_keyword(std::string_view token) -> bool
 auto is_sentinel(std::string_view token) -> bool
 {
     static const std::unordered_set<std::string_view> tokens = {
-        tk_do, tk_elif, tk_else, tk_end
+        tk_do, tk_elif, tk_else, tk_end, tk_rbrace
     };
     return tokens.contains(token);
 }
@@ -29,7 +29,8 @@ auto is_symbol(std::string_view token) -> bool
         tk_add, tk_and, tk_assign, tk_colon, tk_comma,
         tk_div, tk_eq, tk_ge, tk_gt, tk_lbracket, tk_le,
         tk_lparen, tk_lt, tk_mod, tk_mul, tk_ne, tk_or,
-        tk_period, tk_rbracket, tk_rparen, tk_sub, tk_rarrow
+        tk_period, tk_rbracket, tk_rparen, tk_sub, tk_rarrow,
+        tk_lbrace, tk_rbrace
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -8,9 +8,9 @@ namespace anzu {
 auto is_keyword(std::string_view token) -> bool
 {
     static const std::unordered_set<std::string_view> tokens = {
-        tk_break, tk_continue, tk_do, tk_elif, tk_else, tk_end,
-        tk_false, tk_for, tk_if, tk_in, tk_null, tk_true, tk_while,
-        tk_int, tk_bool, tk_str, tk_list, tk_null_type, tk_any
+        tk_break, tk_continue, tk_else, tk_false, tk_for, tk_if,
+        tk_in, tk_null, tk_true, tk_while, tk_int, tk_bool, tk_str,
+        tk_list, tk_null_type, tk_any
     };
     return tokens.contains(token);
 }
@@ -18,7 +18,7 @@ auto is_keyword(std::string_view token) -> bool
 auto is_sentinel(std::string_view token) -> bool
 {
     static const std::unordered_set<std::string_view> tokens = {
-        tk_do, tk_elif, tk_else, tk_end, tk_rbrace
+        tk_else, tk_rbrace
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -8,10 +8,7 @@ using sv = std::string_view;
 // Keywords
 constexpr auto tk_break     = sv{"break"};
 constexpr auto tk_continue  = sv{"continue"};
-constexpr auto tk_do        = sv{"do"};
-constexpr auto tk_elif      = sv{"elif"};
 constexpr auto tk_else      = sv{"else"};
-constexpr auto tk_end       = sv{"end"};
 constexpr auto tk_false     = sv{"false"};
 constexpr auto tk_for       = sv{"for"};
 constexpr auto tk_if        = sv{"if"};

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -53,6 +53,8 @@ constexpr auto tk_rbracket  = sv{"]"};
 constexpr auto tk_rparen    = sv{")"};
 constexpr auto tk_sub       = sv{"-"};
 constexpr auto tk_rarrow    = sv{"->"};
+constexpr auto tk_lbrace    = sv{"{"};
+constexpr auto tk_rbrace    = sv{"}"};
 
 auto is_keyword    (sv token) -> bool;
 auto is_sentinel   (sv token) -> bool;


### PR DESCRIPTION
* Replaced `do` and `end` with braces.
* Braced blocks are now a form of statement, and if statements now work the same way they do in C, where the bodies of the branches can be any statement, including braced lists. This allows for you to omit the braces when you only want one statement in the body.
* Because of the above, `elif` has been removed as a keyword too as `else if` can be used like in C.
* While loops, for loops and function defs also use braces, however this is implemented the same way the if statement is in that they now just accept a single statement, one of which is the braced syntax.
* Simplified the compilation of a for loop node. Now the "container" is just parsed as an expression since we can type check it as a list in the parser. In particular this allows the "container" to a function call that returns a list.
* Added a `range(n)` builtin similar to python to take advantage of the above.
* Added a `typeof(obj)` builtin to return a string representation of the argument passed in.
* Fixed a bug in the lexer.
* Restructure and reorganise the parser to be cleaner. Most of this was just making the code easier to read.
* Added `typecheck_function_signature` function to `typecheck.hpp`, which removes a lot of the type specific code from the parser.
* In a future PR, all type info will be removed from the parser and there will be a separate step to do the type checking.
* The `parser_context` now also scopes function names rather than just object types. This simplifies the code, but also allows for nested functions.
* The `tokenstream` interface has been enhanced, but the naming conventions are all over the place and could do with a tidy.