### PR TITLE
Resolve Variable Names at Compile Time

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/test.az", "run"],
+            "args": ["${workspaceFolder}/examples/feature_test.az", "run"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -61,7 +61,7 @@ fn adder(a: int, b: int, c: int) -> int
 }
 
 print("Does adder(1, 2, 3) == 6? ")
-if to_bool(adder(1, 2, 3) == 6) {
+if adder(1, 2, 3) == 6 {
     println("yes")
 } else {
     println("no")

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,15 @@
+
+
 a := 1
 b := 2
 
 println(a)
 println(b)
+
+for c in [1, 2, 3, 4, 5]
+{
+    println(c)
+}
+
+a = 2
+d := 10

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,3 +4,9 @@ for y in [1, 2, 3, 4]
 {
     println(y)
 }
+println(y)
+
+for y in ["1", "2", "3", "4"]
+{
+    println(y)
+}

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,15 +1,10 @@
 
+a := 5
 
-a := 1
-b := 2
-
-println(a)
-println(b)
-
-for c in [1, 2, 3, 4, 5]
+fn access_global() -> int
 {
-    println(c)
+    println(a)
+    return a
 }
 
-a = 2
-d := 10
+access_global()

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,12 +4,3 @@ for y in [1, 2, 3, 4]
 {
     println(y)
 }
-
-#_Container := [1, 2, 3, 4]
-#_Index := 0
-#while _Index < list_size(_Container)
-#{
-#    y := list_at(_Container, _Index)
-#    println(y)
-#    _Index = _Index + 1
-#}

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,10 +1,9 @@
 
-a := 5
+x := true
 
-fn access_global() -> int
+fn add(x: int, y: int) -> int
 {
-    println(a)
-    return a
+    return x + y
 }
 
-access_global()
+add(1, 2)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,9 +1,15 @@
 
-x := true
 
-fn add(x: int, y: int) -> int
+for y in [1, 2, 3, 4]
 {
-    return x + y
+    println(y)
 }
 
-add(1, 2)
+#_Container := [1, 2, 3, 4]
+#_Index := 0
+#while _Index < list_size(_Container)
+#{
+#    y := list_at(_Container, _Index)
+#    println(y)
+#    _Index = _Index + 1
+#}

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -114,9 +114,6 @@ auto print_node(const anzu::node_stmt& root, int indent) -> void
         [&](const node_return_stmt& node) {
             anzu::print("{}Return:\n", spaces);
             print_node(*node.return_value, indent + 1);
-        },
-        [&](const node_debug_stmt& node) {
-            anzu::print("{}--Debug--\n", spaces);
         }
     }, root);
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -144,11 +144,6 @@ struct node_return_stmt
     anzu::token token;
 };
 
-struct node_debug_stmt
-{
-    anzu::token token;
-};
-
 struct node_stmt : std::variant<
     node_sequence_stmt,
     node_while_stmt,
@@ -160,8 +155,7 @@ struct node_stmt : std::variant<
     node_assignment_stmt,
     node_function_def_stmt,
     node_function_call_stmt,
-    node_return_stmt,
-    node_debug_stmt>
+    node_return_stmt>
 {
 };
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -314,8 +314,10 @@ void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
     ctx.scopes.back().functions[node.name] = { .sig=node.sig ,.ptr=start_pos };
 
     ctx.scopes.emplace_back();
-    for (const auto& arg : node.sig.args | std::views::reverse) {
-        save_variable(ctx, arg.name);
+    // Register the args under the names in the function scope
+    auto& vars = ctx.scopes.back().variables;
+    for (const auto& arg : node.sig.args) {
+        vars.emplace(arg.name, vars.size());
     }
     compile_node(*node.body, ctx);
     ctx.scopes.pop_back();

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -111,7 +111,7 @@ void compile_node(const node_literal_expr& node, compiler_context& ctx)
 
 void compile_node(const node_variable_expr& node, compiler_context& ctx)
 {
-    ctx.program.emplace_back(anzu::op_load_variable{ .name=node.name });
+    ctx.program.emplace_back(anzu::op_load_local{ .name=node.name });
 }
 
 void compile_node(const node_bin_op_expr& node, compiler_context& ctx)
@@ -241,7 +241,7 @@ void compile_node(const node_for_stmt& node, compiler_context& ctx)
     auto& vars = ctx.scopes.back().variables;
     vars.emplace(node.var, vars.size());
     anzu::print("Storing {} at offset {}\n", node.var, vars.at(node.var));
-    ctx.program.emplace_back(anzu::op_save_variable{ .name=node.var }); // Store in var
+    ctx.program.emplace_back(anzu::op_save_local{ .name=node.var }); // Store in var
 
     compile_node(*node.body, ctx);
 
@@ -275,13 +275,13 @@ void compile_node(const node_declaration_stmt& node, compiler_context& ctx)
     auto& vars = ctx.scopes.back().variables;
     vars.emplace(node.name, vars.size());
     anzu::print("Storing {} at offset {}\n", node.name, vars.at(node.name));
-    ctx.program.emplace_back(anzu::op_save_variable{ .name=node.name });
+    ctx.program.emplace_back(anzu::op_save_local{ .name=node.name });
 }
 
 void compile_node(const node_assignment_stmt& node, compiler_context& ctx)
 {
     compile_node(*node.expr, ctx);
-    ctx.program.emplace_back(anzu::op_save_variable{ .name=node.name });
+    ctx.program.emplace_back(anzu::op_save_local{ .name=node.name });
 }
 
 void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
@@ -295,7 +295,7 @@ void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
         auto& vars = ctx.scopes.back().variables;
         vars.emplace(arg.name, vars.size());
         anzu::print("Storing {} at offset {}\n", arg.name, vars.at(arg.name));
-        ctx.program.emplace_back(anzu::op_save_variable{ .name = arg.name });
+        ctx.program.emplace_back(anzu::op_save_local{ .name = arg.name });
     }
     compile_node(*node.body, ctx);
     ctx.scopes.pop_back();

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -136,7 +136,7 @@ void compile_node(const node_variable_expr& node, compiler_context& ctx)
     }
 
     const auto& globals = ctx.scopes.front().variables;
