### PR TITLE
Add `vec2` Type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -78,6 +78,7 @@
         "unordered_set": "cpp",
         "*.rh": "cpp",
         "memory_resource": "cpp",
-        "mutex": "cpp"
+        "mutex": "cpp",
+        "numeric": "cpp"
     }
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,5 @@
 
-x := [1]
+fn vec2_test(v: vec2) -> null
+{}
 
-for y in x {}
-for t in x {}
+x := vec2(1, 2)

--- a/examples/test.az
+++ b/examples/test.az
@@ -5,3 +5,5 @@ fn vec2_test(x: vec2) -> null
 
 x := vec2(1, 2)
 y := 5
+
+println(x)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,7 @@
 
-fn vec2_test(v: vec2) -> null
-{}
+fn vec2_test(x: int) -> int
+{
+    return x
+}
 
-x := vec2(1, 2)
+y := vec2_test(1)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,5 @@
 
+x := [1]
 
-if 1 == 1 {
-    println(5)
-}
+for y in x {}
+for t in x {}

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,6 +4,7 @@ fn vec2_test(x: vec2) -> null
 }
 
 x := vec2(1, 2)
-y := 5
-
-println(x)
+println(vec2_first(x))
+println(vec2_second(x))
+println(vec2_second(x))
+println(vec2_first(x))

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,3 +4,4 @@ fn vec2_test(x: vec2) -> null
 }
 
 x := vec2(1, 2)
+y := 5

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,7 +1,6 @@
 
-fn vec2_test(x: int) -> int
+fn vec2_test(x: vec2) -> null
 {
-    return x
 }
 
-y := vec2_test(1)
+x := vec2(1, 2)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,10 +1,14 @@
 
-fn vec2_test(x: vec2) -> null
+fn make_vec2(x: int, y: int) -> vec2
 {
+    t := vec2(x, y)
+    return t
 }
 
