### PR TITLE
Clean up `vec2` Part 2

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -7,6 +7,3 @@ fn print_first(v: vec2) -> null
 }
 
 print_first(x)
-
-y := int(2)
-println(y)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,12 @@
 
-println(4 + 5)
-println("hello " + "world")
+x := vec2(1, 2)
+
+fn print_first(v: vec2) -> null
+{
+    println(vec2_first(v))
+}
+
+print_first(x)
+
+y := int(2)
+println(y)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -223,16 +223,11 @@ auto compile_function_call(
     if (function == "print" || function == "println") {
         sig.args[0].type = ctx.expr_types[args[0].get()];
     }
-    
-    auto args_size = std::size_t{0};
-    for (const auto& arg : sig.args) {
-        args_size += ctx.registered_types.block_size(arg.type);
-    }
 
     ctx.program.emplace_back(anzu::op_builtin_call{
         .name=function,
         .ptr=builtin.ptr,
-        .args_size=args_size
+        .args_size=signature_args_size(ctx, sig)
     });
     return ctx.registered_types.block_size(sig.return_type);
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -190,7 +190,7 @@ auto compile_function_call(
     // there is currently nothing to do since the arguments are already pushed to
     // the stack.
     if (const auto type = ctx.registered_types.find_by_name(function)) {
-        return type_block_size(*type);
+        return ctx.registered_types.block_size(*type);
     }
 
     // Otherwise, it may be a custom function.
@@ -200,7 +200,7 @@ auto compile_function_call(
             .ptr=function_def->ptr + 1, // Jump into the function
             .sig=function_def->sig
         });
-        return type_block_size(function_def->sig.return_type);
+        return ctx.registered_types.block_size(function_def->sig.return_type);
     }
 
     // Otherwise, it must be a builtin function.
@@ -218,7 +218,7 @@ auto compile_function_call(
         .ptr=builtin.ptr,
         .sig=sig
     });
-    return type_block_size(sig.return_type);
+    return ctx.registered_types.block_size(sig.return_type);
 }
 
 void compile_node(const node_expr& expr, const node_literal_expr& node, compiler_context& ctx)
@@ -232,7 +232,7 @@ void compile_node(const node_expr& expr, const node_literal_expr& node, compiler
 
 void compile_node(const node_expr& expr, const node_variable_expr& node, compiler_context& ctx)
 {
-    const auto size = type_block_size(ctx.expr_types[&expr]);
+    const auto size = ctx.registered_types.block_size(ctx.expr_types[&expr]);
     load_variable(ctx, node.name, size);
 }
 
@@ -382,7 +382,7 @@ void compile_node(const node_continue_stmt&, compiler_context& ctx)
 void compile_node(const node_declaration_stmt& node, compiler_context& ctx)
 {
     compile_node(*node.expr, ctx);
-    const auto size = type_block_size(ctx.expr_types[node.expr.get()]);
+    const auto size = ctx.registered_types.block_size(ctx.expr_types[node.expr.get()]);
     declare_variable_name(ctx, node.name, size);
     save_variable(ctx, node.name, size);
 }
@@ -390,7 +390,7 @@ void compile_node(const node_declaration_stmt& node, compiler_context& ctx)
 void compile_node(const node_assignment_stmt& node, compiler_context& ctx)
 {
     compile_node(*node.expr, ctx);
-    const auto size = type_block_size(ctx.expr_types[node.expr.get()]);
+    const auto size = ctx.registered_types.block_size(ctx.expr_types[node.expr.get()]);
     save_variable(ctx, node.name, size);
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -198,8 +198,9 @@ auto compile_function_call(
     // If this is the name of a simple type, then this is a constructor call, so
     // there is currently nothing to do since the arguments are already pushed to
     // the stack.
-    if (const auto type = ctx.registered_types.find_by_name(function)) {
-        return ctx.registered_types.block_size(*type);
+    const auto as_type_name = type_name{type_simple{ .name=function }};
+    if (ctx.registered_types.is_registered_type(as_type_name)) {
+        return ctx.registered_types.block_size(as_type_name);
     }
 
     // Otherwise, it may be a custom function.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -171,11 +171,6 @@ auto parse_type(tokenstream& tokens) -> type_name
         });
         return ret;
     }
-
-    // Temporary to get vec2 working, generalise later.
-    if (type_name_text == "vec2") {
-        return vec2_type();
-    }
     
     return { type_simple{ .name = type_name_text } };
 }

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -91,14 +91,15 @@ struct op_function_call
 {
     std::string   name;
     std::intptr_t ptr;
-    signature     sig;
+    std::size_t   args_size;
+    std::size_t   return_size;
 };
 
 struct op_builtin_call
 {
     std::string      name;
     builtin_function ptr;
-    signature        sig; // TODO: Remove from op
+    std::size_t      args_size;
 };
 
 struct op_builtin_mem_op

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -157,16 +157,12 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             program_advance(ctx); // Position after function call
 
             ctx.frames.emplace_back();