-    if (auto it = globals.find(node.name); it != locals.end()) {
+    if (auto it = globals.find(node.name); it != globals.end()) {
         ctx.program.emplace_back(anzu::op_load_global{
             .name=node.name, .position=it->second
         });

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -293,8 +293,8 @@ void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
     ctx.scopes.emplace_back();
     for (const auto& arg : node.sig.args | std::views::reverse) {
         auto& vars = ctx.scopes.back().variables;
-        vars.emplace(node.name, vars.size());
-        anzu::print("Storing {} at offset {}\n", node.name, vars.at(node.name));
+        vars.emplace(arg.name, vars.size());
+        anzu::print("Storing {} at offset {}\n", arg.name, vars.at(arg.name));
         ctx.program.emplace_back(anzu::op_store{ .name = arg.name });
     }
     compile_node(*node.body, ctx);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -210,7 +210,7 @@ void compile_node(const node_sequence_stmt& node, compiler_context& ctx)
 void compile_node(const node_while_stmt& node, compiler_context& ctx)
 {
     const auto while_pos = std::ssize(ctx.program);
-    ctx.program.emplace_back(anzu::op_while{});
+    ctx.program.emplace_back(anzu::op_loop_begin{});
 
     compile_node(*node.condition, ctx);
     
@@ -220,7 +220,7 @@ void compile_node(const node_while_stmt& node, compiler_context& ctx)
     compile_node(*node.body, ctx);
 
     const auto end_pos = std::ssize(ctx.program);
-    ctx.program.emplace_back(anzu::op_while_end{ .jump=while_pos }); // Jump back to start
+    ctx.program.emplace_back(anzu::op_loop_end{ .jump=while_pos }); // Jump back to start
 
     link_up_jumps(ctx, while_pos, do_pos, end_pos);
 }
@@ -267,7 +267,7 @@ void compile_node(const node_for_stmt& node, compiler_context& ctx)
     save_variable(ctx, index_name);
 
     const auto begin_pos = std::ssize(ctx.program);
-    ctx.program.emplace_back(anzu::op_while{});
+    ctx.program.emplace_back(anzu::op_loop_begin{});
 
     load_variable(ctx, index_name);
     load_variable(ctx, container_name);
@@ -291,7 +291,7 @@ void compile_node(const node_for_stmt& node, compiler_context& ctx)
     save_variable(ctx, index_name);
 
     const auto end_pos = std::ssize(ctx.program);
-    ctx.program.emplace_back(anzu::op_while_end{ .jump=begin_pos });
+    ctx.program.emplace_back(anzu::op_loop_end{ .jump=begin_pos });
 
     link_up_jumps(ctx, begin_pos, do_pos, end_pos);
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -106,12 +106,12 @@ void compile_function_call(
 
 void compile_node(const node_literal_expr& node, compiler_context& ctx)
 {
-    ctx.program.emplace_back(anzu::op_push_const{ .value=node.value });
+    ctx.program.emplace_back(anzu::op_load_literal{ .value=node.value });
 }
 
 void compile_node(const node_variable_expr& node, compiler_context& ctx)
 {
-    ctx.program.emplace_back(anzu::op_push_var{ .name=node.name });
+    ctx.program.emplace_back(anzu::op_load_variable{ .name=node.name });
 }
 
 void compile_node(const node_bin_op_expr& node, compiler_context& ctx)
@@ -216,7 +216,7 @@ void compile_node(const node_for_stmt& node, compiler_context& ctx)
     });
 
     // Push the counter to the stack
-    ctx.program.emplace_back(anzu::op_push_const{ .value=object{0} });
+    ctx.program.emplace_back(anzu::op_load_literal{ .value=object{0} });
 
     // Stack: list, size, counter(0)
 
@@ -241,12 +241,12 @@ void compile_node(const node_for_stmt& node, compiler_context& ctx)
     auto& vars = ctx.scopes.back().variables;
     vars.emplace(node.var, vars.size());
     anzu::print("Storing {} at offset {}\n", node.var, vars.at(node.var));
-    ctx.program.emplace_back(anzu::op_store{ .name=node.var }); // Store in var
+    ctx.program.emplace_back(anzu::op_save_variable{ .name=node.var }); // Store in var
 
     compile_node(*node.body, ctx);
 
     // Increment the index
-    ctx.program.emplace_back(anzu::op_push_const{ .value=object{1} });
+    ctx.program.emplace_back(anzu::op_load_literal{ .value=object{1} });
     ctx.program.emplace_back(anzu::op_add{});
 
     const auto end_pos = std::ssize(ctx.program);
@@ -275,13 +275,13 @@ void compile_node(const node_declaration_stmt& node, compiler_context& ctx)
     auto& vars = ctx.scopes.back().variables;
     vars.emplace(node.name, vars.size());
     anzu::print("Storing {} at offset {}\n", node.name, vars.at(node.name));
-    ctx.program.emplace_back(anzu::op_store{ .name=node.name });
+    ctx.program.emplace_back(anzu::op_save_variable{ .name=node.name });
 }
 
 void compile_node(const node_assignment_stmt& node, compiler_context& ctx)
 {
     compile_node(*node.expr, ctx);
-    ctx.program.emplace_back(anzu::op_store{ .name=node.name });
+    ctx.program.emplace_back(anzu::op_save_variable{ .name=node.name });
 }
 
 void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
@@ -295,7 +295,7 @@ void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
         auto& vars = ctx.scopes.back().variables;
         vars.emplace(arg.name, vars.size());
         anzu::print("Storing {} at offset {}\n", arg.name, vars.at(arg.name));
-        ctx.program.emplace_back(anzu::op_store{ .name = arg.name });
+        ctx.program.emplace_back(anzu::op_save_variable{ .name = arg.name });
     }
     compile_node(*node.body, ctx);
     ctx.scopes.pop_back();

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -349,11 +349,6 @@ void compile_node(const node_return_stmt& node, compiler_context& ctx)
     ctx.program.emplace_back(anzu::op_return{});
 }
 
-void compile_node(const node_debug_stmt& node, compiler_context& ctx)
-{
-    ctx.program.emplace_back(anzu::op_debug{});
-}
-
 auto compile_node(const node_expr& root, compiler_context& ctx) -> void
 {
     std::visit([&](const auto& node) { compile_node(node, ctx); }, root);

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -65,18 +65,18 @@ public:
 
     auto to_repr() const -> std::string;
 
-    friend object operator+(const object& lhs, const object& rhs);
-    friend object operator-(const object& lhs, const object& rhs);
-    friend object operator*(const object& lhs, const object& rhs);
-    friend object operator/(const object& lhs, const object& rhs);
-    friend object operator%(const object& lhs, const object& rhs);
+    friend auto operator+(const object& lhs, const object& rhs) -> object;
+    friend auto operator-(const object& lhs, const object& rhs) -> object;
+    friend auto operator*(const object& lhs, const object& rhs) -> object;
+    friend auto operator/(const object& lhs, const object& rhs) -> object;
+    friend auto operator%(const object& lhs, const object& rhs) -> object;
     
-    friend std::strong_ordering operator<=>(const object& lhs, const object& rhs) = default;
+    friend auto operator||(const object& lhs, const object& rhs) -> bool;
+    friend auto operator&&(const object& lhs, const object& rhs) -> bool;
 
-    friend bool operator||(const object& lhs, const object& rhs);
-    friend bool operator&&(const object& lhs, const object& rhs);
+    friend auto operator<=>(const object& lhs, const object& rhs) -> std::strong_ordering = default;
 
-    friend void swap(object& lhs, object& rhs);
+    friend auto swap(object& lhs, object& rhs) -> void;
 };
 
 inline auto null_object() -> anzu::object { return object{object_null{}}; }

--- a/src/optimiser.cpp
+++ b/src/optimiser.cpp
@@ -119,8 +119,7 @@ auto evaluate_const_expressions(node_stmt& tree) -> void
         },
         [](node_return_stmt& stmt) {
             evaluate_const_expressions(*stmt.return_value);
-        },
-        [](node_debug_stmt& stmt) {}
+        }
     }, tree);
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -317,9 +317,6 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
     if (tokens.peek(tk_lbrace)) {
         return parse_braced_statement_list(tokens);
     }
-    if (tokens.peek(tk_debug)) {
-        return std::make_unique<node_stmt>(node_debug_stmt{ tokens.consume() });
-    }
     parser_error(tokens.curr(), "unknown statement '{}'", tokens.curr().text);
 }
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -18,8 +18,11 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_load_literal& op) {
             return std::format("OP_LOAD_LITERAL({})", op.value.to_repr());
         },