-x := vec2(1, 2)
-println(vec2_first(x))
-println(vec2_second(x))
-println(vec2_second(x))
-println(vec2_first(x))
+make_vec2(1, 2)
+make_vec2(1, 2)
+make_vec2(1, 2)
+make_vec2(1, 2)
+make_vec2(1, 2)
+make_vec2(1, 2)
+make_vec2(1, 2)

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -12,7 +12,7 @@ auto print_node(const anzu::node_expr& root, int indent) -> void
     const auto spaces = std::string(4 * indent, ' ');
     std::visit(overloaded {
         [&](const node_literal_expr& node) {
-            anzu::print("{}Literal: {}\n", spaces, to_string(node.value));
+            anzu::print("{}Literal: {}\n", spaces, node.value);
         },
         [&](const node_variable_expr& node) {
             anzu::print("{}Variable: {}\n", spaces, node.name);
@@ -99,9 +99,9 @@ auto print_node(const anzu::node_stmt& root, int indent) -> void
         [&](const node_function_def_stmt& node) {
             anzu::print("{}Function: {} (", spaces, node.name);
             anzu::print_comma_separated(node.sig.args, [](const auto& arg) {
-                return std::format("{}: {}", arg.name, to_string(arg.type));
+                return std::format("{}: {}", arg.name, arg.type);
             });
-            anzu::print(") -> {}\n", to_string(node.sig.return_type));
+            anzu::print(") -> {}\n", node.sig.return_type);
             print_node(*node.body, indent + 1);
         },
         [&](const node_function_call_stmt& node) {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -195,10 +195,19 @@ void compile_function_call(
     }
     else {
         const auto& builtin = anzu::fetch_builtin(function);
+        auto sig = builtin.sig;
+        print("compiling a '{}' call with sig {}\n", function, sig);
+
+        // TODO: Make this more generic, but we need to fill in the types before
+        // calling here, so that we can pass in the correct blocks
+        if (function == "print" || function == "println") {
+            sig.args[0].type = ctx.expr_types[args[0].get()];
+        }
+        
         ctx.program.emplace_back(anzu::op_builtin_call{
             .name=function,
             .ptr=builtin.ptr,
-            .sig=builtin.sig
+            .sig=sig
         });
     }
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -589,14 +589,16 @@ void compile_node(const node_continue_stmt&, compiler_context& ctx)
 void compile_node(const node_declaration_stmt& node, compiler_context& ctx)
 {
     compile_node(*node.expr, ctx);
-    declare_variable_name(ctx, node.name, 1);
-    save_variable(ctx, node.name, 1);
+    const auto size = type_block_size(ctx.expr_types[node.expr.get()]);
+    declare_variable_name(ctx, node.name, size);
+    save_variable(ctx, node.name, size);
 }
 
 void compile_node(const node_assignment_stmt& node, compiler_context& ctx)
 {
     compile_node(*node.expr, ctx);
-    save_variable(ctx, node.name, 1);
+    const auto size = type_block_size(ctx.expr_types[node.expr.get()]);
+    save_variable(ctx, node.name, size);
 }
 
 void compile_node(const node_function_def_stmt& node, compiler_context& ctx)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -183,7 +183,10 @@ void compile_function_call(
         compile_node(*arg, ctx);
     }
 
-    if (const auto function_def = find_function(ctx, function)) {
+    if (function == "vec2") {
+        // Noop
+    }
+    else if (const auto function_def = find_function(ctx, function)) {
         ctx.program.emplace_back(anzu::op_function_call{
             .name=function,
             .ptr=function_def->ptr + 1, // Jump into the function

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -195,11 +195,10 @@ void compile_function_call(
     }
     else {
         const auto& builtin = anzu::fetch_builtin(function);
-        auto sig = builtin.sig;
-        print("compiling a '{}' call with sig {}\n", function, sig);
 
         // TODO: Make this more generic, but we need to fill in the types before
-        // calling here, so that we can pass in the correct blocks
+        // calling here, so that we can pass in the correct block count
+        auto sig = builtin.sig;
         if (function == "print" || function == "println") {
             sig.args[0].type = ctx.expr_types[args[0].get()];
         }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -46,6 +46,8 @@ struct compiler_context
     std::optional<var_locations> locals;
 
     expr_types expr_types;
+
+    type_store registered_types;
 };
 
 template <typename T>

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -162,7 +162,7 @@ auto construct_builtin_map() -> std::unordered_map<std::string, builtin>
         .sig = {
             .args = {
                 { .name = "string", .type = str_type() },
-                { .name = "index",    .type = int_type() }
+                { .name = "index",  .type = int_type() }
             },
             .return_type = str_type()
         }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -56,29 +56,51 @@ auto builtin_str_at(std::span<const block> args) -> block
 
 auto builtin_print(std::span<const block> args) -> block
 {
-    const auto& obj = args[0];
-    std::visit(overloaded{
-        [&](const block_str& blk) {
-            anzu::print("{}", format_special_chars(blk));
-        },
-        [&](const auto&) {
-            anzu::print("{}", obj);
+    const auto to_string = [](const block& blk) {
+        return std::visit(overloaded{
+            [](const block_str& blk) {
+                return std::format("{}", format_special_chars(blk));
+            },
+            [&](const auto&) {
+                return std::format("{}", blk);
+            }
+        }, blk);
+    };
+
+    if (args.size() > 1) {
+        auto out = std::format("{{{}", to_string(args.front()));
+        for (const auto& arg : args | std::views::drop(1)) {
+            out += std::format(", {}", to_string(arg));
         }
-    }, obj);
+        print("{}}}", out);
+    } else {
+        print("{}", to_string(args[0]));
+    }
     return block{block_null{}};
 }
 
 auto builtin_println(std::span<const block> args) -> block
 {
-    const auto& obj = args[0];
-    std::visit(overloaded{
-        [&](const block_str& blk) {
-            anzu::print("{}\n", format_special_chars(blk));
-        },
-        [&](const auto&) {
-            anzu::print("{}\n", obj);
+    const auto to_string = [](const block& blk) {
+        return std::visit(overloaded{
+            [](const block_str& blk) {
+                return std::format("{}", format_special_chars(blk));
+            },
+            [&](const auto&) {
+                return std::format("{}", blk);
+            }
+        }, blk);
+    };
+
+    if (args.size() > 1) {
+        auto out = std::format("{{{}", to_string(args.front()));
+        for (const auto& arg : args | std::views::drop(1)) {
+            out += std::format(", {}", to_string(arg));
         }
-    }, obj);
+        print("{}}}\n", out);
+    } else {
+        print("{}\n", to_string(args[0]));
+    }
     return block{block_null{}};
 }
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -121,6 +121,16 @@ auto builtin_range(std::span<const block> args) -> block
     return block{list};
 }
 
+auto builtin_first(std::span<const block> args) -> block
+{
+    return args[0];
+}
+
+auto builtin_second(std::span<const block> args) -> block
+{
+    return args[1];
+}
+
 }
 
 auto construct_builtin_map() -> std::unordered_map<std::string, builtin>
@@ -225,6 +235,26 @@ auto construct_builtin_map() -> std::unordered_map<std::string, builtin>
                 { .name = "max", .type = int_type() }
             },
             .return_type = concrete_list_type(int_type())
+        }
+    });
+
+    builtins.emplace("vec2_first", builtin{
+        .ptr = builtin_first,
+        .sig = {
+            .args = {
+                { .name = "v", .type = vec2_type() }
+            },
+            .return_type = int_type()
+        }
+    });
+
+    builtins.emplace("vec2_second", builtin{
+        .ptr = builtin_second,
+        .sig = {
+            .args = {
+                { .name = "v", .type = vec2_type() }
+            },
+            .return_type = int_type()
         }
     });
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -58,6 +58,11 @@ auto make_null() -> object
     return { .data = { block_null{} }, .type = null_type() };
 }
 
+auto make_vec2(block_int x, block_int y) -> object
+{
+    return { .data = { block_int(x), block_int(y) }, .type = vec2_type() };
+}
+
 auto format_special_chars(const std::string& str) -> std::string
 {
     std::string ret;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -43,6 +43,8 @@ auto make_bool(block_bool val) -> object;
 auto make_str(const block_str& val) -> object;
 auto make_null() -> object;
 
+auto make_vec2(block_int x, block_int y) -> object;
+
 // Should be elsewhere
 auto format_special_chars(const std::string& str) -> std::string;
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -53,3 +53,9 @@ template <> struct std::formatter<anzu::block> : std::formatter<std::string> {
         return std::formatter<std::string>::format(to_string(blk), ctx);
     }
 };
+
+template <> struct std::formatter<anzu::object> : std::formatter<std::string> {
+    auto format(const anzu::object& obj, auto& ctx) {
+        return std::formatter<std::string>::format(to_string(obj), ctx);
+    }
+};

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -171,6 +171,12 @@ auto parse_type(tokenstream& tokens) -> type
         });
         return ret;
     }
