### PR TITLE
Housecleaning

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1,15 +1,11 @@
 #include "ast.hpp"
 #include "utility/print.hpp"
+#include "utility/overloaded.hpp"
 
 #include <functional>
 #include <ranges>
 
 namespace anzu {
-namespace {
-
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
-
-}
 
 auto print_node(const anzu::node_expr& root, int indent) -> void
 {

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -12,8 +12,8 @@ using builtin_function = object(*)(std::span<const object>);
 
 struct builtin
 {
-    builtin_function   ptr;
-    signature sig;
+    builtin_function ptr;
+    signature        sig;
 };
 
 auto is_builtin(const std::string& name) -> bool;

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -78,7 +78,10 @@ auto parse_token(line_iterator& iter) -> std::string
     return return_value;
 };
 
-auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const std::int64_t lineno) -> void
+auto lex_line(
+    std::vector<anzu::token>& tokens, const std::string& line, const std::int64_t lineno
+)
+    -> void
 {
     const auto push_token = [&](const std::string& text, std::int64_t col, token_type type) {
         tokens.push_back({ .text=text, .line=lineno, .col=col, .type=type });

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -27,14 +27,17 @@ auto move_to_next(line_iterator& iter) -> bool
 }
 
 template <typename... Args>
-[[noreturn]] void lexer_error(int lineno, int col, std::string_view msg, Args&&... args)
+[[noreturn]] auto lexer_error(
+    std::int64_t lineno, std::int64_t col, std::string_view msg, Args&&... args
+)
+    -> void
 {
     const auto formatted_msg = std::format(msg, std::forward<Args>(args)...);
     anzu::print("[ERROR] ({}:{}) {}\n", lineno, col, formatted_msg);
     std::exit(1);
 }
 
-auto parse_string_literal(int lineno, line_iterator& iter) -> std::string
+auto parse_string_literal(std::int64_t lineno, line_iterator& iter) -> std::string
 {
     const auto col = iter.position();
     std::string return_value;
@@ -75,15 +78,15 @@ auto parse_token(line_iterator& iter) -> std::string
     return return_value;
 };
 
-auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const int lineno) -> void
+auto lex_line(std::vector<anzu::token>& tokens, const std::string& line, const std::int64_t lineno) -> void
 {
-    const auto push_token = [&](const std::string& text, int col, token_type type) {
+    const auto push_token = [&](const std::string& text, std::int64_t col, token_type type) {
         tokens.push_back({ .text=text, .line=lineno, .col=col, .type=type });
     };
 
     auto iter = line_iterator{line};
     while (move_to_next(iter)) {
-        const int col = iter.position();
+        const auto col = iter.position();
 
         if (iter.consume_maybe('"')) {
             const auto literal = parse_string_literal(lineno, iter);
@@ -125,7 +128,7 @@ auto lex(const std::string& file) -> std::vector<anzu::token>
     std::vector<anzu::token> tokens;
     std::ifstream file_stream{file};
     std::string line;
-    int lineno = 1;
+    std::int64_t lineno = 1;
     while (std::getline(file_stream, line)) {
         lex_line(tokens, line, lineno);
         ++lineno;

--- a/src/optimiser.cpp
+++ b/src/optimiser.cpp
@@ -1,12 +1,11 @@
 #include "optimiser.hpp"
 #include "object.hpp"
+#include "utility/overloaded.hpp"
 
 #include <optional>
 
 namespace anzu {
 namespace {
-
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 
 auto evaluate_bin_op(
     const anzu::object& lhs, const anzu::object& rhs, std::string_view op

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1,12 +1,11 @@
 #include "program.hpp"
 #include "object.hpp"
+#include "utility/overloaded.hpp"
 
 #include <string>
 
 namespace anzu {
 namespace {
-
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 
 constexpr auto FORMAT2 = std::string_view{"{:<30} {}"};
 constexpr auto FORMAT3 = std::string_view{"{:<30} {:<20} {}"};

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -1,14 +1,10 @@
 #include "runtime.hpp"
 #include "utility/print.hpp"
+#include "utility/overloaded.hpp"
 
 #include <utility>
 
 namespace anzu {
-namespace {
-
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
-
-}
 
 auto memory::insert(const std::string& name, const anzu::object& value) -> anzu::object&
 {

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -18,10 +18,10 @@ enum class token_type
 
 struct token
 {
-    std::string text;
-    int         line;
-    int         col;
-    token_type  type;
+    std::string  text;
+    std::int64_t line;
+    std::int64_t col;
+    token_type   type;
 };
 
 auto to_string(token_type type) -> std::string;

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1,15 +1,11 @@
 #include "type.hpp"
 #include "utility/print.hpp"
+#include "utility/overloaded.hpp"
 
 #include <algorithm>
 #include <cassert>
 
 namespace anzu {
-namespace {
-
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
-
-}
 
 auto to_string(const type& type) -> std::string
 {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -1,6 +1,7 @@
 #include "typecheck.hpp"
 #include "vocabulary.hpp"
 #include "type.hpp"
+#include "utility/overloaded.hpp"
 
 #include <algorithm>
 #include <ranges>
@@ -15,8 +16,6 @@ auto return_key() -> std::string
     static const auto ret = std::string{tk_return};
     return ret;
 }
-
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 
 struct typecheck_scope
 {

--- a/src/utility/overloaded.hpp
+++ b/src/utility/overloaded.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace anzu {
+
+template <typename... Ts>
+struct overloaded : Ts...
+{
+    using Ts::operator()...;
+};
+
+}

--- a/src/utility/peekstream.hpp
+++ b/src/utility/peekstream.hpp
@@ -24,7 +24,7 @@ public:
 
     auto curr() const -> const value_type& { return *d_curr; }
     auto next() const -> const value_type& { return *std::next(d_curr); }
-    auto position() const -> int { return std::distance(d_begin, d_curr) + 1; }
+    auto position() const -> std::int64_t { return std::distance(d_begin, d_curr) + 1; }
 
     auto consume() -> value_type
     {


### PR DESCRIPTION
* Fix compiler warnings.
* Move all the `overloaded` copies to `utility/overloaded.hpp`.
* Use `format_comma_separated` in the repr implementation for lists.