-            ctx.frames.back().base_ptr = ctx.memory.size() - op.sig.args.size();
-            ctx.frames.back().return_size = type_block_size(op.sig.return_type);
+            ctx.frames.back().base_ptr = ctx.memory.size() - op.args_size;
+            ctx.frames.back().return_size = op.return_size;
             program_jump_to(ctx, op.ptr); // Jump into the function
         },
         [&](const op_builtin_call& op) {
-            auto arg_size = std::size_t{0};
-            for (const auto arg : op.sig.args) {
-                arg_size += type_block_size(arg.type);
-            }
-            auto args = std::vector<anzu::block>(arg_size);
+            auto args = std::vector<anzu::block>(op.args_size);
             for (auto& arg : args | std::views::reverse) {
                 arg = pop_back(ctx.memory);
             }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -292,4 +292,15 @@ auto type_store::block_size(const type_name& t) const -> std::size_t
     return 1; // By default, assume block size of 1 (should we have this?)
 }
 
+auto type_store::get_fields(const type_name& t) const -> type_fields
+{
+    if (auto it = d_classes.find(t); it != d_classes.end()) {
+        return it->second;
+    }
+    if (is_type_fundamental(t)) {
+        return {{ .name = "blk", .type = t }};
+    }
+    return {};
+}
+
 }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -14,15 +14,6 @@ auto to_string(const type_name& type) -> std::string
 
 auto to_string(const type_simple& type) -> std::string
 {
-    //if (type.fields.has_value()) {
-    //    return std::format(
-    //        "{}({})",
-    //        type.name,
-    //        format_comma_separated(type.fields.value(), [](const auto& field) {
-    //            return std::format("{}: {}", field.name, field.type);
-    //        })
-    //    );
-    //}
     return type.name;
 }
 
@@ -44,14 +35,7 @@ auto hash(const type_name& type) -> std::size_t
 
 auto hash(const type_simple& type) -> std::size_t
 {
-    const auto str_hash = std::hash<std::string>{};
-    auto hash_value = str_hash(type.name);
-    //if (type.fields.has_value()) {
-    //    for (const auto& field : type.fields.value()) {
-    //        hash_value ^= str_hash(field.name) ^ hash(field.type);
-    //    }
-    //}
-    return hash_value;
+    return std::hash<std::string>{}(type.name);
 }
 
 auto hash(const type_compound& type) -> std::size_t

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -224,36 +224,18 @@ auto to_string(const signature& sig) -> std::string
 
 type_store::type_store()
 {
-    d_types.emplace(int_type());
-    d_types.emplace(bool_type());
-    d_types.emplace(str_type());
-    d_types.emplace(null_type());
-
     d_classes.emplace(vec2_type(), type_fields{
         { .name = "x", .type = int_type() },
         { .name = "y", .type = int_type() }
     });
-
-    d_generics.emplace(generic_list_type());
 }
 
 auto type_store::is_registered_type(const type_name& t) const -> bool
 {
-    if (d_types.contains(t)) {
+    if (is_type_fundamental(t)) {
         return true;
     }
-
-    if (d_generics.contains(t)) {
-        return true;
-    }
-
-    if (d_classes.contains(t)) {
-        return true;
-    }
-
-    return std::any_of(begin(d_generics), end(d_generics), [&](const auto& generic) {
-        return match(t, generic).has_value();
-    });
+    return d_classes.contains(t);
 }
 
 auto type_store::block_size(const type_name& t) const -> std::size_t

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -284,4 +284,9 @@ auto type_store::find_by_name(const std::string& name) const -> const type_name*
     return nullptr;
 }
 
