### PR TITLE
Clean up Bin Op Resolution

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -49,7 +49,7 @@ if false {
 
 # simple expressions
 println(2 + 2)
-println(8 * (1 + 6) || 5)
+println(8 * (1 + 6) > 5)
 println(true && true)
 println(true && false)
 println(true || false)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
     object.cpp
     type.cpp
     functions.cpp
+    operators.cpp
     vocabulary.cpp
 )
 

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -11,10 +11,6 @@ namespace anzu {
 struct block;
 using builtin_function = block(*)(std::span<const block>);
 
-// A more dangerous function pointer type that had access to the entire memory
-// vector, and should only be allowed for internal implementations of builtin types.
-using builtin_mem_op = std::function<void(std::vector<block>& memory)>;
-
 struct builtin
 {
     builtin_function ptr;

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -1,0 +1,201 @@
+#include "operators.hpp"
+
+namespace anzu {
+namespace {
+
+template <typename T>
+auto get_back(std::vector<block>& mem, std::size_t index) -> T&
+{
+    return std::get<std::remove_cvref_t<T>>(mem[mem.size() - index - 1]);
+}
+
+template <typename Lhs, typename Rhs>
+auto back_two(std::vector<block>& mem)
+{
+    const auto rhs = get_back<Lhs>(mem, 0);
+    const auto lhs = get_back<Rhs>(mem, 1);
+    return std::pair{lhs, rhs};
+}
+
+template <typename T>
+auto pop_and_emplace(std::vector<block>& mem, T&& val)
+{
+    mem.pop_back();
+    mem.back().emplace<T>(val);
+}
+
+}
+
+auto resolve_bin_op(const bin_op_description& desc) -> std::optional<bin_op_info>
+{
+    if (desc.lhs != desc.rhs) {
+        return std::nullopt;
+    }
+    const auto& type = desc.lhs;
+    
+    if (match(type, generic_list_type()).has_value()) { // No support for having these in bin ops.
+        return std::nullopt;
+    }
+
+    if (type == int_type()) {
+        if (desc.op == tk_add) {
+            return bin_op_info{ .operator_func = int_add_int, .result_type = type };
+        } else if (desc.op == tk_sub) {
+            return bin_op_info{ .operator_func = int_sub_int, .result_type = type };
+        } else if (desc.op == tk_mul) {
+            return bin_op_info{ .operator_func = int_mul_int, .result_type = type };
+        } else if (desc.op == tk_div) {
+            return bin_op_info{ .operator_func = int_div_int, .result_type = type };
+        } else if (desc.op == tk_mod) {
+            return bin_op_info{ .operator_func = int_mod_int, .result_type = type };
+        } else if (desc.op == "<") {
+            return bin_op_info{ .operator_func = int_lt_int, .result_type = type };
+        } else if (desc.op == "<=") {
+            return bin_op_info{ .operator_func = int_le_int, .result_type = type };
+        } else if (desc.op == ">") {
+            return bin_op_info{ .operator_func = int_gt_int, .result_type = type };
+        } else if (desc.op == ">=") {
+            return bin_op_info{ .operator_func = int_ge_int, .result_type = type };
+        } else if (desc.op == "==") {
+            return bin_op_info{ .operator_func = int_eq_int, .result_type = type };
+        } else if (desc.op == "!=") {
+            return bin_op_info{ .operator_func = int_ne_int, .result_type = type };
+        }
+    }
+    else if (type == bool_type()) {
+        if (desc.op == "==") {
+            return bin_op_info{ .operator_func = bool_eq_bool, .result_type = type };
+        } else if (desc.op == "!=") {
+            return bin_op_info{ .operator_func = bool_ne_bool, .result_type = type };
+        } else if (desc.op == "&&") {
+            return bin_op_info{ .operator_func = bool_and_bool, .result_type = type };
+        } else if (desc.op == "||") {
+            return bin_op_info{ .operator_func = bool_or_bool, .result_type = type };
+        }
+    }
+    else if (type == str_type()) {
+        if (desc.op == "+") {
+            return bin_op_info{ .operator_func = str_add_str, .result_type = type };
+        } else if (desc.op == "==") {
+            return bin_op_info{ .operator_func = str_eq_str, .result_type = type };
+        } else if (desc.op == "!=") {
+            return bin_op_info{ .operator_func = str_ne_str, .result_type = type };
+        }
+    }
+
+    return std::nullopt;
+}
+
+void int_add_int(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_int, block_int>(mem);
+    pop_and_emplace<block_int>(mem, lhs + rhs);
+}
+
+void int_sub_int(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_int, block_int>(mem);
+    pop_and_emplace<block_int>(mem, lhs - rhs);
+}
+
+void int_mul_int(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_int, block_int>(mem);
+    pop_and_emplace<block_int>(mem, lhs * rhs);
+}
+
+void int_div_int(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_int, block_int>(mem);
+    if (rhs == 0) {
+        anzu::print("Runtime Error: division by zero\n");
+        std::exit(1);
+    }
+    pop_and_emplace<block_int>(mem, lhs / rhs);
+}
+
+void int_mod_int(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_int, block_int>(mem);
+    pop_and_emplace<block_int>(mem, lhs % rhs);
+}
+
+void int_lt_int(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_int, block_int>(mem);
+    pop_and_emplace<block_bool>(mem, lhs < rhs);
+}
+
+void int_le_int(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_int, block_int>(mem);
+    pop_and_emplace<block_bool>(mem, lhs <= rhs);
+}
+
+void int_gt_int(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_int, block_int>(mem);
+    pop_and_emplace<block_bool>(mem, lhs > rhs);
+}
+
+void int_ge_int(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_int, block_int>(mem);
+    pop_and_emplace<block_bool>(mem, lhs >= rhs);
+}
+
+void int_eq_int(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_int, block_int>(mem);
+    pop_and_emplace<block_bool>(mem, lhs == rhs);
+}
+
+void int_ne_int(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_int, block_int>(mem);
+    pop_and_emplace<block_bool>(mem, lhs != rhs);
+}
+
+void bool_eq_bool(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_bool, block_bool>(mem);
+    pop_and_emplace<block_bool>(mem, lhs == rhs);
+}
+
+void bool_ne_bool(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_bool, block_bool>(mem);
+    pop_and_emplace<block_bool>(mem, lhs != rhs);
+}
+
+void bool_and_bool(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_bool, block_bool>(mem);
+    pop_and_emplace<block_bool>(mem, lhs && rhs);
+}
+
+void bool_or_bool(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_bool, block_bool>(mem);
+    pop_and_emplace<block_bool>(mem, lhs || rhs);
+}
+
+void str_add_str(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_str&, block_str&>(mem);
+    pop_and_emplace<block_str>(mem, lhs + rhs);
+}
+
+void str_eq_str(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_str&, block_str&>(mem);
+    pop_and_emplace<block_bool>(mem, lhs == rhs);
+}
+
+void str_ne_str(std::vector<block>& mem)
+{
+    const auto [lhs, rhs] = back_two<block_str&, block_str&>(mem);
+    pop_and_emplace<block_bool>(mem, lhs != rhs);
+}
+
+}

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -49,17 +49,17 @@ auto resolve_bin_op(const bin_op_description& desc) -> std::optional<bin_op_info
         } else if (desc.op == tk_mod) {
             return bin_op_info{ .operator_func = int_mod_int, .result_type = type };
         } else if (desc.op == "<") {
-            return bin_op_info{ .operator_func = int_lt_int, .result_type = type };
+            return bin_op_info{ .operator_func = int_lt_int, .result_type = bool_type() };
         } else if (desc.op == "<=") {
-            return bin_op_info{ .operator_func = int_le_int, .result_type = type };
+            return bin_op_info{ .operator_func = int_le_int, .result_type = bool_type() };
         } else if (desc.op == ">") {
-            return bin_op_info{ .operator_func = int_gt_int, .result_type = type };
+            return bin_op_info{ .operator_func = int_gt_int, .result_type = bool_type() };
         } else if (desc.op == ">=") {
-            return bin_op_info{ .operator_func = int_ge_int, .result_type = type };
+            return bin_op_info{ .operator_func = int_ge_int, .result_type = bool_type() };
         } else if (desc.op == "==") {
-            return bin_op_info{ .operator_func = int_eq_int, .result_type = type };
+            return bin_op_info{ .operator_func = int_eq_int, .result_type = bool_type() };
         } else if (desc.op == "!=") {
-            return bin_op_info{ .operator_func = int_ne_int, .result_type = type };
+            return bin_op_info{ .operator_func = int_ne_int, .result_type = bool_type() };
         }
     }
     else if (type == bool_type()) {
@@ -77,9 +77,9 @@ auto resolve_bin_op(const bin_op_description& desc) -> std::optional<bin_op_info
         if (desc.op == "+") {
             return bin_op_info{ .operator_func = str_add_str, .result_type = type };
         } else if (desc.op == "==") {
-            return bin_op_info{ .operator_func = str_eq_str, .result_type = type };
+            return bin_op_info{ .operator_func = str_eq_str, .result_type = bool_type() };
         } else if (desc.op == "!=") {
-            return bin_op_info{ .operator_func = str_ne_str, .result_type = type };
+            return bin_op_info{ .operator_func = str_ne_str, .result_type = bool_type() };
         }
     }
 

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -24,68 +24,6 @@ auto pop_and_emplace(std::vector<block>& mem, T&& val)
     mem.back().emplace<T>(val);
 }
 
