### PR TITLE
Lookup Functions Within Other Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Common Modules
 Utility Modules (in src/utility)
 -- print.hpp       : Wrapper for std::format, similar to {fmt}
 -- peekstream.hpp  : A data structure used in the lexer
+-- overloaded.hpp  : A helper class to make std::visit simpler
 ```
 
 # Upcoming Features

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -103,3 +103,16 @@ for l in new_list {
 }
 println("new_list should have 5 elements:")
 println(new_list)
+
+# Allowing functions from other functions
+fn add2(x: int, y: int) -> int
+{
+    return x + y
+}
+
+fn add3(x: int, y: int, z: int) -> int
+{
+    return add2(x, add2(y, z))
+}
+
+println(add3(1, 2, 3))

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,3 @@
-
-
-
 fn front(x: list<int>) -> int
 {
     return list_at(x, 0)

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,8 +3,13 @@
 
 fn front(x: list<int>) -> int
 {
-    return 5
+    return list_at(x, 0)
 }
 
-y = front([1, 2, 3])
-println(y)
+fn print_front(x: list<int>) -> null
+{
+    println(front(x))    
+}
+
+x = [1, 2, 3]
+print_front(x)

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -108,3 +108,16 @@ struct std::formatter<anzu::signature> : std::formatter<std::string>
         return std::formatter<std::string>::format(anzu::to_string(type), ctx);
     }
 };
+
+template <>
+struct std::hash<anzu::signature>
+{
+    auto operator()(const anzu::signature& sig) const -> std::size_t
+    {
+        auto ret = anzu::hash(sig.return_type);
+        for (const auto& arg : sig.args) {
+            ret ^= anzu::hash(arg.type);
+        }
+        return ret;
+    }
+};

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -28,7 +28,7 @@ struct typecheck_context
     std::vector<typecheck_scope> scopes;
     anzu::type_store types;
 
-    std::unordered_map<const node_function_def_stmt*, std::vector<signature>> checked_sigs;
+    std::unordered_map<const node_function_def_stmt*, std::unordered_set<signature>> checked_sigs;
 };
 
 auto typecheck_node(typecheck_context& ctx, const node_stmt& node) -> void;
@@ -278,8 +278,8 @@ auto typecheck_function_call(
         const auto* function_def = fetch_function(ctx, tok, function_name);
         if (is_function_generic(*function_def)) {
             auto& checked_sigs = ctx.checked_sigs[function_def];
-            if (std::find(begin(checked_sigs), end(checked_sigs), signature) == end(checked_sigs)) {
-                checked_sigs.push_back(signature);
+            if (checked_sigs.contains(signature)) {
+                checked_sigs.insert(signature);
                 typecheck_function_body_with_signature(ctx, *function_def, signature);
             }
         }

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -25,7 +25,7 @@ struct typecheck_scope
 
 struct typecheck_context
 {
-    std::stack<typecheck_scope> scopes;
+    std::vector<typecheck_scope> scopes;
     anzu::type_store types;
 
     std::unordered_map<const node_function_def_stmt*, std::vector<signature>> checked_sigs;
@@ -130,7 +130,7 @@ auto fetch_function_signature(
 )
     -> signature
 {
-    const auto& scope = ctx.scopes.top();
+    const auto& scope = ctx.scopes.back();
     if (auto it = scope.functions.find(function_name); it != scope.functions.end()) {
         return it->second->sig;
     }
@@ -232,17 +232,17 @@ auto typecheck_function_body_with_signature(
 )
     -> void
 {
-    ctx.scopes.emplace();
+    ctx.scopes.emplace_back();
     for (const auto& arg : sig.args) {
         verify_real_type(ctx, node.token, arg.type);
-        ctx.scopes.top().variables[arg.name] = arg.type;
+        ctx.scopes.back().variables[arg.name] = arg.type;
     }
     verify_real_type(ctx, node.token, sig.return_type);
-    ctx.scopes.top().variables[return_key()] = sig.return_type; // Expose the return type for children
-    ctx.scopes.top().functions[node.name] = &node;              // Make available for recursion
+    ctx.scopes.back().variables[return_key()] = sig.return_type; // Expose the return type for children
+    ctx.scopes.back().functions[node.name] = &node;              // Make available for recursion
     
     typecheck_node(ctx, *node.body);
-    ctx.scopes.pop();
+    ctx.scopes.pop_back();
 
     check_function_ends_with_return(node);
 }
@@ -260,7 +260,7 @@ auto typecheck_function_call(
     );
 
     if (!is_builtin(function_name)) {
-        const auto* function_def = ctx.scopes.top().functions.at(function_name);
+        const auto* function_def = ctx.scopes.back().functions.at(function_name);
         if (is_function_generic(*function_def)) {
             auto& checked_sigs = ctx.checked_sigs[function_def];
             if (std::find(begin(checked_sigs), end(checked_sigs), signature) == end(checked_sigs)) {
@@ -280,7 +280,7 @@ auto typecheck_expr(typecheck_context& ctx, const node_expr& expr) -> type
             return type_of(node.value);
         },
         [&](const node_variable_expr& node) {
-            const auto& top = ctx.scopes.top();
+            const auto& top = ctx.scopes.back();
             return top.variables.at(node.name);
         },
         [&](const node_function_call_expr& node) {
@@ -346,7 +346,7 @@ auto typecheck_node(typecheck_context& ctx, const node_for_stmt& node) -> void
     if (!matches.has_value()) {
         type_error(get_token(*node.container), "expected '{}', got '{}'", expected_type, container_type);
     }
-    ctx.scopes.top().variables[node.var] = matches->at(0);
+    ctx.scopes.back().variables[node.var] = matches->at(0);
     typecheck_node(ctx, *node.body);
 }
 
@@ -360,12 +360,12 @@ auto typecheck_node(typecheck_context& ctx, const node_continue_stmt&) -> void
 
 auto typecheck_node(typecheck_context& ctx, const node_assignment_stmt& node) -> void
 {
-    ctx.scopes.top().variables[node.name] = typecheck_expr(ctx, *node.expr);
+    ctx.scopes.back().variables[node.name] = typecheck_expr(ctx, *node.expr);
 }
 
 auto typecheck_node(typecheck_context& ctx, const node_function_def_stmt& node) -> void
 {
-    ctx.scopes.top().functions[node.name] = &node; // Make name available in outer scope
+    ctx.scopes.back().functions[node.name] = &node; // Make name available in outer scope
 
     // If this is a generic function, we cannot perform type checking on it here.
     // Instead, store the name, and type check it at the function call sites.
@@ -385,7 +385,7 @@ auto typecheck_node(typecheck_context& ctx, const node_function_call_stmt& node)
 
 auto typecheck_node(typecheck_context& ctx, const node_return_stmt& node)
 {
-    const auto& return_type = ctx.scopes.top().variables.at(return_key());
+    const auto& return_type = ctx.scopes.back().variables.at(return_key());
     verify_expression_type(ctx, *node.return_value, return_type);
 }
 
@@ -436,7 +436,7 @@ auto type_of(const anzu::object& object) -> type
 auto typecheck_ast(const node_stmt_ptr& ast) -> void
 {
     auto ctx = typecheck_context{};
-    ctx.scopes.emplace(); // Global scope
+    ctx.scopes.emplace_back(); // Global scope
     typecheck_node(ctx, *ast);
 }
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -125,7 +125,7 @@ auto is_function_generic(const node_function_def_stmt& node) -> bool
     return is_generic;
 }
 
-auto fetch_function(
+auto fetch_function_def(
     const typecheck_context& ctx, const token& tok, const std::string& function_name
 )
     -> const node_function_def_stmt*
@@ -275,7 +275,7 @@ auto typecheck_function_call(
     );
 
     if (!is_builtin(function_name)) {
-        const auto* function_def = fetch_function(ctx, tok, function_name);
+        const auto* function_def = fetch_function_def(ctx, tok, function_name);
         if (is_function_generic(*function_def)) {
             auto& checked_sigs = ctx.checked_sigs[function_def];
             if (checked_sigs.contains(signature)) {


### PR DESCRIPTION
* Currently, the type checker was disallowing calls to functions from within other functions, only nested functions written inside the given functions, since it only checked the local scope to lookup function signatures. This relaxes the checker to look at previous scopes for function definitions is the current scope is missing it.
* The scopes are now stored in a vector instead of a stack to make all elements accessible.
* The checked signatures that are stored in a map for each function def in now stored in an unordered set rather than a vector. To implement this, signatures are now hashable. The hash ignores the arg names, which we may want in the future?
* Without the type checker, compiled anzu code can call functions from other functions fine, but this is due to the `compiler_context` storing all function definitions in a single map, which will cause issues with shadowed functions and will need to be fixed.