+auto type_store::block_size(const type_name& t) const -> std::size_t
+{
+    return 0;
+}
+
 }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -266,26 +266,13 @@ auto type_store::is_registered_type(const type_name& t) const -> bool
         return true;
     }
 
+    if (d_classes.contains(t)) {
+        return true;
+    }
+
     return std::any_of(begin(d_generics), end(d_generics), [&](const auto& generic) {
         return match(t, generic).has_value();
     });
-}
-
-auto type_store::find_by_name(const std::string& name) const -> const type_name*
-{
-    const auto get_type_name = [](const type_name& t) {
-        return std::visit(overloaded{
-            [](const type_simple& s) { return s.name; },
-            [](const auto&) { return std::string{""}; }
-        }, t);
-    };
-
-    for (const auto& type : d_types) {
-        if (get_type_name(type) == name) {
-            return &type;
-        }
-    }
-    return nullptr;
 }
 
 auto type_store::block_size(const type_name& t) const -> std::size_t

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -14,15 +14,15 @@ auto to_string(const type_name& type) -> std::string
 
 auto to_string(const type_simple& type) -> std::string
 {
-    if (type.fields.has_value()) {
-        return std::format(
-            "{}({})",
-            type.name,
-            format_comma_separated(type.fields.value(), [](const auto& field) {
-                return std::format("{}: {}", field.name, field.type);
-            })
-        );
-    }
+    //if (type.fields.has_value()) {
+    //    return std::format(
+    //        "{}({})",
+    //        type.name,
+    //        format_comma_separated(type.fields.value(), [](const auto& field) {
+    //            return std::format("{}: {}", field.name, field.type);
+    //        })
+    //    );
+    //}
     return type.name;
 }
 
@@ -46,11 +46,11 @@ auto hash(const type_simple& type) -> std::size_t
 {
     const auto str_hash = std::hash<std::string>{};
     auto hash_value = str_hash(type.name);
-    if (type.fields.has_value()) {
-        for (const auto& field : type.fields.value()) {
-            hash_value ^= str_hash(field.name) ^ hash(field.type);
-        }
-    }
+    //if (type.fields.has_value()) {
+    //    for (const auto& field : type.fields.value()) {
+    //        hash_value ^= str_hash(field.name) ^ hash(field.type);
+    //    }
+    //}
     return hash_value;
 }
 
@@ -97,7 +97,7 @@ auto vec2_type() -> type_name
 {
     return {type_simple{
         .name = "vec2",
-        .fields = {{ { .name="x", .type=int_type() }, { .name="y", .type=int_type() } }}
+        //.fields = {{ { .name="x", .type=int_type() }, { .name="y", .type=int_type() } }}
     }};
 }
 
@@ -135,29 +135,6 @@ auto is_type_fundamental(const type_name& type) -> bool
         || type == str_type()
         || type == null_type()
         || match(type, generic_list_type());
