### PR TITLE
Fix Function Scope Issues

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -116,3 +116,26 @@ fn add3(x: int, y: int, z: int) -> int
 }
 
 println(add3(1, 2, 3))
+
+# Nested Function Lookup
+# We define a function, then define a function with the same name within a different
+# function. This should not overwrite the original function in the top scope
+fn get_num() -> int
+{
+    return 1
+}
+
+fn foo() -> null
+{
+    fn get_num() -> int
+    {
+        return 2
+    }
+}
+
+println(
+    "We should get 1 when calling get_num since the version returning 2 is not in this scope"
+)
+print("get_num() == ")
+print(get_num())
+print("\n")

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,12 +1,16 @@
-fn front(x: list<int>) -> int
+fn get_num() -> int
 {
-    return list_at(x, 0)
+    return 1
 }
 
-fn print_front(x: list<int>) -> null
+fn foo() -> null
 {
-    println(front(x))    
+    fn get_num() -> int
+    {
+        return 2
+    }
 }
 
-x = [1, 2, 3]
-print_front(x)
+x = get_num()
+println(x)  # Whoops! Prints 2, should be 1, need to add nesting of fn defs to compiler
+            # See the type checker for a similar system.

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -8,6 +8,7 @@
 #include <string_view>
 #include <optional>
 #include <tuple>
+#include <vector>
 #include <unordered_map>
 
 namespace anzu {
@@ -23,8 +24,21 @@ struct compiler_context
     };
 
     anzu::program program;
-    std::unordered_map<std::string, function_def> functions;
+    std::vector<std::unordered_map<std::string, function_def>> functions;
 };
+
+auto find_function(
+    const compiler_context& ctx, const std::string& function
+)
+    -> const compiler_context::function_def*
+{
+    for (const auto& scope : ctx.functions | std::views::reverse) {
+        if (const auto it = scope.find(function); it != scope.end()) {
+            return &it->second;
+        }
+    }
+    return nullptr;
+}
 
 namespace {
 
@@ -67,12 +81,11 @@ void compile_function_call(
         compile_node(*arg, ctx);
     }
 
-    if (const auto it = ctx.functions.find(function); it != ctx.functions.end()) {
-        const auto& function_def = it->second;
+    if (const auto function_def = find_function(ctx, function)) {
         ctx.program.emplace_back(anzu::op_function_call{
             .name=function,
-            .ptr=function_def.ptr + 1, // Jump into the function
-            .sig=function_def.sig
+            .ptr=function_def->ptr + 1, // Jump into the function
+            .sig=function_def->sig
         });
     }
     else {
@@ -256,9 +269,11 @@ void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
 {
     const auto start_pos = std::ssize(ctx.program);
     ctx.program.emplace_back(anzu::op_function{ .name=node.name, .sig=node.sig });
-    ctx.functions[node.name] = { .sig=node.sig ,.ptr=start_pos };
+    ctx.functions.back()[node.name] = { .sig=node.sig ,.ptr=start_pos };
 
+    ctx.functions.emplace_back();
     compile_node(*node.body, ctx);
+    ctx.functions.pop_back();
 
     const auto end_pos = std::ssize(ctx.program);
     ctx.program.emplace_back(anzu::op_function_end{});
@@ -298,6 +313,7 @@ auto compile_node(const node_stmt& root, compiler_context& ctx) -> void
 auto compile(const std::unique_ptr<node_stmt>& root) -> anzu::program
 {
     anzu::compiler_context ctx;
+    ctx.functions.emplace_back(); // Global scope
     compile_node(*root, ctx);
     return ctx.program;
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -271,7 +271,7 @@ void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
     ctx.program.emplace_back(anzu::op_function{ .name=node.name, .sig=node.sig });
     ctx.functions.back()[node.name] = { .sig=node.sig ,.ptr=start_pos };
 
-    ctx.functions.emplace_back();
+    ctx.functions.emplace_back(); // New scope for nested functions
     compile_node(*node.body, ctx);
     ctx.functions.pop_back();
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -254,8 +254,7 @@ auto typecheck_function_body_with_signature(
     }
     verify_real_type(ctx, node.token, sig.return_type);
     ctx.scopes.back().variables[return_key()] = sig.return_type; // Expose the return type for children
-    ctx.scopes.back().functions[node.name] = &node;              // Make available for recursion
-    
+ 
     typecheck_node(ctx, *node.body);
     ctx.scopes.pop_back();
 


### PR DESCRIPTION
* In the compiler we had no notion of scoped function definitions. So if a function had a nested function with the same name as an outer function, it would overwrite it and calls to the function in the outer scope would call the nested function.
* Similar to the `typecheck_context`, the `compiler_context` now stores the function map as a stack of function maps which fixes the issue.
* With the last PR able to look in outer scopes for function definitions, a function def registering itself in the new scope before evaluating the body is no longer needed. (Minor point but I like it).