### PR TITLE
Move Typechecking out of Parser

### DIFF
--- a/examples/euler.az
+++ b/examples/euler.az
@@ -13,3 +13,4 @@ while i < 1000 {
 }
 
 println(count)
+x = 3 + "string"

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,4 +4,4 @@ function foo(a: int, b: int) -> int
     return "hello"
 }
 
-println(foo(a, b))
+println(foo(1, 2))

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,7 +1,7 @@
 
 function foo(a: int, b: int) -> int
 {
-    return "hello"
+    return 5
 }
 
 println(foo(1, 2))

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -10,11 +10,12 @@
 
 void print_usage()
 {
-    anzu::print("usage: anzu.exe <program_file> (lex|parse|com|debug|run) [-o]\n\n");
+    anzu::print("usage: anzu.exe <program_file> <option> [-o]\n\n");
     anzu::print("The Anzu Programming Language\n\n");
     anzu::print("options:\n");
     anzu::print("    lex   - runs the lexer and prints the tokens\n");
     anzu::print("    parse - runs the parser and prints the AST\n");
+    anzu::print("    check - after parsing, run the type checker then exit\n");
     anzu::print("    com   - runs the compiler and prints the bytecode\n");
     anzu::print("    debug - runs the program and prints each op code executed\n");
     anzu::print("    run   - runs the program\n");
@@ -50,18 +51,21 @@ int main(int argc, char** argv)
 
     anzu::print("-> Parsing\n");
     auto ast = anzu::parse(tokens);
-    
+    if (mode == "parse") {
+        print_node(*ast);
+        return 0;
+    }
+
     anzu::print("-> Type Checking\n");
     anzu::typecheck_ast(ast);
+    if (mode == "check") {
+        print_node(*ast);
+        return 0;
+    }
 
     if (argc == 4) {
         anzu::print("-> Optimising\n");
         anzu::optimise_ast(*ast);
-    }
-
-    if (mode == "parse") {
-        print_node(*ast);
-        return 0;
     }
 
     anzu::print("-> Compiling\n");

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -1,5 +1,6 @@
 #include "lexer.hpp"
 #include "parser.hpp"
+#include "typecheck.hpp"
 #include "optimiser.hpp"
 #include "compiler.hpp"
 #include "runtime.hpp"
@@ -49,6 +50,10 @@ int main(int argc, char** argv)
 
     anzu::print("-> Parsing\n");
     auto ast = anzu::parse(tokens);
+    
+    anzu::print("-> Type Checking\n");
+    anzu::typecheck_ast(ast);
+
     if (argc == 4) {
         anzu::print("-> Optimising\n");
         anzu::optimise_ast(*ast);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -9,17 +9,13 @@ namespace {
 template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 
 template <typename T, typename Func>
-auto print_comma_separated(
-    const std::vector<T>& values, Func&& formatter
-)
-    -> void
+auto print_comma_separated(const std::vector<T>& values, Func&& formatter) -> void
 {
-    if (values.size() == 0) {
-        return;
-    }
-    anzu::print(formatter(values[0]));
-    for (const auto& value : values | std::views::drop(1)) {
-        anzu::print(", {}", formatter(value));
+    if (!values.empty()) {
+        anzu::print(formatter(values.front()));
+        for (const auto& value : values | std::views::drop(1)) {
+            anzu::print(", {}", formatter(value));
+        }
     }
 }
 
@@ -39,16 +35,8 @@ auto print_node(const anzu::node_expr& root, int indent) -> void
             anzu::print("{}BinOp\n", spaces);
             anzu::print("{}- Op: {}\n", spaces, node.op.text);
             anzu::print("{}- Lhs:\n", spaces);
-            if (!node.lhs) {
-                anzu::print("bin op has no lhs\n");
-                std::exit(1);
-            }
             print_node(*node.lhs, indent + 1);
             anzu::print("{}- Rhs:\n", spaces);
-            if (!node.rhs) {
-                anzu::print("bin op has no rhs\n");
-                std::exit(1);
-            }
             print_node(*node.rhs, indent + 1);
         },
         [&](const node_function_call_expr& node) {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -32,7 +32,7 @@ auto print_node(const anzu::node_expr& root, int indent) -> void
             anzu::print("{}Variable: {}\n", spaces, node.name);
         },
         [&](const node_bin_op_expr& node) {
-            anzu::print("{}BinOp\n", spaces);
+            anzu::print("{}BinOp: \n", spaces);
             anzu::print("{}- Op: {}\n", spaces, node.op.text);
             anzu::print("{}- Lhs:\n", spaces);
             print_node(*node.lhs, indent + 1);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -184,9 +184,7 @@ void compile_node(const node_for_stmt& node, compiler_context& ctx)
     ctx.program.emplace_back(anzu::op_copy_index{0});
     const auto& list_size = anzu::fetch_builtin("list_size");
     ctx.program.emplace_back(anzu::op_builtin_call{
-        .name="list_size",
-        .ptr=list_size.ptr,
-        .sig=list_size.sig
+        .name="list_size", .ptr=list_size.ptr, .sig=list_size.sig
     });
 
     // Push the counter to the stack
@@ -209,9 +207,7 @@ void compile_node(const node_for_stmt& node, compiler_context& ctx)
     ctx.program.emplace_back(anzu::op_copy_index{1}); // Push index
     const auto& list_at = anzu::fetch_builtin("list_at");
     ctx.program.emplace_back(anzu::op_builtin_call{
-        .name="list_at",
-        .ptr=list_at.ptr,
-        .sig=list_at.sig
+        .name="list_at", .ptr=list_at.ptr, .sig=list_at.sig
     });
     ctx.program.emplace_back(anzu::op_store{ .name=node.var }); // Store in var
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -110,16 +110,16 @@ auto parse_compound_factor(tokenstream& tokens, std::int64_t level) -> node_expr
         return parse_single_factor(tokens);
     }
 
-    auto left = parse_compound_factor(tokens, level - 1);
+    auto factor = parse_compound_factor(tokens, level - 1);
     while (tokens.valid() && bin_ops_table[level].contains(tokens.curr().text)) {
         auto node = std::make_unique<anzu::node_expr>();
         auto& expr = node->emplace<anzu::node_bin_op_expr>();
-        expr.lhs = std::move(left);
-        expr.op = tokens.consume();;
+        expr.lhs = std::move(factor);
+        expr.op = tokens.consume();
         expr.rhs = parse_compound_factor(tokens, level - 1);
-        left = std::move(node);
+        factor = std::move(node);
     }
-    return left;
+    return factor;
 }
 
 auto parse_expression(tokenstream& tokens) -> node_expr_ptr

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,6 +1,5 @@
 #include "parser.hpp"
 #include "functions.hpp"
-#include "typecheck.hpp"
 #include "vocabulary.hpp"
 
 #include <unordered_set>
@@ -19,11 +18,11 @@ template <typename... Args>
     std::exit(1);
 }
 
-auto parse_expression(parser_context& ctx) -> node_expr_ptr;
+auto parse_expression(tokenstream& tokens) -> node_expr_ptr;
+auto parse_statement(tokenstream& tokens) -> node_stmt_ptr;
 
-auto parse_literal(parser_context& ctx) -> anzu::object
+auto parse_literal(tokenstream& tokens) -> anzu::object
 {
-    auto& tokens = ctx.tokens;
     if (tokens.curr().type == token_type::number) {
         return { anzu::to_int(tokens.consume().text) };
     }
@@ -41,24 +40,24 @@ auto parse_literal(parser_context& ctx) -> anzu::object
     }
     if (tokens.consume_maybe(tk_lbracket)) {
         auto list = std::make_shared<std::vector<anzu::object>>();
-        ctx.tokens.consume_comma_separated_list(tk_rbracket, [&] {
-            list->push_back(parse_literal(ctx));
+        tokens.consume_comma_separated_list(tk_rbracket, [&] {
+            list->push_back(parse_literal(tokens));
         });
         return { list };
     }
-    parser_error(ctx.tokens.curr(), "failed to parse string literal");
+    parser_error(tokens.curr(), "failed to parse literal");
 };
 
 template <typename NodeVariant, typename NodeType>
-auto parse_function_call(parser_context& ctx) -> std::unique_ptr<NodeVariant>
+auto parse_function_call(tokenstream& tokens) -> std::unique_ptr<NodeVariant>
 {
     auto node = std::make_unique<NodeVariant>();
     auto& out = node->emplace<NodeType>();
 
-    out.function_name = ctx.tokens.consume().text;
-    ctx.tokens.consume_only(tk_lparen);
-    ctx.tokens.consume_comma_separated_list(tk_rparen, [&] {
-        out.args.push_back(parse_expression(ctx));
+    out.function_name = tokens.consume().text;
+    tokens.consume_only(tk_lparen);
+    tokens.consume_comma_separated_list(tk_rparen, [&] {
+        out.args.push_back(parse_expression(tokens));
     });
     return node;
 }
@@ -76,21 +75,20 @@ auto precedence_table()
 }
 static const auto bin_ops_table = precedence_table();
 
-auto parse_function_call_expr(parser_context& ctx) -> node_expr_ptr
+auto parse_function_call_expr(tokenstream& tokens) -> node_expr_ptr
 {
-    return parse_function_call<anzu::node_expr, anzu::node_function_call_expr>(ctx);
+    return parse_function_call<anzu::node_expr, anzu::node_function_call_expr>(tokens);
 }
 
-auto parse_single_factor(parser_context& ctx) -> node_expr_ptr
+auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
 {
-    auto& tokens = ctx.tokens;
-    if (ctx.tokens.consume_maybe(tk_lparen)) {
-        auto expr = parse_expression(ctx);
-        ctx.tokens.consume_only(tk_rparen);
+    if (tokens.consume_maybe(tk_lparen)) {
+        auto expr = parse_expression(tokens);
+        tokens.consume_only(tk_rparen);
         return expr;
     }  
     if (tokens.peek_next(tk_lparen)) {
-        return parse_function_call_expr(ctx);
+        return parse_function_call_expr(tokens);
     }
     if (tokens.curr().type == token_type::name) {
         auto node = std::make_unique<anzu::node_expr>();
@@ -101,101 +99,87 @@ auto parse_single_factor(parser_context& ctx) -> node_expr_ptr
 
     auto node = std::make_unique<anzu::node_expr>();
     auto& expr = node->emplace<anzu::node_literal_expr>();
-    expr.value = parse_literal(ctx);
+    expr.value = parse_literal(tokens);
     return node;
 }
 
 // Level is the precendence level, the lower the number, the tighter the factors bind.
-auto parse_compound_factor(parser_context& ctx, std::int64_t level) -> node_expr_ptr
+auto parse_compound_factor(tokenstream& tokens, std::int64_t level) -> node_expr_ptr
 {
     if (level == 0) {
-        return parse_single_factor(ctx);
+        return parse_single_factor(tokens);
     }
 
-    auto left = parse_compound_factor(ctx, level - 1);
-    while (ctx.tokens.valid() && bin_ops_table[level].contains(ctx.tokens.curr().text)) {
-        auto op = ctx.tokens.consume();
-
+    auto left = parse_compound_factor(tokens, level - 1);
+    while (tokens.valid() && bin_ops_table[level].contains(tokens.curr().text)) {
         auto node = std::make_unique<anzu::node_expr>();
         auto& expr = node->emplace<anzu::node_bin_op_expr>();
         expr.lhs = std::move(left);
-        expr.op = op;
-        expr.rhs = parse_compound_factor(ctx, level - 1);
-
+        expr.op = tokens.consume();;
+        expr.rhs = parse_compound_factor(tokens, level - 1);
         left = std::move(node);
     }
     return left;
 }
 
-auto parse_expression(parser_context& ctx) -> node_expr_ptr
+auto parse_expression(tokenstream& tokens) -> node_expr_ptr
 {
-    return parse_compound_factor(ctx, std::ssize(bin_ops_table) - 1i64);
+    return parse_compound_factor(tokens, std::ssize(bin_ops_table) - 1i64);
 }
 
-auto parse_name(parser_context& ctx)
+auto parse_name(tokenstream& tokens)
 {
-    const auto token = ctx.tokens.consume();
+    const auto token = tokens.consume();
     if (token.type != token_type::name) {
         parser_error(token, "'{}' is not a valid name", token.text);
     }
     return token.text;   
 }
 
-auto parse_type(parser_context& ctx)
+auto parse_type(tokenstream& tokens)
 {
-    const auto token = ctx.tokens.consume();
+    const auto token = tokens.consume();
     if (token.type != token_type::keyword) {
         parser_error(token, "'{}' is not a valid type", token.text);
     }
     return token.text;   
 }
 
-auto parse_statement(parser_context& ctx) -> node_stmt_ptr;
-
-auto parse_function_def_stmt(parser_context& ctx) -> node_stmt_ptr
+auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_function_def_stmt>();
 
-    ctx.scopes.emplace();
-    ctx.tokens.consume_only(tk_function);
-    stmt.name = parse_name(ctx);
-    ctx.tokens.consume_only(tk_lparen);
-    ctx.tokens.consume_comma_separated_list(tk_rparen, [&] {
+    tokens.consume_only(tk_function);
+    stmt.name = parse_name(tokens);
+    tokens.consume_only(tk_lparen);
+    tokens.consume_comma_separated_list(tk_rparen, [&] {
         auto arg = function_signature::arg{};
-        arg.name = parse_name(ctx);
-        if (ctx.tokens.consume_maybe(tk_colon)) {
-            arg.type = parse_type(ctx);
+        arg.name = parse_name(tokens);
+        if (tokens.consume_maybe(tk_colon)) {
+            arg.type = parse_type(tokens);
         }
 
         stmt.sig.args.push_back(arg);
     });    
 
-    if (ctx.tokens.consume_maybe(tk_rarrow)) {
-        stmt.sig.return_type = parse_type(ctx); // TODO: Check this
+    if (tokens.consume_maybe(tk_rarrow)) {
+        stmt.sig.return_type = parse_type(tokens); // TODO: Check this
     }
 
-    ctx.scopes.top().functions[stmt.name] = stmt.sig; // Allows for recursion
-    stmt.body = parse_statement(ctx);
-    ctx.scopes.pop();
-
-    ctx.scopes.top().functions[stmt.name] = stmt.sig; // Make function available
+    stmt.body = parse_statement(tokens);
     return node;
 }
 
-auto parse_return_stmt(parser_context& ctx) -> node_stmt_ptr
+auto parse_return_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_return_stmt>();
     
-    ctx.tokens.consume_only(tk_return);
+    tokens.consume_only(tk_return);
 
-    // TODO: Make return statements mandatory and check the expr type
-    // against the function signature
-    if (!anzu::is_sentinel(ctx.tokens.curr().text)) {
-        auto expr = parse_expression(ctx);
-        auto type = type_of_expr(ctx, *expr);
-        stmt.return_value = std::move(expr);
+    if (!anzu::is_sentinel(tokens.curr().text)) {
+        stmt.return_value = parse_expression(tokens);
     } else {
         stmt.return_value = std::make_unique<anzu::node_expr>();
         stmt.return_value->emplace<anzu::node_literal_expr>().value = anzu::null_object();
@@ -203,70 +187,70 @@ auto parse_return_stmt(parser_context& ctx) -> node_stmt_ptr
     return node;
 }
 
-auto parse_while_stmt(parser_context& ctx) -> node_stmt_ptr
+auto parse_while_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_while_stmt>();
 
-    ctx.tokens.consume_only(tk_while);
-    stmt.condition = parse_expression(ctx);
-    stmt.body = parse_statement(ctx);
+    tokens.consume_only(tk_while);
+    stmt.condition = parse_expression(tokens);
+    stmt.body = parse_statement(tokens);
     return node;
 }
 
-auto parse_if_stmt(parser_context& ctx) -> node_stmt_ptr
+auto parse_if_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_if_stmt>();
 
-    ctx.tokens.consume_only(tk_if);
-    stmt.condition = parse_expression(ctx);
-    stmt.body = parse_statement(ctx);
-    if (ctx.tokens.consume_maybe(tk_else)) {
-        stmt.else_body = parse_statement(ctx);
+    tokens.consume_only(tk_if);
+    stmt.condition = parse_expression(tokens);
+    stmt.body = parse_statement(tokens);
+    if (tokens.consume_maybe(tk_else)) {
+        stmt.else_body = parse_statement(tokens);
     }
     return node;
 }
 
-auto parse_for_stmt(parser_context& ctx) -> node_stmt_ptr
+auto parse_for_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_for_stmt>();
 
-    ctx.tokens.consume_only(tk_for);
-    stmt.var = parse_name(ctx);
-    ctx.tokens.consume_only(tk_in);
-    stmt.container = parse_expression(ctx);
-    stmt.body = parse_statement(ctx);
+    tokens.consume_only(tk_for);
+    stmt.var = parse_name(tokens);
+    tokens.consume_only(tk_in);
+    stmt.container = parse_expression(tokens);
+    stmt.body = parse_statement(tokens);
     return node;
 }
 
-auto parse_assignment_stmt(parser_context& ctx) -> node_stmt_ptr
+auto parse_assignment_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_assignment_stmt>();
 
-    stmt.name = parse_name(ctx);
-    ctx.tokens.consume_only(tk_assign);
-    stmt.expr = parse_expression(ctx);
+    stmt.name = parse_name(tokens);
+    tokens.consume_only(tk_assign);
+    stmt.expr = parse_expression(tokens);
     return node;
 }
 
-auto parse_function_call_stmt(parser_context& ctx) -> node_stmt_ptr
+auto parse_function_call_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
-    return parse_function_call<anzu::node_stmt, anzu::node_function_call_stmt>(ctx);
+    return parse_function_call<anzu::node_stmt, anzu::node_function_call_stmt>(tokens);
 }
 
-auto parse_braced_statement_list(parser_context& ctx) -> node_stmt_ptr
+auto parse_braced_statement_list(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_sequence_stmt>();
     
-    ctx.tokens.consume_only(tk_lbrace);
-    while (ctx.tokens.valid() && !anzu::is_sentinel(ctx.tokens.curr().text)) {
-        stmt.sequence.push_back(parse_statement(ctx));
+    tokens.consume_only(tk_lbrace);
+    while (tokens.valid() && !anzu::is_sentinel(tokens.curr().text)) {
+        stmt.sequence.push_back(parse_statement(tokens));
     }
-    ctx.tokens.consume_only(tk_rbrace);
+    tokens.consume_only(tk_rbrace);
 
     // If there is only one element in the sequence, return that directly
     if (stmt.sequence.size() == 1) {
@@ -275,23 +259,22 @@ auto parse_braced_statement_list(parser_context& ctx) -> node_stmt_ptr
     return node;
 }
 
-auto parse_statement(parser_context& ctx) -> node_stmt_ptr
+auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
 {
-    auto& tokens = ctx.tokens;
     if (tokens.peek(tk_function)) {
-        return parse_function_def_stmt(ctx);
+        return parse_function_def_stmt(tokens);
     }
     if (tokens.peek(tk_return)) {
-        return parse_return_stmt(ctx);
+        return parse_return_stmt(tokens);
     }
     if (tokens.peek(tk_while)) {
-        return parse_while_stmt(ctx);
+        return parse_while_stmt(tokens);
     }
     if (tokens.peek(tk_if)) {
-        return parse_if_stmt(ctx);
+        return parse_if_stmt(tokens);
     }
     if (tokens.peek(tk_for)) {
-        return parse_for_stmt(ctx);
+        return parse_for_stmt(tokens);
     }
     if (tokens.consume_maybe(tk_break)) {
         auto node = std::make_unique<anzu::node_stmt>();
@@ -304,28 +287,27 @@ auto parse_statement(parser_context& ctx) -> node_stmt_ptr
         return node;
     }
     if (tokens.peek_next(tk_assign)) { // <name> '='
-        return parse_assignment_stmt(ctx);
+        return parse_assignment_stmt(tokens);
     }
     if (tokens.peek_next(tk_lparen)) { // <name> '('
-        return parse_function_call_stmt(ctx);
+        return parse_function_call_stmt(tokens);
     }
     if (tokens.peek(tk_lbrace)) {
-        return parse_braced_statement_list(ctx);
+        return parse_braced_statement_list(tokens);
     }
-    parser_error(ctx.tokens.curr(), "unknown statement '{}'", ctx.tokens.curr().text);
+    parser_error(tokens.curr(), "unknown statement '{}'", tokens.curr().text);
 }
 
 }
 
 auto parse(const std::vector<anzu::token>& tokens) -> node_stmt_ptr
 {
-    auto ctx = anzu::parser_context{ .tokens = {tokens} };
-    ctx.scopes.emplace();
+    auto stream = tokenstream{tokens};
 
     auto root = std::make_unique<anzu::node_stmt>();
     auto& seq = root->emplace<anzu::node_sequence_stmt>();
-    while (ctx.tokens.valid()) {
-        seq.sequence.push_back(parse_statement(ctx));
+    while (stream.valid()) {
+        seq.sequence.push_back(parse_statement(stream));
     }
     return root;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -172,7 +172,6 @@ auto parse_return_stmt(tokenstream& tokens) -> node_stmt_ptr
     auto& stmt = node->emplace<anzu::node_return_stmt>();
     
     tokens.consume_only(tk_return);
-
     if (!anzu::is_sentinel(tokens.curr().text)) {
         stmt.return_value = parse_expression(tokens);
     } else {
@@ -271,14 +270,10 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
         return parse_for_stmt(tokens);
     }
     if (tokens.consume_maybe(tk_break)) {
-        auto node = std::make_unique<anzu::node_stmt>();
-        node->emplace<anzu::node_break_stmt>();
-        return node;
+        return std::make_unique<node_stmt>(node_break_stmt{});
     }
     if (tokens.consume_maybe(tk_continue)) {
-        auto node = std::make_unique<anzu::node_stmt>();
-        node->emplace<anzu::node_continue_stmt>();
-        return node;
+        return std::make_unique<node_stmt>(node_continue_stmt{});
     }
     if (tokens.peek_next(tk_assign)) { // <name> '='
         return parse_assignment_stmt(tokens);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -156,10 +156,8 @@ auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
     tokens.consume_comma_separated_list(tk_rparen, [&] {
         auto arg = function_signature::arg{};
         arg.name = parse_name(tokens);
-        if (tokens.consume_maybe(tk_colon)) {
-            arg.type = parse_type(tokens);
-        }
-
+        tokens.consume_only(tk_colon);
+        arg.type = parse_type(tokens);
         stmt.sig.args.push_back(arg);
     });    
 
@@ -247,10 +245,9 @@ auto parse_braced_statement_list(tokenstream& tokens) -> node_stmt_ptr
     auto& stmt = node->emplace<anzu::node_sequence_stmt>();
     
     tokens.consume_only(tk_lbrace);
-    while (tokens.valid() && !anzu::is_sentinel(tokens.curr().text)) {
+    while (!tokens.consume_maybe(tk_rbrace)) {
         stmt.sequence.push_back(parse_statement(tokens));
     }
-    tokens.consume_only(tk_rbrace);
 
     // If there is only one element in the sequence, return that directly
     if (stmt.sequence.size() == 1) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -160,11 +160,8 @@ auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
         arg.type = parse_type(tokens);
         stmt.sig.args.push_back(arg);
     });    
-
-    if (tokens.consume_maybe(tk_rarrow)) {
-        stmt.sig.return_type = parse_type(tokens); // TODO: Check this
-    }
-
+    tokens.consume_only(tk_rarrow);
+    stmt.sig.return_type = parse_type(tokens);
     stmt.body = parse_statement(tokens);
     return node;
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -2,27 +2,9 @@
 #include "token.hpp"
 #include "ast.hpp"
 
-#include <unordered_map>
-#include <string>
-#include <stack>
+#include <vector>
 
 namespace anzu {
-
-// A new scope is currently only entered when parsing a function body.
-struct scope
-{
-    std::unordered_map<std::string, function_signature> functions;
-    std::unordered_map<std::string, std::string>        variables;
-};
-
-struct parser_context
-{
-    anzu::tokenstream tokens;
-    std::stack<scope> scopes;
-
-    auto current_scope() -> scope& { return scopes.top(); }
-    auto current_scope() const -> const scope& { return scopes.top(); }
-};
 
 auto parse(const std::vector<anzu::token>& tokens) -> anzu::node_stmt_ptr;
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -1,8 +1,9 @@
 #include "typecheck.hpp"
-#include "parser.hpp"
 #include "vocabulary.hpp"
 
 #include <ranges>
+#include <unordered_map>
+#include <stack>
 
 namespace anzu {
 namespace {
@@ -23,12 +24,6 @@ template <typename... Args>
     const auto formatted_msg = std::format(msg, std::forward<Args>(args)...);
     anzu::print("[ERROR] ({}:{}) {}\n", tok.line, tok.col, formatted_msg);
     std::exit(1);
-}
-
-template <typename... Args>
-[[noreturn]] void type_error(const parser_context& ctx, std::string_view msg, Args&&... args)
-{
-    type_error(ctx.tokens.curr(), msg, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
@@ -86,94 +81,6 @@ auto type_of_bin_op(
 }
 
 auto fetch_function_signature(
-    const parser_context& ctx, const std::string& function_name
-)
-    -> function_signature
-{
-    const auto& scope = ctx.current_scope();
-    if (auto it = scope.functions.find(function_name); it != scope.functions.end()) {
-        return it->second;
-    }
-
-    if (anzu::is_builtin(function_name)) {
-        return anzu::fetch_builtin(function_name).sig;
-    }
-
-    type_error(ctx, "could not find function '{}'", function_name);
-}
-
-}
-
-auto type_of(const anzu::object& object) -> std::string
-{
-    if (object.is<int>()) {
-        return std::string{tk_int};
-    }
-    if (object.is<bool>()) {
-        return std::string{tk_bool};
-    }
-    if (object.is<std::string>()) {
-        return std::string{tk_str};
-    }
-    if (object.is<object_list>()) {
-        return std::string{tk_list};
-    }
-    if (object.is<object_null>()) {
-        return std::string{tk_null_type};
-    }
-    return std::string{tk_any};
-}
-
-auto type_check_function_call(
-    const parser_context& ctx,
-    const std::string& function_name,
-    std::span<const node_expr_ptr> args
-)
-    -> void
-{
-    const auto sig = fetch_function_signature(ctx, function_name);
-    if (sig.args.size() != args.size()) {
-        type_error(
-            ctx, "function '{}' expected {} args, got {}",
-            function_name, sig.args.size(), args.size()
-        );
-    }
-
-    for (std::size_t idx = 0; idx != sig.args.size(); ++idx) {
-        const auto& expected = sig.args.at(idx).type;
-        const auto& actual = type_of_expr(ctx, *args[idx]);
-        if (expected != tk_any && actual != tk_any && expected != actual) {
-            type_error(
-                ctx, "invalid function call, arg {} expects type {}, got {}\n",
-                idx, expected, actual
-            );
-        }
-    }
-}
-
-auto type_of_expr(const parser_context& ctx, const node_expr& expr) -> std::string
-{
-    return std::visit(overloaded {
-        [&](const node_literal_expr& node) {
-            return type_of(node.value);
-        },
-        [&](const node_variable_expr& node) {
-            const auto& top = ctx.scopes.top();
-            return top.variables.at(node.name);
-        },
-        [&](const node_function_call_expr& node) {
-            const auto& func_def = fetch_function_signature(ctx, node.function_name);
-            return func_def.return_type;
-        },
-        [&](const node_bin_op_expr& node) {
-            return type_of_bin_op(
-                type_of_expr(ctx, *node.lhs), type_of_expr(ctx, *node.rhs), node.op
-            );
-        }
-    }, expr);
-};
-
-auto fetch_function_signature(
     const typecheck_context& ctx, const std::string& function_name
 )
     -> function_signature
@@ -212,47 +119,12 @@ auto type_of_expr(const typecheck_context& ctx, const node_expr& expr) -> std::s
     }, expr);
 };
 
-auto type_check_function_call(
-    const typecheck_context& ctx,
-    const std::string& function_name,
-    std::span<const node_expr_ptr> args
-)
-    -> void
-{
-    const auto sig = fetch_function_signature(ctx, function_name);
-    if (sig.args.size() != args.size()) {
-        type_error(
-            "function '{}' expected {} args, got {}",
-            function_name, sig.args.size(), args.size()
-        );
-    }
-
-    for (std::size_t idx = 0; idx != sig.args.size(); ++idx) {
-        const auto& expected = sig.args.at(idx).type;
-        const auto& actual = type_of_expr(ctx, *args[idx]);
-        if (expected != tk_any && actual != tk_any && expected != actual) {
-            type_error(
-                "invalid function call, arg {} expects type {}, got {}\n",
-                idx, expected, actual
-            );
-        }
-    }
-}
-
-namespace {
-
-void verify_type(std::string_view actual, std::string_view expected)
-{
-    if (actual != tk_any && actual != expected)
-    {
-        type_error("expected '{}', got '{}'", expected, actual);
-    }
-}
-
 void verify_expression_type(typecheck_context& ctx, const node_expr& expr, std::string_view expected)
 {
-    const auto expr_type = type_of_expr(ctx, expr);
-    verify_type(expr_type, expected);
+    const auto actual = type_of_expr(ctx, expr);
+    if (actual != tk_any && actual != expected) {
+        type_error("expected '{}', got '{}'", expected, actual);
+    }
 }
 
 auto typecheck_node(typecheck_context& ctx, const node_stmt& node) -> void;
@@ -313,7 +185,24 @@ auto typecheck_node(typecheck_context& ctx, const node_function_def_stmt& node) 
 
 auto typecheck_node(typecheck_context& ctx, const node_function_call_stmt& node) -> void
 {
-    type_check_function_call(ctx, node.function_name, node.args);
+    const auto sig = fetch_function_signature(ctx, node.function_name);
+    if (sig.args.size() != node.args.size()) {
+        type_error(
+            "function '{}' expected {} args, got {}",
+            node.function_name, sig.args.size(), node.args.size()
+        );
+    }
+
+    for (std::size_t idx = 0; idx != sig.args.size(); ++idx) {
+        const auto& expected = sig.args.at(idx).type;
+        const auto& actual = type_of_expr(ctx, *node.args[idx]);
+        if (expected != tk_any && actual != tk_any && expected != actual) {
+            type_error(
+                "invalid function call, arg {} expects type {}, got {}\n",
+                idx, expected, actual
+            );
+        }
+    }
 }
 
 auto typecheck_node(typecheck_context& ctx, const node_return_stmt& node)
@@ -327,6 +216,26 @@ auto typecheck_node(typecheck_context& ctx, const node_stmt& node) -> void
     std::visit([&](const auto& n) { typecheck_node(ctx, n); }, node);
 }
 
+}
+
+auto type_of(const anzu::object& object) -> std::string
+{
+    if (object.is<int>()) {
+        return std::string{tk_int};
+    }
+    if (object.is<bool>()) {
+        return std::string{tk_bool};
+    }
+    if (object.is<std::string>()) {
+        return std::string{tk_str};
+    }
+    if (object.is<object_list>()) {
+        return std::string{tk_list};
+    }
+    if (object.is<object_null>()) {
+        return std::string{tk_null_type};
+    }
+    return std::string{tk_any};
 }
 
 auto typecheck_ast(const node_stmt_ptr& ast) -> void

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -150,7 +150,7 @@ auto typecheck_node(typecheck_context& ctx, const node_if_stmt& node) -> void
 
 auto typecheck_node(typecheck_context& ctx, const node_for_stmt& node) -> void
 {
-    ctx.top().variables[node.var] = tk_any; // Variable is made available, cant know type yet :(
+    ctx.top().variables[node.var] = tk_any; // Can't know type yet :(
     verify_expression_type(ctx, *node.container, tk_list);
     typecheck_node(ctx, *node.body);
 }

--- a/src/typecheck.hpp
+++ b/src/typecheck.hpp
@@ -21,4 +21,10 @@ auto type_of_expr(const parser_context& ctx, const node_expr& node) -> std::stri
 
 auto type_of(const anzu::object& object) -> std::string;
 
+// Scans the AST and performs the following:
+//      - evaluates the type of all expressions to verify they are valid
+//      - verify that expressions passed as function arguments match the function signatures
+//      - verify that the types listed in function signatures are valid types
+auto typecheck_ast(const node_stmt_ptr& ast) -> void;
+
 }

--- a/src/typecheck.hpp
+++ b/src/typecheck.hpp
@@ -1,24 +1,13 @@
 #pragma once
 #include "ast.hpp"
-#include "functions.hpp"
 #include "object.hpp"
+
+#include <string>
 
 namespace anzu {
 
-struct parser_context;
-
-// Given a context and function name along with a set of arguments, verify that the
-// arguments match the function signature.
-auto type_check_function_call(
-    const parser_context& ctx,
-    const std::string& function_name,
-    std::span<const node_expr_ptr> args
-) -> void;
-
-// Evaluates a given expression node with the given context. Produces an error if the
-// expression is invalid, otherwise the returns the type of the expression.
-auto type_of_expr(const parser_context& ctx, const node_expr& node) -> std::string;
-
+// This doesn't belong in typecheck.hpp. In the future when we create an actual struct
+// for representing types, this can be moved into that module.
 auto type_of(const anzu::object& object) -> std::string;
 
 // Scans the AST and performs the following:


### PR DESCRIPTION
* The parser was a bit of a mess doing several things, now it only parses the tokens and does no check on the types of anything.
* The type checking has been moved to a separate stage, to run the pipeline up to and including checking, invoke the interpreter with the `check` command.
* Optimisations now only happen after typechecking. Currently the `-o` flag does nothing for `parse` and `check` stages, only for `com` and `run`. I will change this in the future.
* Removed `parser_context` since the parser now only needs the tokens. This works for functions because checking for a left paren after a name is unambiguously a function call, so it doesn't need to look the name up to check that.
* The rest of the `parser_context` is now called `typecheck_context` and is only needed in the type checker.
* The type checker now checks return statements against the function signature. This works by storing the type in the variables map in the `typecheck_context` as the name `return` which cannot be a variable name since its a keyword.
* Type annotations for functions are now mandatory.
* The error messages in the typechecker don't all show line and col numbers since they are not available without the tokenstream. Nodes should store the tokens for this.