-}
-
-auto type_block_size(const type_name& t) -> std::size_t
-{
-    return std::visit(overloaded{
-        [](const type_simple& t) {
-            if (t.fields.has_value()) {
-                auto size = std::size_t{0};
-                for (const auto& field : t.fields.value()) {
-                    size += type_block_size(field.type);
-                }
-                return size;
-            }
-            return std::size_t{1};
-        },
-
-        // Checking the size of this should be an error, but we are making it return 1
-        // as a hack to make for loops (with lists of elements of size 1) work. Instead, for
-        // loops should properly calculate the size of the contained elements, but that's
-        // more involved. Fixing lists will be its own thing.
-        [](const type_generic&) { return std::size_t{1}; },
-        [](const type_compound&) { return std::size_t{1}; }
-    }, t);
 }
 
 // Loads each key/value pair from src into dst. If the key already exists in dst and has a

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -70,7 +70,7 @@ auto hash(const type_generic& type) -> std::size_t
 
 auto int_type()  -> type_name
 {
-    return {type_simple{ .name = std::string{tk_int}  }};
+    return {type_simple{ .name = std::string{tk_int} }};
 }
 
 auto bool_type() -> type_name
@@ -80,7 +80,7 @@ auto bool_type() -> type_name
 
 auto str_type()  -> type_name
 {
-    return {type_simple{ .name = std::string{tk_str}  }};
+    return {type_simple{ .name = std::string{tk_str} }};
 }
 
 auto null_type() -> type_name
@@ -95,10 +95,7 @@ auto generic_type(int id) -> type_name
 
 auto vec2_type() -> type_name
 {
-    return {type_simple{
-        .name = "vec2",
-        //.fields = {{ { .name="x", .type=int_type() }, { .name="y", .type=int_type() } }}
-    }};
+    return {type_simple{ .name = "vec2", }};
 }
 
 auto concrete_list_type(const type_name& t) -> type_name

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -35,12 +35,15 @@ struct type_generic
 
 struct type_name : public std::variant<type_simple, type_compound, type_generic> {};
 
-struct type_field
+
+struct field
 {
     std::string name;
-    type_name        type;
-    auto operator==(const type_field&) const -> bool = default;
+    type_name   type;
+    auto operator==(const field&) const -> bool = default;
 };
+
+using type_fields = std::vector<field>;
 
 auto to_string(const type_name& type) -> std::string;
 auto to_string(const type_simple& type) -> std::string;
@@ -95,6 +98,8 @@ class type_store
     using type_hash = decltype([](const type_name& t) { return anzu::hash(t); });
     std::unordered_set<type_name, type_hash> d_types;
     std::unordered_set<type_name, type_hash> d_generics;
+
+    std::unordered_map<type_name, type_fields, type_hash> d_classes;
 
 public:
     type_store();

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -19,7 +19,6 @@ struct type_simple
     struct field;
 
     std::string name;
-    std::optional<std::vector<field>> fields; // nullopt == fundamental type
     auto operator==(const type_simple&) const -> bool = default;
 };
 
@@ -38,11 +37,11 @@ struct type_generic
 
 struct type_name : public std::variant<type_simple, type_compound, type_generic> {};
 
-struct type_simple::field
+struct type_field
 {
     std::string name;
     type_name        type;
-    auto operator==(const field&) const -> bool = default;
+    auto operator==(const type_field&) const -> bool = default;
 };
 
 auto to_string(const type_name& type) -> std::string;
@@ -66,9 +65,6 @@ auto concrete_list_type(const type_name& t) -> type_name;
 auto generic_list_type() -> type_name;
 
 auto is_type_complete(const type_name& t) -> bool;
-
-// Returns the number of blocks that represent this type. Returns 0 if the type is not complete.
-auto type_block_size(const type_name& t) -> std::size_t;
 
 // Returns true if and only if the type is not a class type.
 auto it_type_fundamental(const type_name& t) -> bool;
@@ -112,6 +108,9 @@ public:
     // nullptr. This is currently O(n) so we should potentially optimise this in
     // the future.
     auto find_by_name(const std::string& name) const -> const type_name*;
