### PR TITLE
Tokens in AST

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,34 +22,34 @@ print(4 + 5)
 * `if` statements (with optional `else` and `elif` too).
 
     ```
-    if <condition> do
+    if <condition> {
         ...
-    elif <condition> do
+    } else if <condition> {
         ...
-    else
+    } else {
         ...
-    end
+    }
     ```
 * `while` loops (with optional `break` and `continue`):
 
     ```
-    while <condition> do
+    while <condition> {
         ...
-    end
+    }
     ```
 * `for` loops (with optional `break` and `continue`):
 
     ```
-    for <variable_name> in <list_object> do
+    for <variable_name> in <list_object> {
         ...
-    end
+    }
     ```
 * `function` statements (with optional `return`):
 
     ```
-    function <name>(<args>) do
+    function <name>([<arg>: <type>]*) -> <return_type> {
         ...
-    end
+    }
     ```
 * All the common arithmetic, comparison and logical operators. More will be implemented.
 
@@ -62,25 +62,28 @@ Processing Pipeline
 
   Input
    |
-Lexer    -- lexer.hpp    : Converts a .az file into a vector of tokens
+Lexer    -- lexer.hpp     : Converts a .az file into a vector of tokens
    |
-   |     -- token.hpp    : Definition of a token and utility
+   |     -- token.hpp     : Definition of a token and utility
    |
-Parser   -- parser.hpp   : Converts a vector of tokens into an AST
+Parser   -- parser.hpp    : Converts a vector of tokens into an AST
+   |     -- typecheck.hpp : Verifies all expressions have a well defined type
+   |                        and checks function definitions and calls.
    |
-   |     -- ast.hpp      : Definitions of AST nodes and utility
+   |     -- ast.hpp       : Definitions of AST nodes and utility
    |
-Compiler -- compiler.hpp : Converts an AST into a program
+Compiler -- compiler.hpp  : Converts an AST into a program
    |
-   |     -- program.hpp  : Definitions of program op codes and utility
+   |     -- program.hpp   : Definitions of program op codes and utility
    |
-Runtime  -- runtime.hpp  : Executes the program
+Runtime  -- runtime.hpp   : Executes the program
    |
   Output
 
 Common Modules
 -- functions.hpp   : Definitions of builtin functions
 -- object.hpp      : Definition of an object in anzu
+-- type.hpp        : Definition of a type in anzu
 -- vocabulary.hpp  : Definitions of keywords and symbols
 
 Utility Modules (in src/utility)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,6 @@
 
 
-fn foo(x: list) -> str
+fn foo(x: list) -> int
 {
     return to_str(x)
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -23,7 +23,7 @@ auto print_node(const anzu::node_expr& root, int indent) -> void
         },
         [&](const node_bin_op_expr& node) {
             anzu::print("{}BinOp: \n", spaces);
-            anzu::print("{}- Op: {}\n", spaces, node.op.text);
+            anzu::print("{}- Op: {}\n", spaces, node.token.text);
             anzu::print("{}- Lhs:\n", spaces);
             print_node(*node.lhs, indent + 1);
             anzu::print("{}- Rhs:\n", spaces);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -15,24 +15,31 @@ using node_expr_ptr = std::unique_ptr<node_expr>;
 struct node_literal_expr
 {
     anzu::object value;
+
+    anzu::token token;
 };
 
 struct node_variable_expr
 {
     std::string name;
+
+    anzu::token token;
 };
 
 struct node_bin_op_expr
 {
-    anzu::token   op; // Keep as token for debugging info
     node_expr_ptr lhs;
     node_expr_ptr rhs;
+
+    anzu::token token;
 };
 
 struct node_function_call_expr
 {
     std::string                function_name;
     std::vector<node_expr_ptr> args;
+
+    anzu::token token;
 };
 
 struct node_expr : std::variant<
@@ -49,12 +56,16 @@ using node_stmt_ptr = std::unique_ptr<node_stmt>;
 struct node_sequence_stmt
 {
     std::vector<node_stmt_ptr> sequence;
+
+    anzu::token token;
 };
 
 struct node_while_stmt
 {
     node_expr_ptr condition;
     node_stmt_ptr body;
+
+    anzu::token token;
 };
 
 struct node_if_stmt
@@ -62,6 +73,8 @@ struct node_if_stmt
     node_expr_ptr condition;
     node_stmt_ptr body;
     node_stmt_ptr else_body;
+
+    anzu::token token;
 };
 
 struct node_for_stmt
@@ -69,20 +82,26 @@ struct node_for_stmt
     std::string   var;
     node_expr_ptr container;
     node_stmt_ptr body;
+
+    anzu::token token;
 };
 
 struct node_break_stmt
 {
+    anzu::token token;
 };
 
 struct node_continue_stmt
 {
+    anzu::token token;
 };
 
 struct node_assignment_stmt
 {
     std::string   name;
     node_expr_ptr expr;
+
+    anzu::token token;
 };
 
 struct node_function_def_stmt
@@ -90,21 +109,28 @@ struct node_function_def_stmt
     std::string        name;
     function_signature sig;
     node_stmt_ptr      body;