+
+    // Temporary to get vec2 working, generalise later.
+    if (type_name == "vec2") {
+        return vec2_type();
+    }
+    
     return { type_simple{ .name = type_name } };
 }
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -16,7 +16,7 @@ auto to_string(const op& op_code) -> std::string
 {
     return std::visit(overloaded {
         [&](const op_load_literal& op) {
-            return std::format("OP_LOAD_LITERAL({})", to_string(op.value));
+            return std::format("OP_LOAD_LITERAL({})", op.value);
         },
         [&](const op_load_global& op) {
             return std::format("OP_LOAD_GLOBAL({}: {})", op.name, op.position);
@@ -94,7 +94,7 @@ auto print_program(const anzu::program& program) -> void
 {
     int lineno = 0;
     for (const auto& op : program) {
-        anzu::print("{:>4} - {}\n", lineno++, anzu::to_string(op));
+        anzu::print("{:>4} - {}\n", lineno++, op);
     }
 }
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -25,7 +25,7 @@ auto to_string(const op& op_code) -> std::string
             return std::format("OP_LOAD_LOCAL({}: +{})", op.name, op.offset);
         },
         [&](const op_pop& op) {
-            return std::string{"OP_POP"};
+            return std::format("OP_POP({})", op.size);
         },
         [&](const op_save_global& op) {
             return std::format("OP_SAVE_GLOBAL({}: {})", op.name, op.position);

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -152,3 +152,9 @@ auto to_string(const op& op_code) -> std::string;
 auto print_program(const anzu::program& program) -> void;
 
 }
+
+template <> struct std::formatter<anzu::op> : std::formatter<std::string> {
+    auto format(const anzu::op& op, auto& ctx) {
+        return std::formatter<std::string>::format(to_string(op), ctx);
+    }
+};

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -31,6 +31,7 @@ struct op_load_local
 
 struct op_pop
 {
+    std::size_t size;
 };
 
 struct op_save_global

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -19,12 +19,14 @@ struct op_load_global
 {
     std::string name;
     std::size_t position;
+    std::size_t size;
 };
 
 struct op_load_local
 {
     std::string name;
     std::size_t offset;
+    std::size_t size;
 };
 
 struct op_pop

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -35,12 +35,14 @@ struct op_save_global
 {
     std::string name;
     std::size_t position;
+    std::size_t size;
 };
 
 struct op_save_local
 {
     std::string name;
     std::size_t offset;
+    std::size_t size;
 };
 
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -64,7 +64,7 @@ auto pop_frame(runtime_context& ctx) -> void
     for (std::size_t i = 0; i != return_size; ++i) {
         ctx.memory[base_ptr(ctx) + i] = ctx.memory[ctx.memory.size() - return_size + i];
     }
-    while (std::ssize(ctx.memory) > base_ptr(ctx) + return_size) {
+    while (std::ssize(ctx.memory) > base_ptr(ctx) + (int)return_size) {
         ctx.memory.pop_back();
     }
     ctx.frames.pop_back();

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -68,9 +68,10 @@ auto pop_frame(runtime_context& ctx) -> void
     for (std::size_t i = 0; i != return_size; ++i) {
         ctx.memory[base_ptr(ctx) + i] = ctx.memory[ctx.memory.size() - return_size + i];
     }
-    while (std::ssize(ctx.memory) > base_ptr(ctx) + (int)return_size) {
+    while (std::ssize(ctx.memory) > base_ptr(ctx) + (intptr_t)return_size) {
         ctx.memory.pop_back();
     }
+    ctx.frames.pop_back();
 }
 
 auto apply_op(runtime_context& ctx, const op& op_code) -> void

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -51,8 +51,12 @@ auto save_top_at(runtime_context& ctx, std::size_t idx, std::size_t size) -> voi
     if (idx == ctx.memory.size() - size) {
         return;
     }
-    ctx.memory[idx] = ctx.memory.back();
-    ctx.memory.pop_back();
+    for (std::size_t i = 0; i != size; ++i) {
+        ctx.memory[idx + i] = ctx.memory[ctx.memory.size() - size + i];
+    }
+    for (std::size_t i = 0; i != size; ++i) {
+        ctx.memory.pop_back();
+    }
 }
 
 // Cleans up the variables used in the current frame and removes the frame
@@ -67,7 +71,6 @@ auto pop_frame(runtime_context& ctx) -> void
     while (std::ssize(ctx.memory) > base_ptr(ctx) + (int)return_size) {
         ctx.memory.pop_back();
     }
-    ctx.frames.pop_back();
 }
 
 auto apply_op(runtime_context& ctx, const op& op_code) -> void

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -189,7 +189,7 @@ auto run_program_debug(const anzu::program& program) -> void
     ctx.frames.emplace_back();
     while (program_ptr(ctx) < std::ssize(program)) {
         const auto& op = program[program_ptr(ctx)];
-        anzu::print("{:>4} - {}\n", program_ptr(ctx), anzu::to_string(op));
+        anzu::print("{:>4} - {}\n", program_ptr(ctx), op);
         apply_op(ctx, program[program_ptr(ctx)]);
         anzu::print("Memory: {}\n", format_comma_separated(ctx.memory));
     }

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -60,7 +60,7 @@ auto save_top_at(runtime_context& ctx, std::size_t idx, std::size_t size) -> voi
 auto pop_frame(runtime_context& ctx) -> void
 {
     const auto return_size = ctx.frames.back().return_size;
-    
+
     for (std::size_t i = 0; i != return_size; ++i) {
         ctx.memory[base_ptr(ctx) + i] = ctx.memory[ctx.memory.size() - return_size + i];
     }
@@ -148,6 +148,7 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
 
             ctx.frames.emplace_back();
             ctx.frames.back().base_ptr = ctx.memory.size() - op.sig.args.size();
+            ctx.frames.back().return_size = type_block_size(op.sig.return_type);
             program_jump_to(ctx, op.ptr); // Jump into the function
         },
         [&](const op_builtin_call& op) {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -81,12 +81,16 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
         },
         [&](const op_load_global& op) {
             const auto idx = op.position;
-            ctx.memory.push_back(ctx.memory[idx]);
+            for (std::size_t i = 0; i != op.size; ++i) {
+                ctx.memory.push_back(ctx.memory[idx + i]);
+            }
             program_advance(ctx);
         },
         [&](const op_load_local& op) {
             const auto idx = base_ptr(ctx) + op.offset;
-            ctx.memory.push_back(ctx.memory[idx]);
+            for (std::size_t i = 0; i != op.size; ++i) {
+                ctx.memory.push_back(ctx.memory[idx + i]);
+            }
             program_advance(ctx);
         },
         [&](const op_pop& op) {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -160,7 +160,11 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             program_jump_to(ctx, op.ptr); // Jump into the function
         },
         [&](const op_builtin_call& op) {
-            auto args = std::vector<anzu::block>(op.sig.args.size());
+            auto arg_size = std::size_t{0};
+            for (const auto arg : op.sig.args) {
+                arg_size += type_block_size(arg.type);
+            }
+            auto args = std::vector<anzu::block>(arg_size);
             for (auto& arg : args | std::views::reverse) {
                 arg = pop_back(ctx.memory);
             }

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -98,7 +98,9 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             program_advance(ctx);
         },
         [&](const op_pop& op) {
-            ctx.memory.pop_back();
+            for (std::size_t i = 0; i != op.size; ++i) {
+                ctx.memory.pop_back();
+            }
             program_advance(ctx);
         },
         [&](const op_save_global& op) {

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -10,6 +10,7 @@ struct frame
 {
     std::intptr_t program_ptr = 0;
     std::intptr_t base_ptr = 0;
+    std::size_t   return_size = 1;
 };
 
 struct runtime_context

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -27,10 +27,7 @@ auto print_tokens(const std::vector<anzu::token>& tokens) -> void
 {
     for (const auto& token : tokens) {
         const auto text = std::format("'{}'", token.text);
-        anzu::print(
-            "{:<10} - {:<20} {:<5} {:<5}\n",
-            anzu::to_string(token.type), text, token.line, token.col
-        );
+        anzu::print("{:<10} - {:<20} {:<5} {:<5}\n", token.type, text, token.line, token.col);
     }
 }
 

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -3,6 +3,7 @@
 #include "utility/peekstream.hpp"
 
 #include <string>
+#include <format>
 #include <vector>
 
 namespace anzu {
@@ -55,3 +56,9 @@ public:
 };
     
 }
+
+template <> struct std::formatter<anzu::token_type> : std::formatter<std::string> {
+    auto format(const anzu::token_type& tt, auto& ctx) {
+        return std::formatter<std::string>::format(to_string(tt), ctx);
+    }
+};

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -100,7 +100,10 @@ auto generic_type(int id) -> type
 
 auto vec2_type() -> type
 {
-    return {type_simple{ .name = "vec2" }};
+    return {type_class{
+        .name = "vec2",
+        .fields = { { .name="x", .type=int_type() }, { .name="y", .type=int_type() } }
+    }};
 }
 
 auto concrete_list_type(const type& t) -> type

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -233,6 +233,7 @@ type_store::type_store()
     d_types.emplace(bool_type());
     d_types.emplace(str_type());
     d_types.emplace(null_type());
+    d_types.emplace(vec2_type());
 
     d_generics.emplace(generic_list_type());
 }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -77,6 +77,11 @@ auto generic_type(int id) -> type
     return {type_generic{ .id = id }};
 }
 