-}
-
-auto resolve_bin_op(const bin_op_description& desc) -> std::optional<bin_op_info>
-{
-    if (desc.lhs != desc.rhs) {
-        return std::nullopt;
-    }
-    const auto& type = desc.lhs;
-    
-    if (match(type, generic_list_type()).has_value()) { // No support for having these in bin ops.
-        return std::nullopt;
-    }
-
-    if (type == int_type()) {
-        if (desc.op == tk_add) {
-            return bin_op_info{ .operator_func = int_add_int, .result_type = type };
-        } else if (desc.op == tk_sub) {
-            return bin_op_info{ .operator_func = int_sub_int, .result_type = type };
-        } else if (desc.op == tk_mul) {
-            return bin_op_info{ .operator_func = int_mul_int, .result_type = type };
-        } else if (desc.op == tk_div) {
-            return bin_op_info{ .operator_func = int_div_int, .result_type = type };
-        } else if (desc.op == tk_mod) {
-            return bin_op_info{ .operator_func = int_mod_int, .result_type = type };
-        } else if (desc.op == "<") {
-            return bin_op_info{ .operator_func = int_lt_int, .result_type = bool_type() };
-        } else if (desc.op == "<=") {
-            return bin_op_info{ .operator_func = int_le_int, .result_type = bool_type() };
-        } else if (desc.op == ">") {
-            return bin_op_info{ .operator_func = int_gt_int, .result_type = bool_type() };
-        } else if (desc.op == ">=") {
-            return bin_op_info{ .operator_func = int_ge_int, .result_type = bool_type() };
-        } else if (desc.op == "==") {
-            return bin_op_info{ .operator_func = int_eq_int, .result_type = bool_type() };
-        } else if (desc.op == "!=") {
-            return bin_op_info{ .operator_func = int_ne_int, .result_type = bool_type() };
-        }
-    }
-    else if (type == bool_type()) {
-        if (desc.op == "==") {
-            return bin_op_info{ .operator_func = bool_eq_bool, .result_type = type };
-        } else if (desc.op == "!=") {
-            return bin_op_info{ .operator_func = bool_ne_bool, .result_type = type };
-        } else if (desc.op == "&&") {
-            return bin_op_info{ .operator_func = bool_and_bool, .result_type = type };
-        } else if (desc.op == "||") {
-            return bin_op_info{ .operator_func = bool_or_bool, .result_type = type };
-        }
-    }
-    else if (type == str_type()) {
-        if (desc.op == "+") {
-            return bin_op_info{ .operator_func = str_add_str, .result_type = type };
-        } else if (desc.op == "==") {
-            return bin_op_info{ .operator_func = str_eq_str, .result_type = bool_type() };
-        } else if (desc.op == "!=") {
-            return bin_op_info{ .operator_func = str_ne_str, .result_type = bool_type() };
-        }
-    }
-
-    return std::nullopt;
-}
-
 void int_add_int(std::vector<block>& mem)
 {
     const auto [lhs, rhs] = back_two<block_int, block_int>(mem);
@@ -196,6 +134,68 @@ void str_ne_str(std::vector<block>& mem)
 {
     const auto [lhs, rhs] = back_two<block_str&, block_str&>(mem);
     pop_and_emplace<block_bool>(mem, lhs != rhs);
+}
+
+}
+
+auto resolve_bin_op(const bin_op_description& desc) -> std::optional<bin_op_info>
+{
+    if (desc.lhs != desc.rhs) {
+        return std::nullopt;
+    }
+    const auto& type = desc.lhs;
+    
+    if (match(type, generic_list_type()).has_value()) { // No support for having these in bin ops.
+        return std::nullopt;
+    }
+
+    if (type == int_type()) {
+        if (desc.op == tk_add) {
+            return bin_op_info{ .operator_func = int_add_int, .result_type = type };
+        } else if (desc.op == tk_sub) {
+            return bin_op_info{ .operator_func = int_sub_int, .result_type = type };
+        } else if (desc.op == tk_mul) {
+            return bin_op_info{ .operator_func = int_mul_int, .result_type = type };
+        } else if (desc.op == tk_div) {
+            return bin_op_info{ .operator_func = int_div_int, .result_type = type };
+        } else if (desc.op == tk_mod) {
+            return bin_op_info{ .operator_func = int_mod_int, .result_type = type };
+        } else if (desc.op == "<") {
+            return bin_op_info{ .operator_func = int_lt_int, .result_type = bool_type() };
+        } else if (desc.op == "<=") {
+            return bin_op_info{ .operator_func = int_le_int, .result_type = bool_type() };
+        } else if (desc.op == ">") {
+            return bin_op_info{ .operator_func = int_gt_int, .result_type = bool_type() };
+        } else if (desc.op == ">=") {
+            return bin_op_info{ .operator_func = int_ge_int, .result_type = bool_type() };
+        } else if (desc.op == "==") {
+            return bin_op_info{ .operator_func = int_eq_int, .result_type = bool_type() };
+        } else if (desc.op == "!=") {
+            return bin_op_info{ .operator_func = int_ne_int, .result_type = bool_type() };
+        }
+    }
+    else if (type == bool_type()) {
+        if (desc.op == "==") {
+            return bin_op_info{ .operator_func = bool_eq_bool, .result_type = type };
+        } else if (desc.op == "!=") {
+            return bin_op_info{ .operator_func = bool_ne_bool, .result_type = type };
+        } else if (desc.op == "&&") {
+            return bin_op_info{ .operator_func = bool_and_bool, .result_type = type };
+        } else if (desc.op == "||") {
+            return bin_op_info{ .operator_func = bool_or_bool, .result_type = type };
+        }
+    }
+    else if (type == str_type()) {
+        if (desc.op == "+") {
+            return bin_op_info{ .operator_func = str_add_str, .result_type = type };
+        } else if (desc.op == "==") {
+            return bin_op_info{ .operator_func = str_eq_str, .result_type = bool_type() };
+        } else if (desc.op == "!=") {
+            return bin_op_info{ .operator_func = str_ne_str, .result_type = bool_type() };
+        }
+    }
+
+    return std::nullopt;
 }
 
 }