+
+    anzu::token token;
 };
 
 struct node_function_call_stmt
 {
     std::string                function_name;
     std::vector<node_expr_ptr> args;
+
+    anzu::token token;
 };
 
 struct node_return_stmt
 {
     node_expr_ptr return_value;
+
+    anzu::token token;
 };
 
 struct node_debug_stmt
 {
+    anzu::token token;
 };
 
 struct node_stmt : std::variant<

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -99,21 +99,22 @@ void compile_node(const node_bin_op_expr& node, compiler_context& ctx)
 {
     compile_node(*node.lhs, ctx);
     compile_node(*node.rhs, ctx);
-    if      (node.op.text == "+")  { ctx.program.emplace_back(anzu::op_add{}); }
-    else if (node.op.text == "-")  { ctx.program.emplace_back(anzu::op_sub{}); }
-    else if (node.op.text == "*")  { ctx.program.emplace_back(anzu::op_mul{}); }
-    else if (node.op.text == "/")  { ctx.program.emplace_back(anzu::op_div{}); }
-    else if (node.op.text == "%")  { ctx.program.emplace_back(anzu::op_mod{}); }
-    else if (node.op.text == "<")  { ctx.program.emplace_back(anzu::op_lt{}); }
-    else if (node.op.text == "<=") { ctx.program.emplace_back(anzu::op_le{}); }
-    else if (node.op.text == ">")  { ctx.program.emplace_back(anzu::op_gt{}); }
-    else if (node.op.text == ">=") { ctx.program.emplace_back(anzu::op_ge{}); }
-    else if (node.op.text == "==") { ctx.program.emplace_back(anzu::op_eq{}); }
-    else if (node.op.text == "!=") { ctx.program.emplace_back(anzu::op_ne{}); }
-    else if (node.op.text == "||") { ctx.program.emplace_back(anzu::op_or{}); }
-    else if (node.op.text == "&&") { ctx.program.emplace_back(anzu::op_and{}); }
+    const auto op = node.token.text;
+    if      (op == "+")  { ctx.program.emplace_back(anzu::op_add{}); }
+    else if (op == "-")  { ctx.program.emplace_back(anzu::op_sub{}); }
+    else if (op == "*")  { ctx.program.emplace_back(anzu::op_mul{}); }
+    else if (op == "/")  { ctx.program.emplace_back(anzu::op_div{}); }
+    else if (op == "%")  { ctx.program.emplace_back(anzu::op_mod{}); }
+    else if (op == "<")  { ctx.program.emplace_back(anzu::op_lt{}); }
+    else if (op == "<=") { ctx.program.emplace_back(anzu::op_le{}); }
+    else if (op == ">")  { ctx.program.emplace_back(anzu::op_gt{}); }
+    else if (op == ">=") { ctx.program.emplace_back(anzu::op_ge{}); }
+    else if (op == "==") { ctx.program.emplace_back(anzu::op_eq{}); }
+    else if (op == "!=") { ctx.program.emplace_back(anzu::op_ne{}); }
+    else if (op == "||") { ctx.program.emplace_back(anzu::op_or{}); }
+    else if (op == "&&") { ctx.program.emplace_back(anzu::op_and{}); }
     else {
-        anzu::print("syntax error: unknown binary operator: '{}'\n", node.op.text);
+        anzu::print("syntax error: unknown binary operator: '{}'\n", op);
         std::exit(1);
     }
 }

--- a/src/optimiser.cpp
+++ b/src/optimiser.cpp
@@ -49,7 +49,7 @@ auto evaluate_const_expressions_recurse(node_expr& expr) -> std::optional<anzu::
             auto lhs = evaluate_const_expressions_recurse(*node.lhs);
             auto rhs = evaluate_const_expressions_recurse(*node.rhs);
             if (lhs.has_value() && rhs.has_value()) {
-                auto val = evaluate_bin_op(lhs.value(), rhs.value(), node.op.text);
+                auto val = evaluate_bin_op(lhs.value(), rhs.value(), node.token.text);
                 expr.emplace<anzu::node_literal_expr>(val);
                 return val;
             }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -116,7 +116,7 @@ auto parse_compound_factor(tokenstream& tokens, std::int64_t level) -> node_expr
         auto node = std::make_unique<anzu::node_expr>();
         auto& expr = node->emplace<anzu::node_bin_op_expr>();
         expr.lhs = std::move(factor);
