### PR TITLE
Clean up `vec2` Part 1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/test.az", "run"],
+            "args": ["${workspaceFolder}/examples/feature_test.az", "run"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,14 +1,2 @@
 
-fn make_vec2(x: int, y: int) -> vec2
-{
-    t := vec2(x, y)
-    return t
-}
-
-make_vec2(1, 2)
-make_vec2(1, 2)
-make_vec2(1, 2)
-make_vec2(1, 2)
-make_vec2(1, 2)
-make_vec2(1, 2)
-make_vec2(1, 2)
+println(4 + 5)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -185,9 +185,14 @@ auto compile_function_call(
         compile_node(*arg, ctx);
     }
 
-    if (function == "vec2") {
-        return 2; // S
+    // If this is the name of a simple type, then this is a constructor call, so
+    // there is currently nothing to do since the arguments are already pushed to
+    // the stack.
+    if (const auto type = ctx.registered_types.find_by_name(function)) {
+        return type_block_size(*type);
     }
+
+    // Otherwise, it may be a custom function.
     else if (const auto function_def = find_function(ctx, function)) {
         ctx.program.emplace_back(anzu::op_function_call{
             .name=function,
@@ -197,6 +202,7 @@ auto compile_function_call(
         return type_block_size(function_def->sig.return_type);
     }
 
+    // Otherwise, it must be a builtin function.
     const auto& builtin = anzu::fetch_builtin(function);
 
     // TODO: Make this more generic, but we need to fill in the types before

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "type.hpp"
 
+#include <functional>
 #include <string>
 #include <vector>
 #include <span>
@@ -12,7 +13,7 @@ using builtin_function = block(*)(std::span<const block>);
 
 // A more dangerous function pointer type that had access to the entire memory
 // vector, and should only be allowed for internal implementations of builtin types.
-using builtin_mem_op = void(*)(std::vector<block>& memory);
+using builtin_mem_op = std::function<void(std::vector<block>& memory)>;
 
 struct builtin
 {

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -15,7 +15,7 @@ struct block;
 struct object
 {
     std::vector<block> data;
-    anzu::type         type;
+    anzu::type_name         type;
 };
 
 using block_int  = int;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -15,7 +15,7 @@ struct block;
 struct object
 {
     std::vector<block> data;
-    anzu::type_name         type;
+    anzu::type_name    type;
 };
 
 using block_int  = int;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -154,18 +154,18 @@ auto parse_name(tokenstream& tokens)
     return token.text;   
 }
 
-auto parse_type(tokenstream& tokens) -> type
+auto parse_type(tokenstream& tokens) -> type_name
 {
     if (tokens.consume_maybe(tk_lbracket)) {
         const auto id = tokens.consume_int();
         tokens.consume_only(tk_rbracket);
         return { type_generic{ .id = id } };
     }
-    const auto type_name = tokens.consume().text;
+    const auto type_name_text = tokens.consume().text;
     if (tokens.consume_maybe(tk_lt)) {
-        auto ret = type{};
+        auto ret = type_name{};
         auto& compound = ret.emplace<type_compound>();
-        compound.name = type_name;
+        compound.name = type_name_text;
         tokens.consume_comma_separated_list(tk_gt, [&] {
             compound.subtypes.push_back(parse_type(tokens));
         });
@@ -173,11 +173,11 @@ auto parse_type(tokenstream& tokens) -> type
     }
 
     // Temporary to get vec2 working, generalise later.
-    if (type_name == "vec2") {
+    if (type_name_text == "vec2") {
         return vec2_type();
     }
     
-    return { type_simple{ .name = type_name } };
+    return { type_simple{ .name = type_name_text } };
 }
 
 auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -139,10 +139,6 @@ auto is_type_fundamental(const type& type) -> bool
 
 auto type_block_size(const type& t) -> std::size_t
 {
-    if (!is_type_complete(t)) {
-        return 0;
-    }
-
     return std::visit(overloaded{
         [](const type_simple& t) {
             if (t.fields.has_value()) {
@@ -154,7 +150,12 @@ auto type_block_size(const type& t) -> std::size_t
             }
             return std::size_t{1};
         },
-        [](const type_generic&) { return std::size_t{0}; }, // Never reached
+
+        // Checking the size of this should be an error, but we are making it return 1
+        // as a hack to make for loops (with lists of elements of size 1) work. Instead, for
+        // loops should properly calculate the size of the contained elements, but that's
+        // more involved. Fixing lists will be its own thing.
+        [](const type_generic&) { return std::size_t{1}; },
         [](const type_compound&) { return std::size_t{1}; }
     }, t);
 }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -7,7 +7,7 @@
 
 namespace anzu {
 
-auto to_string(const type& type) -> std::string
+auto to_string(const type_name& type) -> std::string
 {
     return std::visit([](const auto& t) { return to_string(t); }, type);
 }
@@ -37,7 +37,7 @@ auto to_string(const type_generic& type) -> std::string
     return std::format("[{}]", type.id);
 }
 
-auto hash(const type& type) -> std::size_t
+auto hash(const type_name& type) -> std::size_t
 {
     return std::visit([](const auto& t) { return hash(t); }, type);
 }
@@ -68,32 +68,32 @@ auto hash(const type_generic& type) -> std::size_t
     return std::hash<int>{}(type.id);
 }
 
-auto int_type()  -> type
+auto int_type()  -> type_name
 {
     return {type_simple{ .name = std::string{tk_int}  }};
 }
 
-auto bool_type() -> type
+auto bool_type() -> type_name
 {
     return {type_simple{ .name = std::string{tk_bool} }};
 }
 
-auto str_type()  -> type
+auto str_type()  -> type_name
 {
     return {type_simple{ .name = std::string{tk_str}  }};
 }
 
-auto null_type() -> type
+auto null_type() -> type_name
 {
     return {type_simple{ .name = std::string{tk_null} }};
 }
 
-auto generic_type(int id) -> type
+auto generic_type(int id) -> type_name
 {
     return {type_generic{ .id = id }};
 }
 
-auto vec2_type() -> type
+auto vec2_type() -> type_name
 {
     return {type_simple{
         .name = "vec2",
@@ -101,21 +101,21 @@ auto vec2_type() -> type
     }};
 }
 
-auto concrete_list_type(const type& t) -> type
+auto concrete_list_type(const type_name& t) -> type_name
 {
     return {type_compound{
         .name = std::string{tk_list}, .subtypes = { t }
     }};
 }
 
-auto generic_list_type() -> type
+auto generic_list_type() -> type_name
 {
     return {type_compound{
         .name = std::string{tk_list}, .subtypes = { generic_type(0) }
     }};
 }
 
-auto is_type_complete(const type& t) -> bool
+auto is_type_complete(const type_name& t) -> bool
 {
     return std::visit(overloaded {
         [](const type_simple&) { return true; },
@@ -128,7 +128,7 @@ auto is_type_complete(const type& t) -> bool
     }, t);
 }
 
-auto is_type_fundamental(const type& type) -> bool
+auto is_type_fundamental(const type_name& type) -> bool
 {
     return type == int_type()
         || type == bool_type()
@@ -137,7 +137,7 @@ auto is_type_fundamental(const type& type) -> bool
         || match(type, generic_list_type());
 }
 
-auto type_block_size(const type& t) -> std::size_t
+auto type_block_size(const type_name& t) -> std::size_t
 {
     return std::visit(overloaded{
         [](const type_simple& t) {
@@ -163,7 +163,7 @@ auto type_block_size(const type& t) -> std::size_t
 // Loads each key/value pair from src into dst. If the key already exists in dst and has a
 // different value, stop and return false.
 auto update(
-    std::unordered_map<int, type>& dst, const std::unordered_map<int, type>& src
+    std::unordered_map<int, type_name>& dst, const std::unordered_map<int, type_name>& src
 )
     -> bool
 {
@@ -179,7 +179,7 @@ auto update(
     return true;
 }
 
-auto match(const type& concrete, const type& pattern) -> std::optional<match_result>
+auto match(const type_name& concrete, const type_name& pattern) -> std::optional<match_result>
 {
     // Pre-condition, concrete must be a complete type (non-generic and no generic subtypes)
     if (!is_type_complete(concrete)) {
@@ -234,7 +234,7 @@ auto match(const type& concrete, const type& pattern) -> std::optional<match_res
     return matches;
 }
 
-auto replace(type& ret, const match_result& matches) -> void
+auto replace(type_name& ret, const match_result& matches) -> void
 {
     std::visit(overloaded {
         [&](type_simple&) {},
@@ -251,7 +251,7 @@ auto replace(type& ret, const match_result& matches) -> void
     }, ret);
 }
 
-auto bind_generics(const type& incomplete, const std::unordered_map<int, type>& matches) -> type
+auto bind_generics(const type_name& incomplete, const std::unordered_map<int, type_name>& matches) -> type_name
 {
     auto ret_type = incomplete;
     replace(ret_type, matches);
@@ -275,7 +275,7 @@ type_store::type_store()
     d_generics.emplace(generic_list_type());
 }
 
-auto type_store::is_registered_type(const type& t) const -> bool
+auto type_store::is_registered_type(const type_name& t) const -> bool
 {
     if (d_types.contains(t)) {
         return true;
@@ -290,9 +290,9 @@ auto type_store::is_registered_type(const type& t) const -> bool
     });
 }
 
-auto type_store::find_by_name(const std::string& name) const -> const type*
+auto type_store::find_by_name(const std::string& name) const -> const type_name*
 {
-    const auto get_type_name = [](const type& t) {
+    const auto get_type_name = [](const type_name& t) {
         return std::visit(overloaded{
             [](const type_simple& s) { return s.name; },
             [](const auto&) { return std::string{""}; }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -289,4 +289,21 @@ auto type_store::is_registered_type(const type& t) const -> bool
     });
 }
 
+auto type_store::find_by_name(const std::string& name) const -> const type*
+{
+    const auto get_type_name = [](const type& t) {
+        return std::visit(overloaded{
+            [](const type_simple& s) { return s.name; },
+            [](const auto&) { return std::string{""}; }
+        }, t);
+    };
+
+    for (const auto& type : d_types) {
+        if (get_type_name(type) == name) {
+            return &type;
+        }
+    }
+    return nullptr;
+}
+
 }

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -107,6 +107,11 @@ public:
 
     // Checks if the given type is registered or matches a registered generic.
     auto is_registered_type(const type& t) const -> bool;
+
+    // Finds the given type with the given name if it exists, otherwise returns
+    // nullptr. This is currently O(n) so we should potentially optimise this in
+    // the future.
+    auto find_by_name(const std::string& name) const -> const type*;
 };
 
 }

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -16,7 +16,10 @@ struct type;
 
 struct type_simple
 {
+    struct field;
+
     std::string name;
+    std::optional<std::vector<field>> fields; // nullopt == fundamental type
     auto operator==(const type_simple&) const -> bool = default;
 };
 
@@ -33,18 +36,9 @@ struct type_generic
     auto operator==(const type_generic&) const -> bool = default;
 };
 
-struct type_class
-{
-    struct field;
+struct type : public std::variant<type_simple, type_compound, type_generic> {};
 
-    std::string        name;
-    std::vector<field> fields;
-    auto operator==(const type_class&) const -> bool = default;
-};
-
-struct type : public std::variant<type_simple, type_compound, type_generic, type_class> {};
-
-struct type_class::field
+struct type_simple::field
 {
     std::string name;
     type        type;
@@ -55,13 +49,11 @@ auto to_string(const type& type) -> std::string;
 auto to_string(const type_simple& type) -> std::string;
 auto to_string(const type_compound& type) -> std::string;
 auto to_string(const type_generic& type) -> std::string;
-auto to_string(const type_class& type) -> std::string;
 
 auto hash(const type& type) -> std::size_t;
 auto hash(const type_simple& type) -> std::size_t;
 auto hash(const type_compound& type) -> std::size_t;
 auto hash(const type_generic& type) -> std::size_t;
-auto hash(const type_class& type) -> std::size_t;
 
 auto int_type() -> type;
 auto bool_type() -> type;

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -12,7 +12,7 @@
 
 namespace anzu {
 
-struct type;
+struct type_name;
 
 struct type_simple
 {
@@ -26,7 +26,7 @@ struct type_simple
 struct type_compound
 {
     std::string       name;
-    std::vector<type> subtypes;
+    std::vector<type_name> subtypes;
     auto operator==(const type_compound&) const -> bool = default;
 };
 
@@ -36,61 +36,61 @@ struct type_generic
     auto operator==(const type_generic&) const -> bool = default;
 };
 
-struct type : public std::variant<type_simple, type_compound, type_generic> {};
+struct type_name : public std::variant<type_simple, type_compound, type_generic> {};
 
 struct type_simple::field
 {
     std::string name;
-    type        type;
+    type_name        type;
     auto operator==(const field&) const -> bool = default;
 };
 
-auto to_string(const type& type) -> std::string;
+auto to_string(const type_name& type) -> std::string;
 auto to_string(const type_simple& type) -> std::string;
 auto to_string(const type_compound& type) -> std::string;
 auto to_string(const type_generic& type) -> std::string;
 
-auto hash(const type& type) -> std::size_t;
+auto hash(const type_name& type) -> std::size_t;
 auto hash(const type_simple& type) -> std::size_t;
 auto hash(const type_compound& type) -> std::size_t;
 auto hash(const type_generic& type) -> std::size_t;
 
-auto int_type() -> type;
-auto bool_type() -> type;
-auto str_type() -> type;
-auto null_type() -> type;
-auto generic_type(int id) -> type;
-auto vec2_type() -> type;
+auto int_type() -> type_name;
+auto bool_type() -> type_name;
+auto str_type() -> type_name;
+auto null_type() -> type_name;
+auto generic_type(int id) -> type_name;
+auto vec2_type() -> type_name;
 
-auto concrete_list_type(const type& t) -> type;
-auto generic_list_type() -> type;
+auto concrete_list_type(const type_name& t) -> type_name;
+auto generic_list_type() -> type_name;
 
-auto is_type_complete(const type& t) -> bool;
+auto is_type_complete(const type_name& t) -> bool;
 
 // Returns the number of blocks that represent this type. Returns 0 if the type is not complete.
-auto type_block_size(const type& t) -> std::size_t;
+auto type_block_size(const type_name& t) -> std::size_t;
 
 // Returns true if and only if the type is not a class type.
-auto it_type_fundamental(const type& t) -> bool;
+auto it_type_fundamental(const type_name& t) -> bool;
 
-using match_result = std::unordered_map<int, type>;
-auto match(const type& concrete, const type& pattern) -> std::optional<match_result>;
+using match_result = std::unordered_map<int, type_name>;
+auto match(const type_name& concrete, const type_name& pattern) -> std::optional<match_result>;
 
 // Given an incomplete type and a map of types, replace the generics in the incomplete type
 // with those from the map.
-auto bind_generics(const type& incomplete, const match_result& matches) -> type;
+auto bind_generics(const type_name& incomplete, const match_result& matches) -> type_name;
 
 struct signature
 {
     struct arg
     {
         std::string name;
-        anzu::type  type;
+        anzu::type_name  type;
         auto operator==(const arg&) const -> bool = default;
     };
 
     std::vector<arg> args;
-    anzu::type       return_type;
+    anzu::type_name       return_type;
     auto operator==(const signature&) const -> bool = default;
 };
 
@@ -98,28 +98,28 @@ auto to_string(const signature& sig) -> std::string;
 
 class type_store
 {
-    using type_hash = decltype([](const type& t) { return anzu::hash(t); });
-    std::unordered_set<type, type_hash> d_types;
-    std::unordered_set<type, type_hash> d_generics;
+    using type_hash = decltype([](const type_name& t) { return anzu::hash(t); });
+    std::unordered_set<type_name, type_hash> d_types;
+    std::unordered_set<type_name, type_hash> d_generics;
 
 public:
     type_store();
 
     // Checks if the given type is registered or matches a registered generic.
-    auto is_registered_type(const type& t) const -> bool;
+    auto is_registered_type(const type_name& t) const -> bool;
 
     // Finds the given type with the given name if it exists, otherwise returns
     // nullptr. This is currently O(n) so we should potentially optimise this in
     // the future.
-    auto find_by_name(const std::string& name) const -> const type*;
+    auto find_by_name(const std::string& name) const -> const type_name*;
 };
 
 }
 
 template <>
-struct std::formatter<anzu::type> : std::formatter<std::string>
+struct std::formatter<anzu::type_name> : std::formatter<std::string>
 {
-    auto format(const anzu::type& type, auto& ctx) {
+    auto format(const anzu::type_name& type, auto& ctx) {
         return std::formatter<std::string>::format(anzu::to_string(type), ctx);
     }
 };

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -30,7 +30,7 @@ struct typecheck_context
 {
     std::unordered_map<std::string, const node_function_def_stmt*> functions;
 
-    using var_types = std::unordered_map<std::string, type>;
+    using var_types = std::unordered_map<std::string, type_name>;
 
     var_types globals;
     std::optional<var_types> locals;
@@ -48,7 +48,7 @@ auto current_vars(typecheck_context& ctx) -> typecheck_context::var_types&
 }
 
 auto declare_var(
-    typecheck_context& ctx, const token& tok, const std::string& name, const type& type
+    typecheck_context& ctx, const token& tok, const std::string& name, const type_name& type
 )
     -> void
 {
@@ -63,7 +63,7 @@ auto declare_var(
 }
 
 auto typecheck_node(typecheck_context& ctx, const node_stmt& node) -> void;
-auto typecheck_expr(typecheck_context& ctx, const node_expr& expr) -> type;
+auto typecheck_expr(typecheck_context& ctx, const node_expr& expr) -> type_name;
 
 auto get_token(const node_stmt& node) -> token
 {
@@ -75,14 +75,14 @@ auto get_token(const node_expr& node) -> token
     return std::visit([](const auto& n) { return n.token; }, node);
 }
 
-auto verify_real_type(typecheck_context& ctx, const token& tok, const type& t) -> void
+auto verify_real_type(typecheck_context& ctx, const token& tok, const type_name& t) -> void
 {
     if (!ctx.registered_types.is_registered_type(t)) {
         type_error(tok, "'{}' is not a recognised type", t);
     }
 }
 
-auto type_of_bin_op(const type& lhs, const type& rhs, const token& op_token) -> type
+auto type_of_bin_op(const type_name& lhs, const type_name& rhs, const token& op_token) -> type_name
 {
     const auto op = op_token.text;
     const auto invalid_expr = [=]() {
@@ -232,7 +232,7 @@ auto get_typechecked_signature(
     }
 
     auto ret_sig = signature{};
-    auto matches = std::unordered_map<int, type>{};
+    auto matches = std::unordered_map<int, type_name>{};
 
     auto ait = args.begin();
     auto sit = sig.args.begin();
@@ -293,7 +293,7 @@ auto typecheck_function_call(
     const std::string& function_name,
     const std::vector<node_expr_ptr>& args
 )
-    -> type
+    -> type_name
 {
     const auto signature = get_typechecked_signature(ctx, tok, function_name, args);
 
@@ -314,7 +314,7 @@ auto typecheck_function_call(
     return signature.return_type;
 }
 
-auto typecheck_expr(typecheck_context& ctx, const node_expr& expr) -> type
+auto typecheck_expr(typecheck_context& ctx, const node_expr& expr) -> type_name
 {
     const auto expr_type = std::visit(overloaded {
         [&](const node_literal_expr& node) {
@@ -359,7 +359,7 @@ auto typecheck_expr(typecheck_context& ctx, const node_expr& expr) -> type
     return expr_type;
 };
 
-void verify_expression_type(typecheck_context& ctx, const node_expr& expr, const type& expected)
+void verify_expression_type(typecheck_context& ctx, const node_expr& expr, const type_name& expected)
 {
     const auto actual = typecheck_expr(ctx, expr);
     if (!match(actual, expected)) {

--- a/src/typecheck.hpp
+++ b/src/typecheck.hpp
@@ -8,7 +8,7 @@
 
 namespace anzu {
 
-using expr_types = std::unordered_map<const node_expr*, type>;
+using expr_types = std::unordered_map<const node_expr*, type_name>;
 
 // Scans the AST and performs the following:
 //      - evaluates the type of all expressions to verify they are valid


### PR DESCRIPTION
* The goal with these PRs is to un-hardcode the `vec2` impl, replace the hacks with features, and eventually remove `vec2` from the code altogether, replacing it with a definition written in pure anzu.
* In `compiler::compile_function_call`, remove the hardcoding of `vec2` to return the size of any given type called as a function. This is not usable yet for fundamental types as the typechecker needs to be made smarter, but this won't need changing when we do.
* Rename `type` to `type_name`, as the fields will eventually be moved out, because we need `type_name` to be constructible from the source code.
* Merge `type_class` into `type_simple`.