### PR TITLE
Fix Function Return Values

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,12 +1,26 @@
 
 
-x := 5
-
-fn foo() -> null
+fn foo(x: int, y: int) -> int
 {
-    x := 6
-    println(x)
+    return 5
 }
 
-foo()
-println(x)
+a := foo(1, 2)
+println(a)
+
+fn not(x: bool) -> bool
+{
+    if x return false
+    return true
+}
+
+fn assert(cond: bool) -> null
+{
+    if not(cond) {
+        println("you are bad at maths")
+    }
+}
+
+assert(2 + 2 == 5)
+
+

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -56,10 +56,10 @@ auto save_top_at(runtime_context& ctx, std::size_t idx) -> void
 }
 
 // Cleans up the variables used in the current frame and removes the frame
-// pointers to return back to the previous scope. Leaves one extra since that is
-// the return value.
+// pointers to return back to the previous scope.
 auto pop_frame(runtime_context& ctx) -> void
 {
+    ctx.memory[base_ptr(ctx)] = ctx.memory.back(); // Move return value
     while (std::ssize(ctx.memory) > base_ptr(ctx) + 1) {
         ctx.memory.pop_back();
     }


### PR DESCRIPTION
* Turns out, return values were broken. Instead of returning the return value, they returned the first function parameter (or null).
* This is because functions leave behind a single value, but the base pointer starts at the first function argument.
* `pop_frame` in the runtime now overwrites the first function arg with the return value.