### PR TITLE
List Expressions

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,4 @@
 
 
-x = 4
-
-l = [1, 2, x]
+x = [[1, 2, 3], "hello world", true, null, [["duffman"]]]
+print(typeof(list_at(x, 1)))

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,15 +1,5 @@
 
 
-fn foo() -> null
-{
-    println("abc")
-}
+x = 4
 
-fn adder(x: int, y: int) -> int
-{
-    return x + y
-}
-
-x = adder(2, 3)
-println(x)
-
+l = [1, 2, x]

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -35,6 +35,13 @@ auto print_node(const anzu::node_expr& root, int indent) -> void
             for (const auto& arg : node.args) {
                 print_node(*arg, indent + 1);
             }
+        },
+        [&](const node_list_expr& node) {
+            anzu::print("{}List (Expr):\n", spaces);
+            anzu::print("{}- Elements:\n", spaces);
+            for (const auto& element : node.elements) {
+                print_node(*element, indent + 1);
+            }
         }
     }, root);
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -42,6 +42,11 @@ struct node_function_call_expr
     anzu::token token;
 };
 
+struct node_list_expr
+{
+    std::vector<node_expr_ptr> elements;
+};
+
 struct node_expr : std::variant<
     node_literal_expr,
     node_variable_expr,

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -45,13 +45,16 @@ struct node_function_call_expr
 struct node_list_expr
 {
     std::vector<node_expr_ptr> elements;
+
+    anzu::token token;
 };
 
 struct node_expr : std::variant<
     node_literal_expr,
     node_variable_expr,
     node_bin_op_expr,
-    node_function_call_expr>
+    node_function_call_expr,
+    node_list_expr>
 {
 };
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -124,6 +124,14 @@ void compile_node(const node_function_call_expr& node, compiler_context& ctx)
     compile_function_call(node.function_name, node.args, ctx);
 }
 
+void compile_node(const node_list_expr& node, compiler_context& ctx)
+{
+    for (const auto& element : node.elements | std::views::reverse) {
+        compile_node(*element, ctx);
+    }
+    ctx.program.emplace_back(anzu::op_build_list{ .size = node.elements.size() });
+}
+
 void compile_node(const node_sequence_stmt& node, compiler_context& ctx)
 {
     for (const auto& seq_node : node.sequence) {

--- a/src/optimiser.cpp
+++ b/src/optimiser.cpp
@@ -54,6 +54,19 @@ auto evaluate_const_expressions_recurse(node_expr& expr) -> std::optional<anzu::
                 return val;
             }
             return std::nullopt;
+        },
+        [&](const node_list_expr& node) -> return_type {
+            auto values = std::make_shared<std::vector<anzu::object>>();
+            values->reserve(node.elements.size());
+            for (const auto& element : node.elements) {
+                auto val = evaluate_const_expressions_recurse(*element);
+                if (!val) {
+                    return std::nullopt;  // Non-literal value in this list.
+                }
+                values->push_back(*val);
+            }
+            expr.emplace<anzu::node_literal_expr>(values);
+            return anzu::object{values};
         }
     }, expr);
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -39,13 +39,6 @@ auto parse_literal(tokenstream& tokens) -> anzu::object
     if (tokens.consume_maybe(tk_null)) {
         return anzu::null_object();
     }
-    if (tokens.consume_maybe(tk_lbracket)) {
-        auto list = std::make_shared<std::vector<anzu::object>>();
-        tokens.consume_comma_separated_list(tk_rbracket, [&] {
-            list->push_back(parse_literal(tokens));
-        });
-        return { list };
-    }
     parser_error(tokens.curr(), "failed to parse literal");
 };
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -81,6 +81,15 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
         auto expr = parse_expression(tokens);
         tokens.consume_only(tk_rparen);
         return expr;
+    }
+    if (tokens.peek(tk_lbracket)) {
+        auto node = std::make_unique<anzu::node_expr>();
+        auto& expr = node->emplace<anzu::node_list_expr>();
+        expr.token = tokens.consume();
+        tokens.consume_comma_separated_list(tk_rbracket, [&] {
+            expr.elements.push_back(parse_expression(tokens));
+        });
+        return node;
     }  
     if (tokens.peek_next(tk_lparen)) {
         return parse_function_call_expr(tokens);

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -125,6 +125,9 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_and& op) {
             return std::string{"OP_AND"};
         },
+        [&](const op_build_list& op) {
+            return std::format("OP_BUILD_LIST({})", op.size);
+        },
         [&](const op_debug& op) {
             return std::string{"OP_DEBUG"};
         }

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -162,6 +162,11 @@ struct op_return
 {
 };
 
+struct op_build_list
+{
+    std::size_t size;
+};
+
 struct op_debug
 {
 
@@ -201,6 +206,8 @@ struct op : std::variant<
     op_return,
     op_function_call,
     op_builtin_call,
+    op_build_list,
+
     op_debug
 >
 {};

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -242,6 +242,14 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.push_value(a && b);
             ctx.peek_frame().ptr += 1;
         },
+        [&](const op_build_list& op) {
+            auto list = std::make_shared<std::vector<anzu::object>>();
+            for (std::size_t i = 0; i != op.size; ++i) {
+                list->push_back(ctx.pop_value());
+            }
+            ctx.push_value(list);
+            ctx.peek_frame().ptr += 1;
+        },
         [&](const op_debug& op) {
             auto& frame = ctx.peek_frame();
             anzu::print("frame memory:\n");

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -130,6 +130,9 @@ auto type_of_expr(const typecheck_context& ctx, const node_expr& expr) -> type
             return type_of_bin_op(
                 type_of_expr(ctx, *node.lhs), type_of_expr(ctx, *node.rhs), node.token
             );
+        },
+        [&](const node_list_expr& node) {
+            return make_list();
         }
     }, expr);
 };


### PR DESCRIPTION
* Previously, you could only write out list literals where the contents were also literals, so the following would be invalid:
    ```
    x = 5
    y = [1, 2, x]
    ```
* This PR adds a new expression node, `node_list_expr`, which contains a list of child expression nodes for its children.
* A `node_list_expr` compiles down to evaluating the nodes, pushing them to the stack, then calling the new op code `op_build_list(n)`, which takes the top n elements off the stack and pushes a list containing them.
* With optimisations on, a list literal is optimised down to a single op code, so this is not a regression in that case.