### PR TITLE
Fix Global Variable Lookup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/feature_test.az", "run"],
+            "args": ["${workspaceFolder}/examples/test.az", "run"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -72,18 +72,6 @@ x := null
 y := println(x)
 println(y)
 
-# Nested functions
-fn outer(a: int, b: int) -> int
-{   
-    fn nested(c: int) -> int
-    {
-        return c
-    }
-
-    return nested(a + b)
-}
-println(outer(1, 2))
-
 # For loops
 println("list test, 3 elements with a break after the second, should only see two")
 println("additionally, there is a while loop with its own break statement which should be fine")
@@ -116,29 +104,6 @@ fn add3(x: int, y: int, z: int) -> int
 }
 
 println(add3(1, 2, 3))
-
-# Nested Function Lookup
-# We define a function, then define a function with the same name within a different
-# function. This should not overwrite the original function in the top scope
-fn get_num() -> int
-{
-    return 1
-}
-
-fn foo() -> null
-{
-    fn get_num() -> int
-    {
-        return 2
-    }
-}
-
-println(
-    "We should get 1 when calling get_num since the version returning 2 is not in this scope"
-)
-print("get_num() == ")
-print(get_num())
-print("\n")
 
 fn print_one_to_ten() -> null
 {

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,12 +1,13 @@
 
 
-for y in [1, 2, 3, 4]
-{
-    println(y)
-}
-println(y)
 
-for y in ["1", "2", "3", "4"]
+
+fn foo() -> null
 {
-    println(y)
+    fn bar() -> int
+    {
+        return 1
+    }
 }
+
+foo()

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,13 +1,12 @@
 
 
-
+x := 5
 
 fn foo() -> null
 {
-    fn bar() -> int
-    {
-        return 1
-    }
+    x := 6
+    println(x)
 }
 
 foo()
+println(x)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -13,7 +13,7 @@
 
 namespace anzu {
 
-struct compiler_scope
+struct compiler_frame
 {
     struct function_def
     {
@@ -30,13 +30,13 @@ struct compiler_scope
 struct compiler_context
 {
     anzu::program program;
-    std::vector<compiler_scope> scopes;
+    std::vector<compiler_frame> frames;
 };
 
 // Registers the given name in the current scope
 auto declare_variable_name(compiler_context& ctx, const std::string& name) -> void
 {
-    auto& vars = ctx.scopes.back().variables;
+    auto& vars = ctx.frames.back().variables;
     vars.emplace(name, vars.size());
 }
 
@@ -44,13 +44,13 @@ auto save_variable(compiler_context& ctx, const std::string& name) -> void
 {
     declare_variable_name(ctx, name);
     ctx.program.emplace_back(anzu::op_save_variable{
-        .name=name, .offset=ctx.scopes.back().variables.at(name)
+        .name=name, .offset=ctx.frames.back().variables.at(name)
     });
 }
 
 auto load_variable(compiler_context& ctx, const std::string& name) -> void
 {
-    for (const auto& scope : ctx.scopes | std::views::reverse) {
+    for (const auto& scope : ctx.frames | std::views::reverse) {
         if (auto it = scope.variables.find(name); it != scope.variables.end()) {
             ctx.program.emplace_back(anzu::op_load_variable{
                 .name=name, .offset=it->second
@@ -71,9 +71,9 @@ auto call_builtin(compiler_context& ctx, const std::string& function_name) -> vo
 auto find_function(
     const compiler_context& ctx, const std::string& function
 )
-    -> const compiler_scope::function_def*
+    -> const compiler_frame::function_def*
 {
-    for (const auto& scope : ctx.scopes | std::views::reverse) {
+    for (const auto& scope : ctx.frames | std::views::reverse) {
         if (const auto it = scope.functions.find(function); it != scope.functions.end()) {
             return &it->second;
         }
@@ -308,14 +308,14 @@ void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
 {
     const auto start_pos = std::ssize(ctx.program);
     ctx.program.emplace_back(anzu::op_function{ .name=node.name, .sig=node.sig });
-    ctx.scopes.back().functions[node.name] = { .sig=node.sig ,.ptr=start_pos };
+    ctx.frames.back().functions[node.name] = { .sig=node.sig ,.ptr=start_pos };
 
-    ctx.scopes.emplace_back();
+    ctx.frames.emplace_back();
     for (const auto& arg : node.sig.args) {
         declare_variable_name(ctx, arg.name);
     }
     compile_node(*node.body, ctx);
-    ctx.scopes.pop_back();
+    ctx.frames.pop_back();
 
     const auto end_pos = std::ssize(ctx.program);
     ctx.program.emplace_back(anzu::op_function_end{});
@@ -350,7 +350,7 @@ auto compile_node(const node_stmt& root, compiler_context& ctx) -> void
 auto compile(const std::unique_ptr<node_stmt>& root) -> anzu::program
 {
     anzu::compiler_context ctx;
-    ctx.scopes.emplace_back(); // Global scope
+    ctx.frames.emplace_back(); // Global scope
     compile_node(*root, ctx);
     return ctx.program;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -284,9 +284,6 @@ auto parse_braced_statement_list(tokenstream& tokens) -> node_stmt_ptr
 
 auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
 {
-    if (tokens.peek(tk_function)) {
-        return parse_function_def_stmt(tokens);
-    }
     if (tokens.peek(tk_return)) {
         return parse_return_stmt(tokens);
     }
@@ -320,6 +317,14 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
     parser_error(tokens.curr(), "unknown statement '{}'", tokens.curr().text);
 }
 
+auto parse_top_level_statement(tokenstream& tokens) -> node_stmt_ptr
+{
+    if (tokens.peek(tk_function)) {
+        return parse_function_def_stmt(tokens);
+    }
+    return parse_statement(tokens);
+}
+
 }
 
 auto parse(const std::vector<anzu::token>& tokens) -> node_stmt_ptr
@@ -329,7 +334,7 @@ auto parse(const std::vector<anzu::token>& tokens) -> node_stmt_ptr
     auto root = std::make_unique<anzu::node_stmt>();
     auto& seq = root->emplace<anzu::node_sequence_stmt>();
     while (stream.valid()) {
-        seq.sequence.push_back(parse_statement(stream));
+        seq.sequence.push_back(parse_top_level_statement(stream));
     }
     return root;
 }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -18,14 +18,20 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_load_literal& op) {
             return std::format("OP_LOAD_LITERAL({})", op.value.to_repr());
         },
-        [&](const op_load_variable& op) {
-            return std::format("OP_LOAD_VARIABLE({})", op.name);
+        [&](const op_load_global& op) {
+            return std::format("OP_LOAD_GLOBAL({})", op.name);
+        },
+        [&](const op_load_local& op) {
+            return std::format("OP_LOAD_LOCAL({})", op.name);
         },
         [&](const op_pop& op) {
             return std::string{"OP_POP"};
         },
-        [&](const op_save_variable& op) {
-            return std::format("OP_SAVE_VARIABLE({})", op.name);
+        [&](const op_save_global& op) {
+            return std::format("OP_SAVE_GLOBAL({})", op.name);
+        },
+        [&](const op_save_local& op) {
+            return std::format("OP_SAVE_LOCAL({})", op.name);
         },
         [&](const op_if& op) {
             return std::string{"OP_IF"};

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -19,19 +19,19 @@ auto to_string(const op& op_code) -> std::string
             return std::format("OP_LOAD_LITERAL({})", op.value.to_repr());
         },
         [&](const op_load_global& op) {
-            return std::format("OP_LOAD_GLOBAL({})", op.name);
+            return std::format("OP_LOAD_GLOBAL({}: {})", op.name, op.position);
         },
         [&](const op_load_local& op) {
-            return std::format("OP_LOAD_LOCAL({})", op.name);
+            return std::format("OP_LOAD_LOCAL({}: +{})", op.name, op.offset);
         },
         [&](const op_pop& op) {
             return std::string{"OP_POP"};
         },
         [&](const op_save_global& op) {
-            return std::format("OP_SAVE_GLOBAL({})", op.name);
+            return std::format("OP_SAVE_GLOBAL({}: {})", op.name, op.position);
         },
         [&](const op_save_local& op) {
-            return std::format("OP_SAVE_LOCAL({})", op.name);
+            return std::format("OP_SAVE_LOCAL({}: +{})", op.name, op.offset);
         },
         [&](const op_if& op) {
             return std::string{"OP_IF"};

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -15,7 +15,13 @@ struct op_load_literal
     anzu::object value;
 };
 
-struct op_load_variable
+struct op_load_global
+{
+    std::string name;
+    std::size_t position;
+};
+
+struct op_load_local
 {
     std::string name;
     std::size_t offset;
@@ -25,7 +31,13 @@ struct op_pop
 {
 };
 
-struct op_save_variable
+struct op_save_global
+{
+    std::string name;
+    std::size_t position;
+};
+
+struct op_save_local
 {
     std::string name;
     std::size_t offset;
@@ -157,9 +169,11 @@ struct op_build_list
 
 struct op : std::variant<
     op_load_literal,
-    op_load_variable,
+    op_load_global,
+    op_load_local,
     op_pop,
-    op_save_variable,
+    op_save_global,
+    op_save_local,
     op_if,
     op_if_end,
     op_else,

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -73,7 +73,12 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.memory.push_back(op.value);
             program_advance(ctx);
         },
-        [&](const op_load_variable& op) {
+        [&](const op_load_global& op) {
+            const auto idx = op.position;
+            ctx.memory.push_back(ctx.memory[idx]);
+            program_advance(ctx);
+        },
+        [&](const op_load_local& op) {
             const auto idx = base_ptr(ctx) + op.offset;
             ctx.memory.push_back(ctx.memory[idx]);
             program_advance(ctx);
@@ -82,7 +87,11 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.memory.pop_back();
             program_advance(ctx);
         },
-        [&](const op_save_variable& op) {
+        [&](const op_save_global& op) {
+            save_top_at(ctx, op.position);
+            program_advance(ctx);
+        },
+        [&](const op_save_local& op) {
             save_top_at(ctx, base_ptr(ctx) + op.offset);
             program_advance(ctx);
         },


### PR DESCRIPTION
* Disallow nested functions. They serve no purpose since we don't have closures.
* In the compiler/typecheck contexts, replace the stack of "scopes" with a map of functions, a map of global variables, and an optional map of local variables for when inside a function.
* Global variables can be read/modified in a function via assignment. You can also shadow global variables using a declaration. All uses of the variable name after a declaration will refer to the local variable.
* The load/save variable op codes have been replaced with local and global versions. This is mainly for debuggability.