+auto vec2_type() -> type
+{
+    return {type_simple{ .name = "vec2" }};
+}
+
 auto concrete_list_type(const type& t) -> type
 {
     return {type_compound{

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -49,6 +49,7 @@ auto bool_type() -> type;
 auto str_type() -> type;
 auto null_type() -> type;
 auto generic_type(int id) -> type;
+auto vec2_type() -> type;
 
 auto concrete_list_type(const type& t) -> type;
 auto generic_list_type() -> type;

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <unordered_set>
 #include <unordered_map>
+#include <utility>
 
 namespace anzu {
 
@@ -32,17 +33,35 @@ struct type_generic
     auto operator==(const type_generic&) const -> bool = default;
 };
 
-struct type : public std::variant<type_simple, type_compound, type_generic> {};
+struct type_class
+{
+    struct field;
+
+    std::string        name;
+    std::vector<field> fields;
+    auto operator==(const type_class&) const -> bool = default;
+};
+
+struct type : public std::variant<type_simple, type_compound, type_generic, type_class> {};
+
+struct type_class::field
+{
+    std::string name;
+    type        type;
+    auto operator==(const field&) const -> bool = default;
+};
 
 auto to_string(const type& type) -> std::string;
 auto to_string(const type_simple& type) -> std::string;
 auto to_string(const type_compound& type) -> std::string;
 auto to_string(const type_generic& type) -> std::string;
+auto to_string(const type_class& type) -> std::string;
 
 auto hash(const type& type) -> std::size_t;
 auto hash(const type_simple& type) -> std::size_t;
 auto hash(const type_compound& type) -> std::size_t;
 auto hash(const type_generic& type) -> std::size_t;
+auto hash(const type_class& type) -> std::size_t;
 
 auto int_type() -> type;
 auto bool_type() -> type;
@@ -55,6 +74,8 @@ auto concrete_list_type(const type& t) -> type;
 auto generic_list_type() -> type;
 
 auto is_type_complete(const type& type) -> bool;
+
+// Returns true if and only if the type is not a class type.
 auto it_type_fundamental(const type& type) -> bool;
 
 using match_result = std::unordered_map<int, type>;

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -73,10 +73,13 @@ auto vec2_type() -> type;
 auto concrete_list_type(const type& t) -> type;
 auto generic_list_type() -> type;
 
-auto is_type_complete(const type& type) -> bool;
+auto is_type_complete(const type& t) -> bool;
+
+// Returns the number of blocks that represent this type. Returns 0 if the type is not complete.
+auto type_block_size(const type& t) -> std::size_t;
 
 // Returns true if and only if the type is not a class type.
-auto it_type_fundamental(const type& type) -> bool;
+auto it_type_fundamental(const type& t) -> bool;
 
 using match_result = std::unordered_map<int, type>;
 auto match(const type& concrete, const type& pattern) -> std::optional<match_result>;

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -211,6 +211,16 @@ auto get_typechecked_signature(
 )
     -> signature
 {
+    if (function_name == "vec2") {
+        return signature{
+            .args = {
+                { .name="x", .type=int_type() },
+                { .name="y", .type=int_type() }
+            },
+            .return_type = vec2_type()
+        };
+    }
+
     const auto sig = fetch_function_signature(ctx, tok, function_name);
 
     if (sig.args.size() != args.size()) {
@@ -287,6 +297,9 @@ auto typecheck_function_call(
 {
     const auto signature = get_typechecked_signature(ctx, tok, function_name, args);
 
+    if (function_name == "vec2") {
+        return vec2_type();
+    }
     if (!is_builtin(function_name)) {
         const auto* function_def = fetch_function_def(ctx, tok, function_name);
         if (is_function_generic(*function_def)) {


### PR DESCRIPTION
* This is a very hacky implementation, is probably very error prone, and is lacking a lot of features.
* The bulk of this PR is allowing for objects that are larger than one block in size. There are probably some things I've missed since the assumption that an object == a single block is everywhere in the code.
* Builtin functions that accept generic objects are currently broken.
* `print` and `println` are exceptions to the above. I've hacked those in as special cases to work properly. When compiling either of these functions, we resolve the function signature based on the parameters passed in so the size is known, so the correct number of blocks get passed in when called. This needs to be generalized by resolving all generic signatures at compile-time, which is doable, just tedious.
* `var_locations` in the compiler is now a struct rather than a typedef, since the index of the next position needs to be stored alongside it (previously we just used the size since everything was size 1).
* All the `op_(store|load)_(global|local)` and `op_pop` now have a `size` parameter so the runtime knows how many blocks to store/load/pop.
* `vec2` is treated as a special function name, which essentially acts as a constructor without the constructor being a specific thing. We should generalize this.
* For loops need to be generalized to allow for lists of objects of size >1.#
* `vec2` is an example of a `type_class`, a new struct added into the type variant. This should be merged with `simple` types.
* `vec2` is also treated specially in the parser when parsing a type. Again, this should be generalized.
* Many changes to the runtime to replace singular pops and pushes with sized ones.
* Remove many occurrences of `to_string` calls since there are `std::formatter<>` implementations for most custom types.
* Added `type_block_size` to query the size of a type.
* Added builtins `vec2_first` and `vec2_second`. We can remove these when we add attribute access.