--- a/src/operators.hpp
+++ b/src/operators.hpp
@@ -1,0 +1,50 @@
+#pragma once
+#include "object.hpp"
+#include "type.hpp"
+
+#include <functional>
+#include <optional>
+#include <vector>
+
+namespace anzu {
+
+using builtin_mem_op = std::function<void(std::vector<block>& memory)>;
+
+struct bin_op_description
+{
+    std::string op;
+    type_name   lhs;
+    type_name   rhs;
+};
+
+struct bin_op_info
+{
+    builtin_mem_op operator_func;
+    type_name      result_type;
+};
+
+auto resolve_bin_op(const bin_op_description& desc) -> std::optional<bin_op_info>;
+
+void int_add_int(std::vector<block>& mem);
+void int_sub_int(std::vector<block>& mem);
+void int_mul_int(std::vector<block>& mem);
+void int_div_int(std::vector<block>& mem);
+void int_mod_int(std::vector<block>& mem);
+
+void int_lt_int(std::vector<block>& mem);
+void int_le_int(std::vector<block>& mem);
+void int_gt_int(std::vector<block>& mem);
+void int_ge_int(std::vector<block>& mem);
+void int_eq_int(std::vector<block>& mem);
+void int_ne_int(std::vector<block>& mem);
+
+void bool_eq_bool(std::vector<block>& mem);
+void bool_ne_bool(std::vector<block>& mem);
+void bool_and_bool(std::vector<block>& mem);
+void bool_or_bool(std::vector<block>& mem);
+
+void str_add_str(std::vector<block>& mem);
+void str_eq_str(std::vector<block>& mem);
+void str_ne_str(std::vector<block>& mem);
+
+}