-        expr.op = tokens.consume();
+        expr.token = tokens.consume();
         expr.rhs = parse_compound_factor(tokens, level - 1);
         factor = std::move(node);
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -54,8 +54,9 @@ auto parse_function_call(tokenstream& tokens) -> std::unique_ptr<NodeVariant>
 {
     auto node = std::make_unique<NodeVariant>();
     auto& out = node->emplace<NodeType>();
+    out.token = tokens.consume();
 
-    out.function_name = tokens.consume().text;
+    out.function_name = out.token.text;
     tokens.consume_only(tk_lparen);
     tokens.consume_comma_separated_list(tk_rparen, [&] {
         out.args.push_back(parse_expression(tokens));
@@ -94,12 +95,14 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
     if (tokens.curr().type == token_type::name) {
         auto node = std::make_unique<anzu::node_expr>();
         auto& expr = node->emplace<anzu::node_variable_expr>();
-        expr.name = tokens.consume().text;
+        expr.token = tokens.consume();
+        expr.name = expr.token.text;
         return node;
     }
 
     auto node = std::make_unique<anzu::node_expr>();
     auto& expr = node->emplace<anzu::node_literal_expr>();
+    expr.token = tokens.curr();
     expr.value = parse_literal(tokens);
     return node;
 }
@@ -162,7 +165,7 @@ auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_function_def_stmt>();
 
-    tokens.consume_only(tk_function);
+    stmt.token = tokens.consume_only(tk_function);
     stmt.name = parse_name(tokens);
     tokens.consume_only(tk_lparen);
     tokens.consume_comma_separated_list(tk_rparen, [&] {
@@ -183,7 +186,7 @@ auto parse_return_stmt(tokenstream& tokens) -> node_stmt_ptr
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_return_stmt>();
     
-    tokens.consume_only(tk_return);
+    stmt.token = tokens.consume_only(tk_return);
     if (!anzu::is_sentinel(tokens.curr().text)) {
         stmt.return_value = parse_expression(tokens);
     } else {
@@ -198,7 +201,7 @@ auto parse_while_stmt(tokenstream& tokens) -> node_stmt_ptr
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_while_stmt>();
 
-    tokens.consume_only(tk_while);
+    stmt.token = tokens.consume_only(tk_while);
     stmt.condition = parse_expression(tokens);
     stmt.body = parse_statement(tokens);
     return node;
@@ -209,7 +212,7 @@ auto parse_if_stmt(tokenstream& tokens) -> node_stmt_ptr
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_if_stmt>();
 
-    tokens.consume_only(tk_if);
+    stmt.token = tokens.consume_only(tk_if);
     stmt.condition = parse_expression(tokens);
     stmt.body = parse_statement(tokens);
     if (tokens.consume_maybe(tk_else)) {
@@ -223,7 +226,7 @@ auto parse_for_stmt(tokenstream& tokens) -> node_stmt_ptr
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_for_stmt>();
 
-    tokens.consume_only(tk_for);
+    stmt.token = tokens.consume_only(tk_for);
     stmt.var = parse_name(tokens);
     tokens.consume_only(tk_in);
     stmt.container = parse_expression(tokens);
@@ -237,7 +240,7 @@ auto parse_assignment_stmt(tokenstream& tokens) -> node_stmt_ptr
     auto& stmt = node->emplace<anzu::node_assignment_stmt>();
 
     stmt.name = parse_name(tokens);
-    tokens.consume_only(tk_assign);
+    stmt.token = tokens.consume_only(tk_assign);
     stmt.expr = parse_expression(tokens);
     return node;
 }
@@ -252,7 +255,7 @@ auto parse_braced_statement_list(tokenstream& tokens) -> node_stmt_ptr
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_sequence_stmt>();
     
-    tokens.consume_only(tk_lbrace);
+    stmt.token = tokens.consume_only(tk_lbrace);
     while (!tokens.consume_maybe(tk_rbrace)) {
         stmt.sequence.push_back(parse_statement(tokens));
     }
@@ -281,11 +284,11 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
     if (tokens.peek(tk_for)) {
         return parse_for_stmt(tokens);
     }
-    if (tokens.consume_maybe(tk_break)) {
-        return std::make_unique<node_stmt>(node_break_stmt{});
+    if (tokens.peek(tk_break)) {
+        return std::make_unique<node_stmt>(node_break_stmt{ tokens.consume() });
     }
-    if (tokens.consume_maybe(tk_continue)) {
-        return std::make_unique<node_stmt>(node_continue_stmt{});
+    if (tokens.peek(tk_continue)) {
+        return std::make_unique<node_stmt>(node_continue_stmt{ tokens.consume() });
     }
     if (tokens.peek_next(tk_assign)) { // <name> '='
         return parse_assignment_stmt(tokens);
@@ -296,8 +299,8 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
     if (tokens.peek(tk_lbrace)) {
         return parse_braced_statement_list(tokens);
     }
-    if (tokens.consume_maybe(tk_debug)) {
-        return std::make_unique<node_stmt>(node_debug_stmt{});
+    if (tokens.peek(tk_debug)) {
+        return std::make_unique<node_stmt>(node_debug_stmt{ tokens.consume() });
     }
     parser_error(tokens.curr(), "unknown statement '{}'", tokens.curr().text);
 }

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -122,7 +122,7 @@ auto type_of_expr(const typecheck_context& ctx, const node_expr& expr) -> type
         },
         [&](const node_bin_op_expr& node) {
             return type_of_bin_op(
-                type_of_expr(ctx, *node.lhs), type_of_expr(ctx, *node.rhs), node.op
+                type_of_expr(ctx, *node.lhs), type_of_expr(ctx, *node.rhs), node.token
             );
         }
     }, expr);


### PR DESCRIPTION
* All ast nodes now store a `token` passed through from the lexer by the parser. This allows for line/col values to be in the typechecker error messages.