+
+    // Given a type name, return the size of the type in blocks.
+    auto block_size(const type_name& t) const -> std::size_t;
 };
 
 }

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -16,8 +16,6 @@ struct type_name;
 
 struct type_simple
 {
-    struct field;
-
     std::string name;
     auto operator==(const type_simple&) const -> bool = default;
 };

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -96,9 +96,6 @@ auto to_string(const signature& sig) -> std::string;
 class type_store
 {
     using type_hash = decltype([](const type_name& t) { return anzu::hash(t); });
-    std::unordered_set<type_name, type_hash> d_types;
-    std::unordered_set<type_name, type_hash> d_generics;
-
     std::unordered_map<type_name, type_fields, type_hash> d_classes;
 
 public:

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -109,6 +109,8 @@ public:
 
     // Given a type name, return the size of the type in blocks.
     auto block_size(const type_name& t) const -> std::size_t;
+
+    auto get_fields(const type_name& t) const -> type_fields;
 };
 
 }

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -107,11 +107,6 @@ public:
     // Checks if the given type is registered or matches a registered generic.
     auto is_registered_type(const type_name& t) const -> bool;
 
-    // Finds the given type with the given name if it exists, otherwise returns
-    // nullptr. This is currently O(n) so we should potentially optimise this in
-    // the future.
-    auto find_by_name(const std::string& name) const -> const type_name*;
-
     // Given a type name, return the size of the type in blocks.
     auto block_size(const type_name& t) const -> std::size_t;
 };

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -251,6 +251,24 @@ auto typecheck_function_call(
     // If this is a type name, its a constructor call
     const auto as_type_name = type_name{type_simple{ .name=function_name }};
     if (ctx.registered_types.is_registered_type(as_type_name)) {
+        const auto fields = ctx.registered_types.get_fields(as_type_name);
+        if (fields.size() != args.size()) {
+            type_error(
+                tok,
+                "Invalid number of args for {} constructor, expected {} got {}\n",
+                function_name, fields.size(), args.size()
+            );
+        }
+        for (std::size_t i = 0; i != args.size(); ++i) {
+            const auto given_type = typecheck_expr(ctx, *args[i]);
+            if (fields[i].type != given_type) {
+                type_error(
+                    tok,
+                    "Invalid type at position {} for {} constructor, expected {} got {}\n",
+                    i, function_name, fields[i].type, given_type
+                );
+            }
+        }
         return as_type_name;
     }
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -174,16 +174,6 @@ auto get_typechecked_signature(
 )
     -> signature
 {
-    if (function_name == "vec2") {
-        return signature{
-            .args = {
-                { .name="x", .type=int_type() },
-                { .name="y", .type=int_type() }
-            },
-            .return_type = vec2_type()
-        };
-    }
-
     const auto sig = fetch_function_signature(ctx, tok, function_name);
 
     if (sig.args.size() != args.size()) {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -258,11 +258,13 @@ auto typecheck_function_call(
 )
     -> type_name
 {
-    const auto signature = get_typechecked_signature(ctx, tok, function_name, args);
-
-    if (function_name == "vec2") {
-        return vec2_type();
+    // If this is a type name, its a constructor call
+    const auto as_type_name = type_name{type_simple{ .name=function_name }};
+    if (ctx.registered_types.is_registered_type(as_type_name)) {
+        return as_type_name;
     }
+
+    const auto signature = get_typechecked_signature(ctx, tok, function_name, args);
     if (!is_builtin(function_name)) {
         const auto* function_def = fetch_function_def(ctx, tok, function_name);
         if (is_function_generic(*function_def)) {


### PR DESCRIPTION
* Unhardcode the remaining vec2s in the parser, typechecker and compiler.
* Remove the function that calculates the block size of a type. This has been replaced with a function on the `type_store`.
* The `type_name` no longer contains the fields of the type, making it possible to parse a full `type_name` from source code.
* The set in the type store is now a map, mapping class names to field lists.
* Remove `signature` objects from the runtime, instead only storing the arg sizes. This is because we could no longer calculate the size of types from the signature since we need the type store. Doing this at runtime was bad anyway so this is also an optimisation.