-        [&](const op_load_variable& op) {
-            return std::format("OP_LOAD_VARIABLE({})", op.name);
+        [&](const op_load_local& op) {
+            return std::format("OP_LOAD_LOCAL({})", op.name);
+        },
+        [&](const op_load_global& op) {
+            return std::format("OP_LOAD_GLOBAL({})", op.name);
         },
         [&](const op_pop& op) {
             return std::string{"OP_POP"};
@@ -27,8 +30,11 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_copy_index& op) {
             return std::format("OP_COPY_INDEX({})", op.index);
         },
-        [&](const op_save_variable& op) {
-            return std::format("OP_SAVE_VARIABLE({})", op.name);
+        [&](const op_save_local& op) {
+            return std::format("OP_SAVE_LOCAL({})", op.name);
+        },
+        [&](const op_save_global& op) {
+            return std::format("OP_SAVE_GLOBAL({})", op.name);
         },
         [&](const op_if& op) {
             return std::string{"OP_IF"};

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -46,19 +46,12 @@ auto to_string(const op& op_code) -> std::string
             const auto jump_str = std::format("JUMP -> {}", op.jump);
             return std::format(FORMAT2, "OP_ELSE", jump_str);
         },
-        [&](const op_while& op) {
-            return std::string{"OP_WHILE"};
+        [&](const op_loop_begin& op) {
+            return std::string{"OP_LOOP_BEGIN"};
         },
-        [&](const op_while_end& op) {
+        [&](const op_loop_end& op) {
             const auto jump_str = std::format("JUMP -> {}", op.jump);
-            return std::format(FORMAT2, "OP_END_WHILE", jump_str);
-        },
-        [&](const op_for& op) {
-            return std::string{"OP_FOR"};
-        },
-        [&](const op_for_end& op) {
-            const auto jump_str = std::format("JUMP -> {}", op.jump);
-            return std::format(FORMAT2, "OP_END_FOR", jump_str);
+            return std::format(FORMAT2, "OP_LOOP_END", jump_str);
         },
         [&](const op_break& op) {
             const auto jump_str = std::format("JUMP -> {}", op.jump);

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -125,9 +125,6 @@ auto to_string(const op& op_code) -> std::string
         },
         [&](const op_build_list& op) {
             return std::format("OP_BUILD_LIST({})", op.size);
-        },
-        [&](const op_debug& op) {
-            return std::string{"OP_DEBUG"};
         }
     }, op_code);
 }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -24,9 +24,6 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_pop& op) {
             return std::string{"OP_POP"};
         },