--- a/src/operators.hpp
+++ b/src/operators.hpp
@@ -25,26 +25,4 @@ struct bin_op_info
 
 auto resolve_bin_op(const bin_op_description& desc) -> std::optional<bin_op_info>;
 
-void int_add_int(std::vector<block>& mem);
-void int_sub_int(std::vector<block>& mem);
-void int_mul_int(std::vector<block>& mem);
-void int_div_int(std::vector<block>& mem);
-void int_mod_int(std::vector<block>& mem);
-
-void int_lt_int(std::vector<block>& mem);
-void int_le_int(std::vector<block>& mem);
-void int_gt_int(std::vector<block>& mem);
-void int_ge_int(std::vector<block>& mem);
-void int_eq_int(std::vector<block>& mem);
-void int_ne_int(std::vector<block>& mem);
-
-void bool_eq_bool(std::vector<block>& mem);
-void bool_ne_bool(std::vector<block>& mem);
-void bool_and_bool(std::vector<block>& mem);
-void bool_or_bool(std::vector<block>& mem);
-
-void str_add_str(std::vector<block>& mem);
-void str_eq_str(std::vector<block>& mem);
-void str_ne_str(std::vector<block>& mem);
-
 }

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "functions.hpp"
+#include "operators.hpp"
 #include "object.hpp"
 
 #include <variant>


### PR DESCRIPTION
* We had very similar logic in the typechecker and the compiler for handling binary operators. The type checker takes two type and an op and works out the result type, while the compiler works out which function is needed to carry out the operation.
* This had to be kept in sync, making adding more operations error prone. This PR moves it all into the same function.
* The replacement code is also much cleaner.