-        [&](const op_copy_index& op) {
-            return std::format("OP_COPY_INDEX({})", op.index);
-        },
         [&](const op_save_variable& op) {
             return std::format("OP_SAVE_VARIABLE({})", op.name);
         },

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -15,11 +15,11 @@ constexpr auto FORMAT3 = std::string_view{"{:<30} {:<20} {}"};
 auto to_string(const op& op_code) -> std::string
 {
     return std::visit(overloaded {
-        [&](const op_push_const& op) {
-            return std::format("OP_PUSH_CONST({})", op.value.to_repr());
+        [&](const op_load_literal& op) {
+            return std::format("OP_LOAD_LITERAL({})", op.value.to_repr());
         },
-        [&](const op_push_var& op) {
-            return std::format("OP_PUSH_VAR({})", op.name);
+        [&](const op_load_variable& op) {
+            return std::format("OP_LOAD_VARIABLE({})", op.name);
         },
         [&](const op_pop& op) {
             return std::string{"OP_POP"};
@@ -27,8 +27,8 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_copy_index& op) {
             return std::format("OP_COPY_INDEX({})", op.index);
         },
-        [&](const op_store& op) {
-            return std::format("OP_STORE({})", op.name);
+        [&](const op_save_variable& op) {
+            return std::format("OP_SAVE_VARIABLE({})", op.name);
         },
         [&](const op_if& op) {
             return std::string{"OP_IF"};

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -18,11 +18,8 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_load_literal& op) {
             return std::format("OP_LOAD_LITERAL({})", op.value.to_repr());
         },
-        [&](const op_load_local& op) {
-            return std::format("OP_LOAD_LOCAL({})", op.name);
-        },
-        [&](const op_load_global& op) {
-            return std::format("OP_LOAD_GLOBAL({})", op.name);
+        [&](const op_load_variable& op) {
+            return std::format("OP_LOAD_VARIABLE({})", op.name);
         },
         [&](const op_pop& op) {
             return std::string{"OP_POP"};
@@ -30,11 +27,8 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_copy_index& op) {
             return std::format("OP_COPY_INDEX({})", op.index);
         },
-        [&](const op_save_local& op) {
-            return std::format("OP_SAVE_LOCAL({})", op.name);
-        },
-        [&](const op_save_global& op) {
-            return std::format("OP_SAVE_GLOBAL({})", op.name);
+        [&](const op_save_variable& op) {
+            return std::format("OP_SAVE_VARIABLE({})", op.name);
         },
         [&](const op_if& op) {
             return std::string{"OP_IF"};

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -63,20 +63,11 @@ struct op_else
     std::intptr_t jump = -1;
 };
 
-struct op_while
+struct op_loop_begin
 {
 };
 
-struct op_while_end
-{
-    std::intptr_t jump = -1;
-};
-
-struct op_for
-{
-};
-
-struct op_for_end
+struct op_loop_end
 {
     std::intptr_t jump = -1;
 };
@@ -198,10 +189,8 @@ struct op : std::variant<
     op_if,
     op_if_end,
     op_else,
-    op_while,
-    op_while_end,
-    op_for,
-    op_for_end,
+    op_loop_begin,
+    op_loop_end,
     op_break,
     op_continue,
     op_jump_if_false,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -15,7 +15,12 @@ struct op_load_literal
     anzu::object value;
 };
 
-struct op_load_variable
+struct op_load_local
+{
+    std::string name;
+};
+
+struct op_load_global
 {
     std::string name;
 };
@@ -30,10 +35,16 @@ struct op_copy_index
     int index;
 };
 
-struct op_save_variable
+struct op_save_local
 {
     std::string name;
 };
+
+struct op_save_global
+{
+    std::string name;
+};
+
 
 struct op_if
 {
@@ -174,10 +185,12 @@ struct op_debug
 
 struct op : std::variant<
     op_load_literal,
-    op_load_variable,
+    op_load_local,
+    op_load_global,
     op_pop,
     op_copy_index,
-    op_save_variable,
+    op_save_local,
+    op_save_global,
     op_if,
     op_if_end,
     op_else,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -173,11 +173,6 @@ struct op_build_list
     std::size_t size;
 };
 
-struct op_debug
-{
-
-};
-
 struct op : std::variant<
     op_load_literal,
     op_load_local,
@@ -212,9 +207,7 @@ struct op : std::variant<
     op_return,
     op_function_call,
     op_builtin_call,
-    op_build_list,
-
-    op_debug
+    op_build_list
 >
 {};
 

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -15,16 +15,10 @@ struct op_load_literal
     anzu::object value;
 };
 
-struct op_load_local
+struct op_load_variable
 {
     std::string name;
     std::size_t offset;
-};
-
-struct op_load_global
-{
-    std::string name;
-    std::size_t position;
 };
 
 struct op_pop
@@ -37,16 +31,10 @@ struct op_copy_index
     int index;
 };
 
-struct op_save_local
+struct op_save_variable
 {
     std::string name;
     std::size_t offset;
-};
-
-struct op_save_global
-{
-    std::string name;
-    std::size_t position;
 };
 
 
@@ -175,12 +163,10 @@ struct op_build_list
 
 struct op : std::variant<
     op_load_literal,
-    op_load_local,
-    op_load_global,
+    op_load_variable,
     op_pop,
     op_copy_index,
-    op_save_local,
-    op_save_global,
+    op_save_variable,
     op_if,
     op_if_end,
     op_else,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -25,12 +25,6 @@ struct op_pop
 {
 };
 
-// 0 == OP_DUP, 1 == OP_OVER, ...
-struct op_copy_index
-{
-    int index;
-};
-
 struct op_save_variable
 {
     std::string name;
@@ -165,7 +159,6 @@ struct op : std::variant<
     op_load_literal,
     op_load_variable,
     op_pop,
-    op_copy_index,
     op_save_variable,
     op_if,
     op_if_end,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -10,12 +10,12 @@
 
 namespace anzu {
 
-struct op_push_const
+struct op_load_literal
 {
     anzu::object value;
 };
 
-struct op_push_var
+struct op_load_variable
 {
     std::string name;
 };
@@ -30,7 +30,7 @@ struct op_copy_index
     int index;
 };
 
-struct op_store
+struct op_save_variable
 {
     std::string name;
 };
@@ -173,11 +173,11 @@ struct op_debug
 };
 
 struct op : std::variant<
-    op_push_const,
-    op_push_var,
+    op_load_literal,
+    op_load_variable,
     op_pop,
     op_copy_index,
-    op_store,
+    op_save_variable,
     op_if,
     op_if_end,
     op_else,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -18,11 +18,13 @@ struct op_load_literal
 struct op_load_local
 {
     std::string name;
+    std::size_t offset;
 };
 
 struct op_load_global
 {
     std::string name;
+    std::size_t position;
 };
 
 struct op_pop
@@ -38,11 +40,13 @@ struct op_copy_index
 struct op_save_local
 {
     std::string name;
+    std::size_t offset;
 };
 
 struct op_save_global
 {
     std::string name;
+    std::size_t position;
 };
 
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -8,41 +8,41 @@ namespace anzu {
 
 auto runtime_context::push_frame() -> frame&
 {
-    d_frames.push_back({});
-    return d_frames.back();
+    frames.push_back({});
+    return frames.back();
 }
 
 auto runtime_context::pop_frame() -> void
 {
-    d_frames.pop_back();
+    frames.pop_back();
 }
 
 auto runtime_context::peek_frame(std::size_t index) -> frame&
 {
-    return d_frames[d_frames.size() - index - 1];
+    return frames[frames.size() - index - 1];
 }
 
 auto runtime_context::push_value(const object& val) -> object&
 {
-    d_values.push_back(val);
-    return d_values.back();
+    stack.push_back(val);
+    return stack.back();
 }
 
 auto runtime_context::pop_value() -> object
 {
-    auto ret = d_values.back();
-    d_values.pop_back();
+    auto ret = stack.back();
+    stack.pop_back();
     return ret;
 }
 
 auto runtime_context::peek_value(std::size_t index) -> object&
 {
-    return d_values[d_values.size() - index - 1];
+    return stack[stack.size() - index - 1];
 }
 
 auto runtime_context::size() const -> std::size_t
 {
-    return d_values.size();
+    return stack.size();
 }
 
 auto apply_op(runtime_context& ctx, const op& op_code) -> void
@@ -50,104 +50,104 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
     std::visit(overloaded {
         [&](const op_load_literal& op) {
             ctx.push_value(op.value);
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_load_local& op) {
             auto& frame = ctx.peek_frame();
             const auto idx = frame.base_ptr + op.offset;
-            ctx.push_value(ctx.values[idx]);
-            frame.ptr += 1;
+            ctx.push_value(ctx.memory[idx]);
+            frame.program_ptr += 1;
         },
         [&](const op_load_global& op) {
             auto& frame = ctx.peek_frame();
             const auto idx = op.position;
-            ctx.push_value(ctx.values[idx]);
-            frame.ptr += 1;
+            ctx.push_value(ctx.memory[idx]);
+            frame.program_ptr += 1;
         },
         [&](const op_pop& op) {
             ctx.pop_value();
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_copy_index& op) {
             ctx.push_value(ctx.peek_value(op.index));
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_save_local& op) {
             auto& frame = ctx.peek_frame();
             const auto idx = frame.base_ptr + op.offset;
-            if (idx >= ctx.values.size()) {
-                ctx.values.resize(idx + 1);
+            if (idx >= ctx.memory.size()) {
+                ctx.memory.resize(idx + 1);
             }
-            ctx.values[idx] = ctx.pop_value();
-            frame.ptr += 1;
+            ctx.memory[idx] = ctx.pop_value();
+            frame.program_ptr += 1;
         },
         [&](const op_save_global& op) {
             auto& frame = ctx.peek_frame();
             const auto idx = op.position;
-            if (idx >= ctx.values.size()) {
-                ctx.values.resize(idx + 1);
+            if (idx >= ctx.memory.size()) {
+                ctx.memory.resize(idx + 1);
             }
-            ctx.values[idx] = ctx.pop_value();
-            frame.ptr += 1;
+            ctx.memory[idx] = ctx.pop_value();
+            frame.program_ptr += 1;
         },
         [&](const op_if& op) {
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_if_end& op) {
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_else& op) {
-            ctx.peek_frame().ptr = op.jump;
+            ctx.peek_frame().program_ptr = op.jump;
         },
         [&](const op_while& op) {
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_while_end& op) {
-            ctx.peek_frame().ptr = op.jump;
+            ctx.peek_frame().program_ptr = op.jump;
         },
         [&](const op_for& op) {
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_for_end& op) {
-            ctx.peek_frame().ptr = op.jump;
+            ctx.peek_frame().program_ptr = op.jump;
         },
         [&](const op_break& op) {
-            ctx.peek_frame().ptr = op.jump;
+            ctx.peek_frame().program_ptr = op.jump;
         },
         [&](const op_continue& op) {
-            ctx.peek_frame().ptr = op.jump;
+            ctx.peek_frame().program_ptr = op.jump;
         },
         [&](const op_jump_if_false& op) {
             if (ctx.pop_value().to_bool()) {
-                ctx.peek_frame().ptr += 1;
+                ctx.peek_frame().program_ptr += 1;
             } else {
-                ctx.peek_frame().ptr = op.jump;
+                ctx.peek_frame().program_ptr = op.jump;
             }
         },
         [&](const op_function& op) {
-            ctx.peek_frame().ptr = op.jump;
+            ctx.peek_frame().program_ptr = op.jump;
         },
         [&](const op_function_end& op) {
-            const auto num_to_pop = ctx.values.size() - ctx.peek_frame().base_ptr;
+            const auto num_to_pop = ctx.memory.size() - ctx.peek_frame().base_ptr;
             for (std::size_t i = 0; i != num_to_pop; ++i) {
-                ctx.values.pop_back();
+                ctx.memory.pop_back();
             }
             ctx.push_value(anzu::null_object());
             ctx.pop_frame();
         },
         [&](const op_return& op) {
-            const auto num_to_pop = ctx.values.size() - ctx.peek_frame().base_ptr;
+            const auto num_to_pop = ctx.memory.size() - ctx.peek_frame().base_ptr;
             for (std::size_t i = 0; i != num_to_pop; ++i) {
-                ctx.values.pop_back();
+                ctx.memory.pop_back();
             }
             ctx.pop_frame();
         },
         [&](const op_function_call& op) {
-            ctx.peek_frame().ptr += 1; // Position after function call
+            ctx.peek_frame().program_ptr += 1; // Position after function call
 
             auto& frame = ctx.push_frame();
-            frame.base_ptr = ctx.values.size();
-            frame.ptr = op.ptr; // Jump into the function
+            frame.base_ptr = ctx.memory.size();
+            frame.program_ptr = op.ptr; // Jump into the function
         },
         [&](const op_builtin_call& op) {
             const auto argc = op.sig.args.size();
@@ -159,85 +159,85 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
 
             // Call the builtin function with the given args and push the return value
             ctx.push_value(op.ptr(args));
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_add& op) {
             auto b = ctx.pop_value();
             auto a = ctx.pop_value();
             ctx.push_value(a + b);
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_sub& op) {
             auto b = ctx.pop_value();
             auto a = ctx.pop_value();
             ctx.push_value(a - b);
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_mul& op) {
             auto b = ctx.pop_value();
             auto a = ctx.pop_value();
             ctx.push_value(a * b);
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_div& op) {
             auto b = ctx.pop_value();
             auto a = ctx.pop_value();
             ctx.push_value(a / b);
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_mod& op) {
             auto b = ctx.pop_value();
             auto a = ctx.pop_value();
             ctx.push_value(a % b);
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_eq& op) {
             auto b = ctx.pop_value();
             auto a = ctx.pop_value();
             ctx.push_value(object{a == b});
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_ne& op) {
             auto b = ctx.pop_value();
             auto a = ctx.pop_value();
             ctx.push_value(object{a != b});
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_lt& op) {
             auto b = ctx.pop_value();
             auto a = ctx.pop_value();
             ctx.push_value(object{a < b});
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_le& op) {
             auto b = ctx.pop_value();
             auto a = ctx.pop_value();
             ctx.push_value(object{a <= b});
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_gt& op) {
             auto b = ctx.pop_value();
             auto a = ctx.pop_value();
             ctx.push_value(object{a > b});
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_ge& op) {
             auto b = ctx.pop_value();
             auto a = ctx.pop_value();
             ctx.push_value(object{a >= b});
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_or& op) {
             auto b = ctx.pop_value();
             auto a = ctx.pop_value();
             ctx.push_value(object{a || b});
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_and& op) {
             auto b = ctx.pop_value();
             auto a = ctx.pop_value();
             ctx.push_value(object{a && b});
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_build_list& op) {
             auto list = std::make_shared<std::vector<anzu::object>>();
@@ -245,11 +245,11 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
                 list->push_back(ctx.pop_value());
             }
             ctx.push_value(object{list});
-            ctx.peek_frame().ptr += 1;
+            ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_debug& op) {
             auto& frame = ctx.peek_frame();
-            frame.ptr += 1;
+            frame.program_ptr += 1;
         }
     }, op_code);
 }
@@ -259,21 +259,21 @@ auto run_program(const anzu::program& program) -> void
     runtime_context ctx;
     ctx.push_frame();
 
-    while (ctx.peek_frame().ptr < std::ssize(program)) {
-        apply_op(ctx, program[ctx.peek_frame().ptr]);
+    while (ctx.peek_frame().program_ptr < std::ssize(program)) {
+        apply_op(ctx, program[ctx.peek_frame().program_ptr]);
     }
 }
 
 auto run_program_debug(const anzu::program& program) -> void
 {
     anzu::runtime_context ctx;
-    ctx.values.reserve(1000);
+    ctx.memory.reserve(1000);
     ctx.push_frame();
 
-    while (ctx.peek_frame().ptr < std::ssize(program)) {
-        const auto& op = program[ctx.peek_frame().ptr];
-        anzu::print("{:>4} - {}\n", ctx.peek_frame().ptr, anzu::to_string(op));
-        apply_op(ctx, program[ctx.peek_frame().ptr]);
+    while (ctx.peek_frame().program_ptr < std::ssize(program)) {
+        const auto& op = program[ctx.peek_frame().program_ptr];
+        anzu::print("{:>4} - {}\n", ctx.peek_frame().program_ptr, anzu::to_string(op));
+        apply_op(ctx, program[ctx.peek_frame().program_ptr]);
     }
 }
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -6,15 +6,19 @@
 
 namespace anzu {
 
-auto runtime_context::push_frame() -> frame&
+template <typename T>
+T pop_back(std::vector<T>& vec)
 {
-    frames.push_back({});
-    return frames.back();
+    const auto back = vec.back();
+    vec.pop_back();
+    return back;   
 }
 
-auto runtime_context::pop_frame() -> void
+template <typename T>
+T& push_back(std::vector<T>& vec, const T& val)
 {
-    frames.pop_back();
+    vec.push_back(val);
+    return vec.back();   
 }
 
 auto runtime_context::peek_frame(std::size_t index) -> frame&
@@ -22,54 +26,36 @@ auto runtime_context::peek_frame(std::size_t index) -> frame&
     return frames[frames.size() - index - 1];
 }
 
-auto runtime_context::push_value(const object& val) -> object&
-{
-    stack.push_back(val);
-    return stack.back();
-}
-
-auto runtime_context::pop_value() -> object
-{
-    auto ret = stack.back();
-    stack.pop_back();
-    return ret;
-}
-
 auto runtime_context::peek_value(std::size_t index) -> object&
 {
     return stack[stack.size() - index - 1];
-}
-
-auto runtime_context::size() const -> std::size_t
-{
-    return stack.size();
 }
 
 auto apply_op(runtime_context& ctx, const op& op_code) -> void
 {
     std::visit(overloaded {
         [&](const op_load_literal& op) {
-            ctx.push_value(op.value);
+            push_back(ctx.stack, op.value);
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_load_local& op) {
             auto& frame = ctx.peek_frame();
             const auto idx = frame.base_ptr + op.offset;
-            ctx.push_value(ctx.memory[idx]);
+            push_back(ctx.stack, ctx.memory[idx]);
             frame.program_ptr += 1;
         },
         [&](const op_load_global& op) {
             auto& frame = ctx.peek_frame();
             const auto idx = op.position;
-            ctx.push_value(ctx.memory[idx]);
+            push_back(ctx.stack, ctx.memory[idx]);
             frame.program_ptr += 1;
         },
         [&](const op_pop& op) {
-            ctx.pop_value();
+            pop_back(ctx.stack);
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_copy_index& op) {
-            ctx.push_value(ctx.peek_value(op.index));
+            push_back(ctx.stack, ctx.peek_value(op.index));
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_save_local& op) {
@@ -78,7 +64,7 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             if (idx >= ctx.memory.size()) {
                 ctx.memory.resize(idx + 1);
             }
-            ctx.memory[idx] = ctx.pop_value();
+            ctx.memory[idx] = pop_back(ctx.stack);
             frame.program_ptr += 1;
         },
         [&](const op_save_global& op) {
@@ -87,7 +73,7 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             if (idx >= ctx.memory.size()) {
                 ctx.memory.resize(idx + 1);
             }
-            ctx.memory[idx] = ctx.pop_value();
+            ctx.memory[idx] = pop_back(ctx.stack);
             frame.program_ptr += 1;
         },
         [&](const op_if& op) {
@@ -118,7 +104,7 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.peek_frame().program_ptr = op.jump;
         },
         [&](const op_jump_if_false& op) {
-            if (ctx.pop_value().to_bool()) {
+            if (pop_back(ctx.stack).to_bool()) {
                 ctx.peek_frame().program_ptr += 1;
             } else {
                 ctx.peek_frame().program_ptr = op.jump;
@@ -132,20 +118,21 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             for (std::size_t i = 0; i != num_to_pop; ++i) {
                 ctx.memory.pop_back();
             }
-            ctx.push_value(anzu::null_object());
-            ctx.pop_frame();
+            push_back(ctx.stack, null_object());
+            ctx.frames.pop_back();
         },
         [&](const op_return& op) {
             const auto num_to_pop = ctx.memory.size() - ctx.peek_frame().base_ptr;
             for (std::size_t i = 0; i != num_to_pop; ++i) {
                 ctx.memory.pop_back();
             }
-            ctx.pop_frame();
+            ctx.frames.pop_back();
         },
         [&](const op_function_call& op) {
             ctx.peek_frame().program_ptr += 1; // Position after function call
 
-            auto& frame = ctx.push_frame();
+            ctx.frames.emplace_back();
+            auto& frame = ctx.frames.back();
             frame.base_ptr = ctx.memory.size();
             frame.program_ptr = op.ptr; // Jump into the function
         },
@@ -154,97 +141,97 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             auto args = std::vector<anzu::object>{};
             args.resize(argc);
             for (std::size_t i = 0; i != argc; ++i) {
-                args[argc - 1 - i] = ctx.pop_value();
+                args[argc - 1 - i] = pop_back(ctx.stack);
             }
 
             // Call the builtin function with the given args and push the return value
-            ctx.push_value(op.ptr(args));
+            push_back(ctx.stack, op.ptr(args));
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_add& op) {
-            auto b = ctx.pop_value();
-            auto a = ctx.pop_value();
-            ctx.push_value(a + b);
+            auto b = pop_back(ctx.stack);
+            auto a = pop_back(ctx.stack);
+            push_back(ctx.stack, a + b);
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_sub& op) {
-            auto b = ctx.pop_value();
-            auto a = ctx.pop_value();
-            ctx.push_value(a - b);
+            auto b = pop_back(ctx.stack);
+            auto a = pop_back(ctx.stack);
+            push_back(ctx.stack, a - b);
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_mul& op) {
-            auto b = ctx.pop_value();
-            auto a = ctx.pop_value();
-            ctx.push_value(a * b);
+            auto b = pop_back(ctx.stack);
+            auto a = pop_back(ctx.stack);
+            push_back(ctx.stack, a * b);
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_div& op) {
-            auto b = ctx.pop_value();
-            auto a = ctx.pop_value();
-            ctx.push_value(a / b);
+            auto b = pop_back(ctx.stack);
+            auto a = pop_back(ctx.stack);
+            push_back(ctx.stack, a / b);
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_mod& op) {
-            auto b = ctx.pop_value();
-            auto a = ctx.pop_value();
-            ctx.push_value(a % b);
+            auto b = pop_back(ctx.stack);
+            auto a = pop_back(ctx.stack);
+            push_back(ctx.stack, a % b);
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_eq& op) {
-            auto b = ctx.pop_value();
-            auto a = ctx.pop_value();
-            ctx.push_value(object{a == b});
+            auto b = pop_back(ctx.stack);
+            auto a = pop_back(ctx.stack);
+            push_back(ctx.stack, object{a == b});
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_ne& op) {
-            auto b = ctx.pop_value();
-            auto a = ctx.pop_value();
-            ctx.push_value(object{a != b});
+            auto b = pop_back(ctx.stack);
+            auto a = pop_back(ctx.stack);
+            push_back(ctx.stack, object{a != b});
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_lt& op) {
-            auto b = ctx.pop_value();
-            auto a = ctx.pop_value();
-            ctx.push_value(object{a < b});
+            auto b = pop_back(ctx.stack);
+            auto a = pop_back(ctx.stack);
+            push_back(ctx.stack, object{a < b});
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_le& op) {
-            auto b = ctx.pop_value();
-            auto a = ctx.pop_value();
-            ctx.push_value(object{a <= b});
+            auto b = pop_back(ctx.stack);
+            auto a = pop_back(ctx.stack);
+            push_back(ctx.stack, object{a <= b});
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_gt& op) {
-            auto b = ctx.pop_value();
-            auto a = ctx.pop_value();
-            ctx.push_value(object{a > b});
+            auto b = pop_back(ctx.stack);
+            auto a = pop_back(ctx.stack);
+            push_back(ctx.stack, object{a > b});
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_ge& op) {
-            auto b = ctx.pop_value();
-            auto a = ctx.pop_value();
-            ctx.push_value(object{a >= b});
+            auto b = pop_back(ctx.stack);
+            auto a = pop_back(ctx.stack);
+            push_back(ctx.stack, object{a >= b});
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_or& op) {
-            auto b = ctx.pop_value();
-            auto a = ctx.pop_value();
-            ctx.push_value(object{a || b});
+            auto b = pop_back(ctx.stack);
+            auto a = pop_back(ctx.stack);
+            push_back(ctx.stack, object{a || b});
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_and& op) {
-            auto b = ctx.pop_value();
-            auto a = ctx.pop_value();
-            ctx.push_value(object{a && b});
+            auto b = pop_back(ctx.stack);
+            auto a = pop_back(ctx.stack);
+            push_back(ctx.stack, object{a && b});
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_build_list& op) {
             auto list = std::make_shared<std::vector<anzu::object>>();
             for (std::size_t i = 0; i != op.size; ++i) {
-                list->push_back(ctx.pop_value());
+                list->push_back(pop_back(ctx.stack));
             }
-            ctx.push_value(object{list});
+            push_back(ctx.stack, object{list});
             ctx.peek_frame().program_ptr += 1;
         },
         [&](const op_debug& op) {
@@ -257,7 +244,8 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
 auto run_program(const anzu::program& program) -> void
 {
     runtime_context ctx;
-    ctx.push_frame();
+    ctx.memory.reserve(1000);
+    ctx.frames.emplace_back();
 
     while (ctx.peek_frame().program_ptr < std::ssize(program)) {
         apply_op(ctx, program[ctx.peek_frame().program_ptr]);
@@ -268,7 +256,7 @@ auto run_program_debug(const anzu::program& program) -> void
 {
     anzu::runtime_context ctx;
     ctx.memory.reserve(1000);
-    ctx.push_frame();
+    ctx.frames.emplace_back();
 
     while (ctx.peek_frame().program_ptr < std::ssize(program)) {
         const auto& op = program[ctx.peek_frame().program_ptr];

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -1,7 +1,9 @@
 #include "runtime.hpp"
 #include "utility/print.hpp"
 #include "utility/overloaded.hpp"
+#include "utility/scope_timer.hpp"
 
+#include <chrono>
 #include <utility>
 
 namespace anzu {
@@ -249,10 +251,10 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
 
 auto run_program(const anzu::program& program) -> void
 {
-    runtime_context ctx;
-    ctx.memory.reserve(1000);
-    ctx.frames.emplace_back();
+    const auto timer = scope_timer{};
 
+    runtime_context ctx;
+    ctx.frames.emplace_back();
     while (program_ptr(ctx) < std::ssize(program)) {
         apply_op(ctx, program[program_ptr(ctx)]);
     }
@@ -260,10 +262,10 @@ auto run_program(const anzu::program& program) -> void
 
 auto run_program_debug(const anzu::program& program) -> void
 {
-    anzu::runtime_context ctx;
-    ctx.memory.reserve(1000);
-    ctx.frames.emplace_back();
+    const auto timer = scope_timer{};
 
+    runtime_context ctx;
+    ctx.frames.emplace_back();
     while (program_ptr(ctx) < std::ssize(program)) {
         const auto& op = program[program_ptr(ctx)];
         anzu::print("{:>4} - {}\n", program_ptr(ctx), anzu::to_string(op));

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -67,11 +67,11 @@ auto runtime_context::size() const -> std::size_t
 auto apply_op(runtime_context& ctx, const op& op_code) -> void
 {
     std::visit(overloaded {
-        [&](const op_push_const& op) {
+        [&](const op_load_literal& op) {
             ctx.push_value(op.value);
             ctx.peek_frame().ptr += 1;
         },
-        [&](const op_push_var& op) {
+        [&](const op_load_variable& op) {
             auto& frame = ctx.peek_frame();
             ctx.push_value(frame.memory.get(op.name));
             frame.ptr += 1;
@@ -84,7 +84,7 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.push_value(ctx.peek_value(op.index));
             ctx.peek_frame().ptr += 1;
         },
-        [&](const op_store& op) {
+        [&](const op_save_variable& op) {
             auto& frame = ctx.peek_frame();
             frame.memory.insert(op.name, ctx.pop_value());
             frame.ptr += 1;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -6,25 +6,6 @@
 
 namespace anzu {
 
-auto memory::insert(const std::string& name, const anzu::object& value) -> anzu::object&
-{
-    auto [iter, success] = d_values.insert_or_assign(name, value);
-    return iter->second;
-}
-
-auto memory::get(const std::string& name) -> anzu::object&
-{
-    return d_values.at(name);
-}
-
-auto memory::print() const -> void
-{
-    anzu::print("Values:\n");
-    for (const auto& [key, val] : d_values) {
-        anzu::print(" - {} -> {}\n", key, val.to_repr());
-    }
-}
-
 auto runtime_context::push_frame() -> frame&
 {
     d_frames.push_back({});
@@ -268,8 +249,6 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
         },
         [&](const op_debug& op) {
             auto& frame = ctx.peek_frame();
-            anzu::print("frame memory:\n");
-            frame.memory.print();
             frame.ptr += 1;
         }
     }, op_code);

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -82,11 +82,6 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.memory.pop_back();
             program_advance(ctx);
         },
-        [&](const op_copy_index& op) {
-            const auto it = ctx.memory.rbegin() + op.index;
-            ctx.memory.push_back(*it);
-            program_advance(ctx);
-        },
         [&](const op_save_variable& op) {
             save_top_at(ctx, base_ptr(ctx) + op.offset);
             program_advance(ctx);

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -71,7 +71,12 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.push_value(op.value);
             ctx.peek_frame().ptr += 1;
         },
-        [&](const op_load_variable& op) {
+        [&](const op_load_local& op) {
+            auto& frame = ctx.peek_frame();
+            ctx.push_value(frame.memory.get(op.name));
+            frame.ptr += 1;
+        },
+        [&](const op_load_global& op) {
             auto& frame = ctx.peek_frame();
             ctx.push_value(frame.memory.get(op.name));
             frame.ptr += 1;
@@ -84,7 +89,12 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.push_value(ctx.peek_value(op.index));
             ctx.peek_frame().ptr += 1;
         },
-        [&](const op_save_variable& op) {
+        [&](const op_save_local& op) {
+            auto& frame = ctx.peek_frame();
+            frame.memory.insert(op.name, ctx.pop_value());
+            frame.ptr += 1;
+        },
+        [&](const op_save_global& op) {
             auto& frame = ctx.peek_frame();
             frame.memory.insert(op.name, ctx.pop_value());
             frame.ptr += 1;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -237,9 +237,6 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             }
             push_back(ctx.memory, object{list});
             program_advance(ctx);
-        },
-        [&](const op_debug& op) {
-            program_advance(ctx);
         }
     }, op_code);
 }
@@ -268,8 +265,7 @@ auto run_program_debug(const anzu::program& program) -> void
         anzu::print(
             "Memory: {}\n", 
             anzu::format_comma_separated(
-                ctx.memory,
-                [](const auto& o) { return o.to_repr(); }
+                ctx.memory, [](const auto& o) { return o.to_repr(); }
             )
         );
     }

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -38,6 +38,15 @@ auto program_ptr(const runtime_context& ctx) -> std::intptr_t
     return ctx.frames.back().program_ptr;
 }
 
+auto save_top_at(runtime_context& ctx, std::size_t idx) -> void
+{
+    if (idx == ctx.memory.size()) {
+        ctx.memory.push_back(pop_back(ctx.memory));    
+    } else if (idx < ctx.memory.size() - 1) {
+        ctx.memory[idx] = pop_back(ctx.memory);
+    }
+}
+
 // Cleans up the variables used in the current frame and removes the frame
 // pointers to return back to the previous scope. Leaves one extra since that is
 // the return value.
@@ -77,22 +86,12 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
         },
         [&](const op_save_local& op) {
             auto& frame = ctx.frames.back();
-            const auto idx = frame.base_ptr + op.offset;
-            if (idx == std::ssize(ctx.memory)) {
-                ctx.memory.push_back(pop_back(ctx.memory));    
-            } else if (idx < std::ssize(ctx.memory) - 1) {
-                ctx.memory[idx] = pop_back(ctx.memory);
-            }
+            save_top_at(ctx, frame.base_ptr + op.offset);
             program_advance(ctx);
         },
         [&](const op_save_global& op) {
             auto& frame = ctx.frames.back();
-            const auto idx = op.position;
-            if (idx == std::ssize(ctx.memory)) {
-                ctx.memory.push_back(pop_back(ctx.memory));  
-            } else if (idx < std::ssize(ctx.memory) - 1) {
-                ctx.memory[idx] = pop_back(ctx.memory);
-            }
+            save_top_at(ctx, op.position);
             program_advance(ctx);
         },
         [&](const op_if& op) {
@@ -155,80 +154,80 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
         },
         [&](const op_add& op) {
             auto b = pop_back(ctx.memory);
-            auto a = pop_back(ctx.memory);
-            push_back(ctx.memory, a + b);
+            auto& a = ctx.memory.back();
+            a = a + b;
             program_advance(ctx);
         },
         [&](const op_sub& op) {
             auto b = pop_back(ctx.memory);
-            auto a = pop_back(ctx.memory);
-            push_back(ctx.memory, a - b);
+            auto& a = ctx.memory.back();
+            a = a - b;
             program_advance(ctx);
         },
         [&](const op_mul& op) {
             auto b = pop_back(ctx.memory);
-            auto a = pop_back(ctx.memory);
-            push_back(ctx.memory, a * b);
+            auto& a = ctx.memory.back();
+            a = a * b;
             program_advance(ctx);
         },
         [&](const op_div& op) {
             auto b = pop_back(ctx.memory);
-            auto a = pop_back(ctx.memory);
-            push_back(ctx.memory, a / b);
+            auto& a = ctx.memory.back();
+            a = a / b;
             program_advance(ctx);
         },
         [&](const op_mod& op) {
             auto b = pop_back(ctx.memory);
-            auto a = pop_back(ctx.memory);
-            push_back(ctx.memory, a % b);
+            auto& a = ctx.memory.back();
+            a = a % b;
             program_advance(ctx);
         },
         [&](const op_eq& op) {
             auto b = pop_back(ctx.memory);
-            auto a = pop_back(ctx.memory);
-            push_back(ctx.memory, object{a == b});
+            auto& a = ctx.memory.back();
+            a = object{a == b};
             program_advance(ctx);
         },
         [&](const op_ne& op) {
             auto b = pop_back(ctx.memory);
-            auto a = pop_back(ctx.memory);
-            push_back(ctx.memory, object{a != b});
+            auto& a = ctx.memory.back();
+            a = object{a != b};
             program_advance(ctx);
         },
         [&](const op_lt& op) {
             auto b = pop_back(ctx.memory);
-            auto a = pop_back(ctx.memory);
-            push_back(ctx.memory, object{a < b});
+            auto& a = ctx.memory.back();
+            a = object{a < b};
             program_advance(ctx);
         },
         [&](const op_le& op) {
             auto b = pop_back(ctx.memory);
-            auto a = pop_back(ctx.memory);
-            push_back(ctx.memory, object{a <= b});
+            auto& a = ctx.memory.back();
+            a = object{a <= b};
             program_advance(ctx);
         },
         [&](const op_gt& op) {
             auto b = pop_back(ctx.memory);
-            auto a = pop_back(ctx.memory);
-            push_back(ctx.memory, object{a > b});
+            auto& a = ctx.memory.back();
+            a = object{a > b};
             program_advance(ctx);
         },
         [&](const op_ge& op) {
             auto b = pop_back(ctx.memory);
-            auto a = pop_back(ctx.memory);
-            push_back(ctx.memory, object{a >= b});
+            auto& a = ctx.memory.back();
+            a = object{a >= b};
             program_advance(ctx);
         },
         [&](const op_or& op) {
             auto b = pop_back(ctx.memory);
-            auto a = pop_back(ctx.memory);
-            push_back(ctx.memory, object{a || b});
+            auto& a = ctx.memory.back();
+            a = object{a || b};
             program_advance(ctx);
         },
         [&](const op_and& op) {
             auto b = pop_back(ctx.memory);
-            auto a = pop_back(ctx.memory);
-            push_back(ctx.memory, object{a && b});
+            auto& a = ctx.memory.back();
+            a = object{a && b};
             program_advance(ctx);
         },
         [&](const op_build_list& op) {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -142,11 +142,6 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
 
             auto& frame = ctx.push_frame(); 
             frame.ptr = op.ptr; // Jump into the function
-
-            // Pop elements off the stack and load them into the new scope
-            for (const auto& arg : op.sig.args | std::views::reverse) {
-                frame.memory.insert(arg.name, ctx.pop_value());
-            }
         },
         [&](const op_builtin_call& op) {
             const auto argc = op.sig.args.size();

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -14,10 +14,6 @@ auto memory::insert(const std::string& name, const anzu::object& value) -> anzu:
 
 auto memory::get(const std::string& name) -> anzu::object&
 {
-    if (!d_values.contains(name)) {
-        anzu::print("Error: Unknown value '{}'", name);
-        std::exit(1);
-    }
     return d_values.at(name);
 }
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -104,16 +104,10 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
         [&](const op_else& op) {
             program_jump_to(ctx, op.jump);
         },
-        [&](const op_while& op) {
+        [&](const op_loop_begin& op) {
             program_advance(ctx);
         },
-        [&](const op_while_end& op) {
-            program_jump_to(ctx, op.jump);
-        },
-        [&](const op_for& op) {
-            program_advance(ctx);
-        },
-        [&](const op_for_end& op) {
+        [&](const op_loop_end& op) {
             program_jump_to(ctx, op.jump);
         },
         [&](const op_break& op) {

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -2,25 +2,18 @@
 #include "object.hpp"
 #include "program.hpp"
 
-#include <stack>
-#include <string>
-#include <variant>
-#include <ranges>
+#include <vector>
 
 namespace anzu {
 
 struct frame
 {
-    std::intptr_t ptr = 0;
+    std::intptr_t program_ptr = 0;
     std::intptr_t base_ptr = 0;
 };
 
-class runtime_context
+struct runtime_context
 {
-    std::vector<frame>        d_frames;
-    std::vector<anzu::object> d_values;
-
-public:
     auto push_frame() -> frame&;
     auto pop_frame() -> void;
     auto peek_frame(std::size_t index = 0) -> frame&;
@@ -30,7 +23,9 @@ public:
     auto peek_value(std::size_t index = 0) -> object&;
     auto size() const -> std::size_t;
 
-    std::vector<anzu::object> values;
+    std::vector<frame>        frames;
+    std::vector<anzu::object> stack;
+    std::vector<anzu::object> memory;
 };
 
 auto run_program(const anzu::program& program) -> void;

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -14,9 +14,6 @@ struct frame
 
 struct runtime_context
 {
-    auto peek_frame(std::size_t index = 0) -> frame&;
-    auto peek_value(std::size_t index = 0) -> object&;
-
     std::vector<frame>        frames;
     std::vector<anzu::object> stack;
     std::vector<anzu::object> memory;

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -24,6 +24,7 @@ struct frame
 {
     anzu::memory  memory;
     std::intptr_t ptr = 0;
+    std::intptr_t base_ptr = 0;
 };
 
 class runtime_context
@@ -40,6 +41,8 @@ public:
     auto pop_value() -> object;
     auto peek_value(std::size_t index = 0) -> object&;
     auto size() const -> std::size_t;
+
+    std::vector<anzu::object> values;
 };
 
 auto run_program(const anzu::program& program) -> void;

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -14,14 +14,8 @@ struct frame
 
 struct runtime_context
 {
-    auto push_frame() -> frame&;
-    auto pop_frame() -> void;
     auto peek_frame(std::size_t index = 0) -> frame&;
-
-    auto push_value(const object& val) -> object&;
-    auto pop_value() -> object;
     auto peek_value(std::size_t index = 0) -> object&;
-    auto size() const -> std::size_t;
 
     std::vector<frame>        frames;
     std::vector<anzu::object> stack;

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -14,12 +14,12 @@ struct frame
 
 struct runtime_context
 {
-    std::vector<frame>        frames;
-    std::vector<anzu::object> stack;
-    std::vector<anzu::object> memory;
+    std::vector<frame>  frames;
+    std::vector<object> stack;
+    std::vector<object> memory;
 };
 
-auto run_program(const anzu::program& program) -> void;
-auto run_program_debug(const anzu::program& program) -> void;
+auto run_program(const program& prog) -> void;
+auto run_program_debug(const program& prog) -> void;
 
 }

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -3,26 +3,14 @@
 #include "program.hpp"
 
 #include <stack>
-#include <unordered_map>
 #include <string>
 #include <variant>
 #include <ranges>
 
 namespace anzu {
 
-class memory
-{
-    std::unordered_map<std::string, anzu::object> d_values;
-
-public:
-    auto insert(const std::string& name, const anzu::object& value) -> anzu::object&;
-    auto get(const std::string& name) -> anzu::object&;
-    auto print() const -> void;
-};
-
 struct frame
 {
-    anzu::memory  memory;
     std::intptr_t ptr = 0;
     std::intptr_t base_ptr = 0;
 };

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -15,7 +15,6 @@ struct frame
 struct runtime_context
 {
     std::vector<frame>  frames;
-    std::vector<object> stack;
     std::vector<object> memory;
 };
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -292,13 +292,10 @@ auto typecheck_expr(typecheck_context& ctx, const node_expr& expr) -> type
             return type_of(node.value);
         },
         [&](const node_variable_expr& node) {
-            const auto& locals = ctx.scopes.back().variables;
-            if (auto it = locals.find(node.name); it != locals.end()) {
-                return it->second;
-            }
-            const auto& globals = ctx.scopes.front().variables;
-            if (auto it = globals.find(node.name); it != globals.end()) {
-                return it->second;
+            for (const auto& scope : ctx.scopes | std::views::reverse) {
+                if (auto it = scope.variables.find(node.name); it != scope.variables.end()) {
+                    return it->second;
+                }
             }
             type_error(node.token, "could not find variable '{}'\n", node.name);
         },

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -426,10 +426,6 @@ auto typecheck_node(typecheck_context& ctx, const node_return_stmt& node)
     verify_expression_type(ctx, *node.return_value, return_type);
 }
 
-auto typecheck_node(typecheck_context& ctx, const node_debug_stmt& node)
-{
-}
-
 auto typecheck_node(typecheck_context& ctx, const node_stmt& node) -> void
 {
     std::visit([&](const auto& n) { typecheck_node(ctx, n); }, node);

--- a/src/utility/scope_timer.hpp
+++ b/src/utility/scope_timer.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include "utility/print.hpp"
+
+#include <chrono>
+
+namespace anzu {
+
+struct scope_timer
+{
+    using clock_type = std::chrono::steady_clock;
+	using second_type = std::chrono::duration<double, std::ratio<1>>;
+    
+    clock_type::time_point start;
+
+    scope_timer() : start(clock_type::now()) {}
+    ~scope_timer()
+    {
+        const auto duration = std::chrono::steady_clock::now() - start;
+        const auto time_elapsed = std::chrono::duration_cast<second_type>(duration).count();
+        anzu::print("\n -> Program took {} seconds\n", time_elapsed);
+    }
+};
+
+}

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -10,7 +10,7 @@ auto is_keyword(std::string_view token) -> bool
     static const std::unordered_set<std::string_view> tokens = {
         tk_break, tk_continue, tk_else, tk_false, tk_for, tk_if,
         tk_in, tk_null, tk_true, tk_while, tk_int, tk_bool, tk_str,
-        tk_list, tk_function, tk_return, tk_debug
+        tk_list, tk_function, tk_return
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -18,7 +18,6 @@ constexpr auto tk_true      = sv{"true"};
 constexpr auto tk_while     = sv{"while"};
 constexpr auto tk_function  = sv{"fn"};
 constexpr auto tk_return    = sv{"return"};
-constexpr auto tk_debug     = sv{"__debug__"};
 
 // Builtin Types
 constexpr auto tk_int       = sv{"int"};


### PR DESCRIPTION
* In the current implementation, the runtime maintains scopes and performs hash map lookups whenever a variable is referenced.
* This is expensive and slow. A better approach is to store all variables in a vector, calculate their location at compile time, and then at runtime we can just index into the stack.
* The `runtime_context` now just stores a vector of objects. Each variable in a function is now stored as an offset from a "base_ptr", which is set when that function is invoked.
* Now that stored variables and the "stack" are all in the same data structure, various optimisations can be made to reduce the number of pops and pushes.
* An example of the above are function calls and returns no longer doing copies. Since args get pushed to the stack before invoking a function, the base_ptr is set accordingly so that the args can be "seen". Similarly the return value is just left on the stack after for future use.
* Re-implemented for loops as the current way broke with the new memory model. It is now equivalent to a while loop.
* `op_while` and `op_for` have been replaced with `op_loop_begin`, and the corresponding end op codes are now `op_loop_end`.
* Because referring to variables by name or by index is now equivalent, `op_copy_index` has been removed since it is no longer needed for `for`-loops. The new implementation is now much more readable.
* Remove `__debug__` as a keyword along with the associated ast node and op code since it wasn't very useful. Running a program in debug mode is much better.
* Running in debug now prints the memory vector after each op code. This can be improved in the future.
* Add a scope timer utility class for timing how long a program runs.
