### PR TITLE
Attribute Access

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -111,3 +111,11 @@ fn print_one_to_ten() -> null
         println(i)
     }
 }
+
+# Attribute access
+my_vec := vec2(1, 2)
+println(my_vec)
+println(my_vec.x)
+println(my_vec.y)
+my_vec.x = 5
+println(my_vec.x)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,13 +1,17 @@
 
 my_vec := vec2(1, 2)
 
-fn func() -> null
+fn int_x() -> null
 {
-
-    my_vec.x = 5
-    my_vec.y = 123
+    my_vec.z = my_vec.x + 1
 }
 
-func()
-
+println(my_vec)
+int_x()
+println(my_vec)
+int_x()
+println(my_vec)
+int_x()
+println(my_vec)
+int_x()
 println(my_vec)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,2 +1,4 @@
 
-x.y = 5
+my_vec := vec2(1, 2)
+
+println(my_vec.x)

--- a/examples/test.az
+++ b/examples/test.az
@@ -7,3 +7,5 @@ fn print_first(v: vec2) -> null
 }
 
 print_first(x)
+
+vec2(1, 2) + 3

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,16 +3,12 @@
 
 fn foo(x: int) -> null {}
 
-fn func() -> null
-{
-    my_vec := vec2(1, 2)
-    y := my_vec.y
-    x := my_vec.x
 
-    println(y)
-    println(y)
-    println(x)
-    println(y)
-}
+my_vec := vec2(1, 2)
+y := my_vec.y
+x := my_vec.x
 
-func()
+println(y)
+println(y)
+println(x)
+println(y)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,18 @@
 
-my_vec := vec2(1, 2)
+
 
 fn foo(x: int) -> null {}
 
-foo(my_vec.z)
+fn func() -> null
+{
+    my_vec := vec2(1, 2)
+    y := my_vec.y
+    x := my_vec.x
+
+    println(y)
+    println(y)
+    println(x)
+    println(y)
+}
+
+func()

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,6 @@
 
 my_vec := vec2(1, 2)
 
-println(my_vec.x)
+fn foo(x: int) -> null {}
+
+foo(my_vec.z)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,14 +1,9 @@
 
 
 
-fn foo(x: int) -> null {}
+
 
 
 my_vec := vec2(1, 2)
-y := my_vec.y
-x := my_vec.x
 
-println(y)
-println(y)
-println(x)
-println(y)
+my_vec.x = 5

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,13 +1,13 @@
 
+my_vec := vec2(1, 2)
 
 fn func() -> null
 {
-    my_vec := vec2(1, 2)
 
     my_vec.x = 5
     my_vec.y = 123
-
-    println(my_vec)
 }
 
 func()
+
+println(my_vec)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,11 @@
 
 
-struct vec3
-{
-    x: int
-    y: int
-    z: int
-}
+#struct vec3
+#{
+#    x: int
+#    y: int
+#    z: int
+#}
 
 my_vec := vec2(1, 2)
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,17 +1,19 @@
 
+
+struct vec3
+{
+    x: int
+    y: int
+    z: int
+}
+
 my_vec := vec2(1, 2)
 
 fn int_x() -> null
 {
-    my_vec.z = my_vec.x + 1
+    my_vec.x = my_vec.x + 1
 }
 
-println(my_vec)
-int_x()
-println(my_vec)
-int_x()
-println(my_vec)
-int_x()
 println(my_vec)
 int_x()
 println(my_vec)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,2 @@
 
-x := vec2(1, 2)
-
-fn print_first(v: vec2) -> null
-{
-    println(vec2_first(v))
-}
-
-print_first(x)
-
-vec2(1, 2) + 3
+x.y = 5

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,9 +1,13 @@
 
 
+fn func() -> null
+{
+    my_vec := vec2(1, 2)
 
+    my_vec.x = 5
+    my_vec.y = 123
 
+    println(my_vec)
+}
 
-
-my_vec := vec2(1, 2)
-
-my_vec.x = 5
+func()

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -102,6 +102,13 @@ auto print_node(const node_stmt& root, int indent) -> void
             print("{}- Value:\n", spaces);
             print_node(*node.expr, indent + 1);
         },
+        [&](const node_field_assignment_stmt& node) {
+            print("{}FieldAssignment:\n", spaces);
+            print("{}- Name: {}\n", spaces, node.name);
+            print("{}- Fields: {}\n", spaces, format_comma_separated(node.fields));
+            print("{}- Value:\n", spaces);
+            print_node(*node.expr, indent + 1);
+        },
         [&](const node_function_def_stmt& node) {
             print("{}Function: {} (", spaces, node.name);
             print_comma_separated(node.sig.args, [](const auto& arg) {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -7,34 +7,40 @@
 
 namespace anzu {
 
-auto print_node(const anzu::node_expr& root, int indent) -> void
+auto print_node(const node_expr& root, int indent) -> void
 {
     const auto spaces = std::string(4 * indent, ' ');
     std::visit(overloaded {
         [&](const node_literal_expr& node) {
-            anzu::print("{}Literal: {}\n", spaces, node.value);
+            print("{}Literal: {}\n", spaces, node.value);
         },
         [&](const node_variable_expr& node) {
-            anzu::print("{}Variable: {}\n", spaces, node.name);
+            print("{}Variable: {}\n", spaces, node.name);
+        },
+        [&](const node_field_expr& node) {
+            print("{}Field: \n", spaces);
+            print("{}- Expr:\n", spaces);
+            print_node(*node.expression, indent + 1);
+            print("{}- Field: {}\n", spaces, node.field_name);
         },
         [&](const node_bin_op_expr& node) {
-            anzu::print("{}BinOp: \n", spaces);
-            anzu::print("{}- Op: {}\n", spaces, node.token.text);
-            anzu::print("{}- Lhs:\n", spaces);
+            print("{}BinOp: \n", spaces);
+            print("{}- Op: {}\n", spaces, node.token.text);
+            print("{}- Lhs:\n", spaces);
             print_node(*node.lhs, indent + 1);
-            anzu::print("{}- Rhs:\n", spaces);
+            print("{}- Rhs:\n", spaces);
             print_node(*node.rhs, indent + 1);
         },
         [&](const node_function_call_expr& node) {
-            anzu::print("{}FunctionCall (Expr): {}\n", spaces, node.function_name);
-            anzu::print("{}- Args:\n", spaces);
+            print("{}FunctionCall (Expr): {}\n", spaces, node.function_name);
+            print("{}- Args:\n", spaces);
             for (const auto& arg : node.args) {
                 print_node(*arg, indent + 1);
             }
         },
         [&](const node_list_expr& node) {
-            anzu::print("{}List (Expr):\n", spaces);
-            anzu::print("{}- Elements:\n", spaces);
+            print("{}List (Expr):\n", spaces);
+            print("{}- Elements:\n", spaces);
             for (const auto& element : node.elements) {
                 print_node(*element, indent + 1);
             }
@@ -42,77 +48,77 @@ auto print_node(const anzu::node_expr& root, int indent) -> void
     }, root);
 }
 
-auto print_node(const anzu::node_stmt& root, int indent) -> void
+auto print_node(const node_stmt& root, int indent) -> void
 {
     const auto spaces = std::string(4 * indent, ' ');
     std::visit(overloaded {
         [&](const node_sequence_stmt& node) {
-            anzu::print("{}Sequence:\n", spaces);
+            print("{}Sequence:\n", spaces);
             for (const auto& seq_node : node.sequence) {
                 print_node(*seq_node, indent + 1);
             }
         },
         [&](const node_while_stmt& node) {
-            anzu::print("{}While:\n", spaces);
-            anzu::print("{}- Condition:\n", spaces);
+            print("{}While:\n", spaces);
+            print("{}- Condition:\n", spaces);
             print_node(*node.condition, indent + 1);
-            anzu::print("{}- Body:\n", spaces);
+            print("{}- Body:\n", spaces);
             print_node(*node.body, indent + 1);
         },
         [&](const node_if_stmt& node) {
-            anzu::print("{}If:\n", spaces);
-            anzu::print("{}- Condition:\n", spaces);
+            print("{}If:\n", spaces);
+            print("{}- Condition:\n", spaces);
             print_node(*node.condition, indent + 1);
-            anzu::print("{}- Body:\n", spaces);
+            print("{}- Body:\n", spaces);
             print_node(*node.body, indent + 1);
             if (node.else_body) {
-                anzu::print("{}- Else:\n", spaces);
+                print("{}- Else:\n", spaces);
                 print_node(*node.else_body, indent + 1);
             }
         },
         [&](const node_for_stmt& node) {
-            anzu::print("{}For:\n", spaces);
-            anzu::print("{}- Bind: {}\n",spaces, node.var);
-            anzu::print("{}- Container:\n",spaces);
+            print("{}For:\n", spaces);
+            print("{}- Bind: {}\n",spaces, node.var);
+            print("{}- Container:\n",spaces);
             print_node(*node.container, indent + 1);
-            anzu::print("{}- Body:\n",spaces);
+            print("{}- Body:\n",spaces);
             print_node(*node.body, indent + 1);
         },
         [&](const node_break_stmt& node) {
-            anzu::print("{}Break\n", spaces);
+            print("{}Break\n", spaces);
         },
         [&](const node_continue_stmt& node) {
-            anzu::print("{}Continue\n", spaces);
+            print("{}Continue\n", spaces);
         },
         [&](const node_declaration_stmt& node) {
-            anzu::print("{}Declaration:\n", spaces);
-            anzu::print("{}- Name: {}\n", spaces, node.name);
-            anzu::print("{}- Value:\n", spaces);
+            print("{}Declaration:\n", spaces);
+            print("{}- Name: {}\n", spaces, node.name);
+            print("{}- Value:\n", spaces);
             print_node(*node.expr, indent + 1);
         },
         [&](const node_assignment_stmt& node) {
-            anzu::print("{}Assignment:\n", spaces);
-            anzu::print("{}- Name: {}\n", spaces, node.name);
-            anzu::print("{}- Value:\n", spaces);
+            print("{}Assignment:\n", spaces);
+            print("{}- Name: {}\n", spaces, node.name);
+            print("{}- Value:\n", spaces);
             print_node(*node.expr, indent + 1);
         },
         [&](const node_function_def_stmt& node) {
-            anzu::print("{}Function: {} (", spaces, node.name);
-            anzu::print_comma_separated(node.sig.args, [](const auto& arg) {
+            print("{}Function: {} (", spaces, node.name);
+            print_comma_separated(node.sig.args, [](const auto& arg) {
                 return std::format("{}: {}", arg.name, arg.type);
             });
-            anzu::print(") -> {}\n", node.sig.return_type);
+            print(") -> {}\n", node.sig.return_type);
             print_node(*node.body, indent + 1);
         },
         [&](const node_function_call_stmt& node) {
-            anzu::print("{}FunctionCall (Stmt): {}\n", spaces, node.function_name);
-            anzu::print("{}- Args:\n", spaces);
+            print("{}FunctionCall (Stmt): {}\n", spaces, node.function_name);
+            print("{}- Args:\n", spaces);
             for (const auto& arg : node.args) {
                 print_node(*arg, indent + 1);
             }
         },
         [&](const node_return_stmt& node) {
-            anzu::print("{}Return:\n", spaces);
+            print("{}Return:\n", spaces);
             print_node(*node.return_value, indent + 1);
         }
     }, root);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -76,6 +76,14 @@ auto print_node(const node_stmt& root, int indent) -> void
                 print_node(*node.else_body, indent + 1);
             }
         },
+        [&](const node_struct_stmt& node) {
+            print("{}Struct:\n", spaces);
+            print("{}- Name: {}\n", spaces, node.name);
+            print("{}- Fields:\n", spaces);
+            for (const auto& field : node.fields) {
+                print("{}  - {}: {}\n", field.name, field.type);
+            }
+        },
         [&](const node_for_stmt& node) {
             print("{}For:\n", spaces);
             print("{}- Bind: {}\n",spaces, node.var);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -26,6 +26,14 @@ struct node_variable_expr
     anzu::token token;
 };
 
+struct node_field_expr
+{
+    node_expr_ptr expression;
+    std::string   field_name;
+
+    anzu::token token;
+};
+
 struct node_bin_op_expr
 {
     node_expr_ptr lhs;
@@ -52,6 +60,7 @@ struct node_list_expr
 struct node_expr : std::variant<
     node_literal_expr,
     node_variable_expr,
+    node_field_expr,
     node_bin_op_expr,
     node_function_call_expr,
     node_list_expr>

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -171,6 +171,7 @@ struct node_stmt : std::variant<
     node_continue_stmt,
     node_declaration_stmt,
     node_assignment_stmt,
+    node_field_assignment_stmt,
     node_function_def_stmt,
     node_function_call_stmt,
     node_return_stmt>

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -103,7 +103,9 @@ struct node_struct_stmt
 
     std::string        name;
     std::vector<field> fields;
-}
+
+    anzu::token token;
+};
 
 struct node_for_stmt
 {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -94,6 +94,17 @@ struct node_if_stmt
     anzu::token token;
 };
 
+struct node_struct_stmt
+{
+    struct field {
+        std::string name;
+        type_name   type;
+    };
+
+    std::string        name;
+    std::vector<field> fields;
+}
+
 struct node_for_stmt
 {
     std::string   var;
@@ -166,6 +177,7 @@ struct node_stmt : std::variant<
     node_sequence_stmt,
     node_while_stmt,
     node_if_stmt,
+    node_struct_stmt,
     node_for_stmt,
     node_break_stmt,
     node_continue_stmt,

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -129,6 +129,15 @@ struct node_assignment_stmt
     anzu::token token;
 };
 
+struct node_field_assignment_stmt
+{
+    std::string              name;
+    std::vector<std::string> fields;
+    node_expr_ptr            expr;
+
+    anzu::token token;
+};
+
 struct node_function_def_stmt
 {
     std::string   name;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -247,6 +247,10 @@ void compile_node(const node_expr& expr, const node_variable_expr& node, compile
     load_variable(ctx, node.name, size);
 }
 
+void compile_node(const node_expr& expr, const node_field_expr& node, compiler_context& ctx)
+{
+}
+
 // This is a copy of the logic from typecheck.cpp now, pretty bad, we should make it more
 // generic and combine the logic.
 void compile_node(const node_expr& expr, const node_bin_op_expr& node, compiler_context& ctx)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -449,6 +449,12 @@ void compile_node(const node_assignment_stmt& node, compiler_context& ctx)
     save_variable(ctx, node.name);
 }
 
+void compile_node(const node_field_assignment_stmt& node, compiler_context& ctx)
+{
+    print("field assignment not implemented\n");
+    std::exit(1);
+}
+
 void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
 {
     const auto begin_pos = append_op(ctx, op_function{ .name=node.name, .sig=node.sig });

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -264,8 +264,20 @@ void compile_node(const node_expr& expr, const node_field_expr& node, compiler_c
         }
     }
 
-    print("failed to compile\n");
-    std::exit(1);
+    auto field_addr = ctx.globals.locs[var_name];
+    auto field_size = std::size_t{0};
+    for (const auto& field : ctx.registered_types.get_fields(var_type)) {
+        if (field.name == node.field_name) {
+            field_size = ctx.registered_types.block_size(field.type);
+            break;
+        }
+        field_addr += ctx.registered_types.block_size(field.type);
+    }
+    ctx.program.emplace_back(op_load_global{
+        .name = std::format("{}.{}", var_name, node.field_name),
+        .position = field_addr,
+        .size = field_size
+    });
 }
 
 // This is a copy of the logic from typecheck.cpp now, pretty bad, we should make it more

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -362,6 +362,11 @@ void compile_node(const node_if_stmt& node, compiler_context& ctx)
     }
 }
 
+void compile_node(const node_struct_stmt& node, compiler_context& ctx)
+{
+
+}
+
 // TODO: This only works if the contained type has size 1, because lists are broken
 void compile_node(const node_for_stmt& node, compiler_context& ctx)
 {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -451,7 +451,35 @@ void compile_node(const node_assignment_stmt& node, compiler_context& ctx)
 
 void compile_node(const node_field_assignment_stmt& node, compiler_context& ctx)
 {
-    print("field assignment not implemented\n");
+    if (ctx.locals && ctx.locals->info.contains(node.name)) {
+        compile_node(*node.expr, ctx);
+        const auto& info = ctx.locals->info.at(node.name);
+        auto location = info.location;
+        auto type = info.type;
+        for (const auto& field_name : node.fields) { // Field names in the assignemnt
+            for (const auto& field : ctx.registered_types.get_fields(type)) { // Field of curr type
+                if (field.name == field_name) {
+                    type = field.type;
+                    break;
+                }
+                location += ctx.registered_types.block_size(field.type);
+            }
+        }
+        ctx.program.emplace_back(op_save_local{
+            .name="temp", .offset=location, .size=ctx.registered_types.block_size(type)
+        });
+        return;
+    }
+    
+    //if (ctx.globals.info.contains(name)) {
+    //    const auto& info = ctx.globals.info.at(name);
+    //    ctx.program.emplace_back(anzu::op_save_global{
+    //        .name=name, .position=info.location, .size=ctx.registered_types.block_size(info.type)
+    //    });
+    //    return;
+    //}
+
+    print("field assignment not implemented for globals\n");
     std::exit(1);
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -15,9 +15,15 @@
 
 namespace anzu {
 
+struct var_info
+{
+    std::size_t location;
+    type_name   type;
+};
+
 struct var_locations
 {
-    std::unordered_map<std::string, std::size_t> locs;
+    std::unordered_map<std::string, var_info> info;
     std::size_t next = 0;
 };
 
@@ -65,27 +71,29 @@ auto append_op(compiler_context& ctx, T&& op) -> std::intptr_t
 }
 
 // Registers the given name in the current scope
-auto declare_variable_name(compiler_context& ctx, const std::string& name, std::size_t size) -> void
+auto declare_variable_name(compiler_context& ctx, const std::string& name, const type_name& type) -> void
 {
     auto& vars = ctx.locals.has_value() ? ctx.locals.value() : ctx.globals;
-    const auto [iter, success] = vars.locs.emplace(name, vars.next);
+    const auto [iter, success] = vars.info.emplace(name, var_info{vars.next, type});
     if (success) { // If not successful, then the name already existed, so dont increase
-        vars.next += size;
+        vars.next += ctx.registered_types.block_size(type);
     }
 }
 
-auto save_variable(compiler_context& ctx, const std::string& name, std::size_t size) -> void
+auto save_variable(compiler_context& ctx, const std::string& name) -> void
 {
-    if (ctx.locals && ctx.locals->locs.contains(name)) {
+    if (ctx.locals && ctx.locals->info.contains(name)) {
+        const auto& info = ctx.locals->info.at(name);
         ctx.program.emplace_back(anzu::op_save_local{
-            .name=name, .offset=ctx.locals->locs.at(name), .size=size
+            .name=name, .offset=info.location, .size=ctx.registered_types.block_size(info.type)
         });
         return;
     }
     
-    if (ctx.globals.locs.contains(name)) {
+    if (ctx.globals.info.contains(name)) {
+        const auto& info = ctx.globals.info.at(name);
         ctx.program.emplace_back(anzu::op_save_global{
-            .name=name, .position=ctx.globals.locs.at(name), .size=size
+            .name=name, .position=info.location, .size=ctx.registered_types.block_size(info.type)
         });
         return;
     }
@@ -94,19 +102,23 @@ auto save_variable(compiler_context& ctx, const std::string& name, std::size_t s
     std::exit(1);
 }
 
-auto load_variable(compiler_context& ctx, const std::string& name, std::size_t size) -> void
+auto load_variable(compiler_context& ctx, const std::string& name) -> void
 {
     if (ctx.locals) {
-        if (auto it = ctx.locals->locs.find(name); it != ctx.locals->locs.end()) {
+        if (auto it = ctx.locals->info.find(name); it != ctx.locals->info.end()) {
             ctx.program.emplace_back(anzu::op_load_local{
-                .name=name, .offset=it->second, .size=size
+                .name=name,
+                .offset=it->second.location,
+                .size=ctx.registered_types.block_size(it->second.type)
             });
             return;
         }
     }
-    if (auto it = ctx.globals.locs.find(name); it != ctx.globals.locs.end()) {
+    if (auto it = ctx.globals.info.find(name); it != ctx.globals.info.end()) {
         ctx.program.emplace_back(anzu::op_load_global{
-            .name=name, .position=it->second, .size=size
+            .name=name,
+            .position=it->second.location,
+            .size=ctx.registered_types.block_size(it->second.type)
         });
     }
 }
@@ -231,8 +243,7 @@ void compile_node(const node_expr& expr, const node_literal_expr& node, compiler
 
 void compile_node(const node_expr& expr, const node_variable_expr& node, compiler_context& ctx)
 {
-    const auto size = ctx.registered_types.block_size(ctx.expr_types[&expr]);
-    load_variable(ctx, node.name, size);
+    load_variable(ctx, node.name);
 }
 
 void compile_node(const node_expr& expr, const node_field_expr& node, compiler_context& ctx)
@@ -245,8 +256,8 @@ void compile_node(const node_expr& expr, const node_field_expr& node, compiler_c
     const auto& var_type = ctx.expr_types[node.expression.get()];
 
     if (ctx.locals) {
-        if (auto it = ctx.locals->locs.find(var_name); it != ctx.locals->locs.end()) {
-            auto field_addr = it->second;
+        if (auto it = ctx.locals->info.find(var_name); it != ctx.locals->info.end()) {
+            auto field_addr = it->second.location;
             auto field_size = std::size_t{0};
             for (const auto& field : ctx.registered_types.get_fields(var_type)) {
                 if (field.name == node.field_name) {
@@ -264,7 +275,7 @@ void compile_node(const node_expr& expr, const node_field_expr& node, compiler_c
         }
     }
 
-    auto field_addr = ctx.globals.locs[var_name];
+    auto field_addr = ctx.globals.info[var_name].location;
     auto field_size = std::size_t{0};
     for (const auto& field : ctx.registered_types.get_fields(var_type)) {
         if (field.name == node.field_name) {
@@ -355,26 +366,28 @@ void compile_node(const node_if_stmt& node, compiler_context& ctx)
 void compile_node(const node_for_stmt& node, compiler_context& ctx)
 {
     const auto container_name = std::string{"_Container"};
+    const auto container_type = ctx.expr_types[node.container.get()];
+    const auto contained_type = match(container_type, generic_list_type())->at(0);
     const auto index_name = std::string{"_Index"};
 
     // Push the container to the stack
     compile_node(*node.container, ctx);
-    declare_variable_name(ctx, container_name, 1);
-    save_variable(ctx, container_name, 1); // Currently only lists are allowed in for stmts
+    declare_variable_name(ctx, container_name, container_type);
+    save_variable(ctx, container_name); // Currently only lists are allowed in for stmts
 
     // Push the counter to the stack
     ctx.program.emplace_back(anzu::op_load_literal{
         .value=make_int(0)
     });
-    declare_variable_name(ctx, index_name, 1);
-    save_variable(ctx, index_name, 1);
+    declare_variable_name(ctx, index_name, int_type());
+    save_variable(ctx, index_name);
 
-    declare_variable_name(ctx, node.var, 1);
+    declare_variable_name(ctx, node.var, contained_type);
 
     const auto begin_pos = append_op(ctx, op_loop_begin{});
 
-    load_variable(ctx, index_name, 1);
-    load_variable(ctx, container_name, 1);
+    load_variable(ctx, index_name);
+    load_variable(ctx, container_name);
     call_builtin(ctx, "list_size");
 
     // OP_NE - TODO: Make this better
@@ -391,22 +404,22 @@ void compile_node(const node_for_stmt& node, compiler_context& ctx)
     
     const auto jump_pos = append_op(ctx, op_jump_if_false{}); // If size == index, jump to end
 
-    load_variable(ctx, container_name, 1);
-    load_variable(ctx, index_name, 1);
+    load_variable(ctx, container_name);
+    load_variable(ctx, index_name);
     call_builtin(ctx, "list_at");
-    save_variable(ctx, node.var, 1);
+    save_variable(ctx, node.var);
 
     compile_node(*node.body, ctx);
 
     // Increment the index
-    load_variable(ctx, index_name, 1);
+    load_variable(ctx, index_name);
     ctx.program.emplace_back(op_builtin_mem_op{
         .name = "increment",
         .ptr = +[](std::vector<block>& mem) {
             ++std::get<block_int>(back(mem));
         }
     });
-    save_variable(ctx, index_name, 1);
+    save_variable(ctx, index_name);
 
     const auto end_pos = append_op(ctx, op_loop_end{ .jump=begin_pos });
 
@@ -426,16 +439,14 @@ void compile_node(const node_continue_stmt&, compiler_context& ctx)
 void compile_node(const node_declaration_stmt& node, compiler_context& ctx)
 {
     compile_node(*node.expr, ctx);
-    const auto size = ctx.registered_types.block_size(ctx.expr_types[node.expr.get()]);
-    declare_variable_name(ctx, node.name, size);
-    save_variable(ctx, node.name, size);
+    declare_variable_name(ctx, node.name, ctx.expr_types[node.expr.get()]);
+    save_variable(ctx, node.name);
 }
 
 void compile_node(const node_assignment_stmt& node, compiler_context& ctx)
 {
     compile_node(*node.expr, ctx);
-    const auto size = ctx.registered_types.block_size(ctx.expr_types[node.expr.get()]);
-    save_variable(ctx, node.name, size);
+    save_variable(ctx, node.name);
 }
 
 void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
@@ -445,7 +456,7 @@ void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
 
     ctx.locals.emplace();
     for (const auto& arg : node.sig.args) {
-        declare_variable_name(ctx, arg.name, 1);
+        declare_variable_name(ctx, arg.name, arg.type);
     }
     compile_node(*node.body, ctx);
     ctx.locals.reset();

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -121,16 +121,6 @@ auto builtin_range(std::span<const block> args) -> block
     return block{list};
 }
 
-auto builtin_first(std::span<const block> args) -> block
-{
-    return args[0];
-}
-
-auto builtin_second(std::span<const block> args) -> block
-{
-    return args[1];
-}
-
 }
 
 auto construct_builtin_map() -> std::unordered_map<std::string, builtin>
@@ -235,26 +225,6 @@ auto construct_builtin_map() -> std::unordered_map<std::string, builtin>
                 { .name = "max", .type = int_type() }
             },
             .return_type = concrete_list_type(int_type())
-        }
-    });
-
-    builtins.emplace("vec2_first", builtin{
-        .ptr = builtin_first,
-        .sig = {
-            .args = {
-                { .name = "v", .type = vec2_type() }
-            },
-            .return_type = int_type()
-        }
-    });
-
-    builtins.emplace("vec2_second", builtin{
-        .ptr = builtin_second,
-        .sig = {
-            .args = {
-                { .name = "v", .type = vec2_type() }
-            },
-            .return_type = int_type()
         }
     });
 

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -45,37 +45,37 @@ auto resolve_bin_op(const bin_op_description& desc) -> std::optional<bin_op_info
             return bin_op_info{ bin_op<block_int, std::divides>, type };
         } else if (desc.op == tk_mod) {
             return bin_op_info{ bin_op<block_int, std::modulus>, type };
-        } else if (desc.op == "<") {
+        } else if (desc.op == tk_lt) {
             return bin_op_info{ bin_op<block_int, std::less>, bool_type() };
-        } else if (desc.op == "<=") {
+        } else if (desc.op == tk_le) {
             return bin_op_info{ bin_op<block_int, std::less_equal>, bool_type() };
-        } else if (desc.op == ">") {
+        } else if (desc.op == tk_gt) {
             return bin_op_info{ bin_op<block_int, std::greater>, bool_type() };
-        } else if (desc.op == ">=") {
+        } else if (desc.op == tk_ge) {
             return bin_op_info{ bin_op<block_int, std::greater_equal>, bool_type() };
-        } else if (desc.op == "==") {
+        } else if (desc.op == tk_eq) {
             return bin_op_info{ bin_op<block_int, std::equal_to>, bool_type() };
-        } else if (desc.op == "!=") {
+        } else if (desc.op == tk_ne) {
             return bin_op_info{ bin_op<block_int, std::not_equal_to>, bool_type() };
         }
     }
     else if (type == bool_type()) {
-        if (desc.op == "==") {
+        if (desc.op == tk_eq) {
             return bin_op_info{ bin_op<block_bool, std::equal_to>, type };
-        } else if (desc.op == "!=") {
+        } else if (desc.op == tk_ne) {
             return bin_op_info{ bin_op<block_bool, std::not_equal_to>, type };
-        } else if (desc.op == "&&") {
+        } else if (desc.op == tk_and) {
             return bin_op_info{ bin_op<block_bool, std::logical_and>, type };
-        } else if (desc.op == "||") {
+        } else if (desc.op == tk_or) {
             return bin_op_info{ bin_op<block_bool, std::logical_or>, type };
         }
     }
     else if (type == str_type()) {
-        if (desc.op == "+") {
+        if (desc.op == tk_add) {
             return bin_op_info{ bin_op<block_str, std::plus>, type };
-        } else if (desc.op == "==") {
+        } else if (desc.op == tk_eq) {
             return bin_op_info{ bin_op<block_str, std::equal_to>, bool_type() };
-        } else if (desc.op == "!=") {
+        } else if (desc.op == tk_ne) {
             return bin_op_info{ bin_op<block_str, std::not_equal_to>, bool_type() };
         }
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -258,6 +258,14 @@ auto parse_for_stmt(tokenstream& tokens) -> node_stmt_ptr
     return node;
 }
 
+auto parse_struct_stmt(tokenstream& tokens) -> node_stmt_ptr
+{
+    auto node = std::make_unique<anzu::node_stmt>();
+    auto& stmt = node->emplace<anzu::node_struct_stmt>();
+
+    return node;
+}
+
 auto parse_declaration_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_unique<anzu::node_stmt>();
@@ -329,6 +337,9 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
     }
     if (tokens.peek(tk_for)) {
         return parse_for_stmt(tokens);
+    }
+    if (tokens.peek(tk_struct)) {
+        return parse_struct_stmt(tokens);
     }
     if (tokens.peek(tk_break)) {
         return std::make_unique<node_stmt>(node_break_stmt{ tokens.consume() });

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -89,35 +89,42 @@ auto parse_function_call_expr(tokenstream& tokens) -> node_expr_ptr
 
 auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
 {
+    auto node = std::make_unique<anzu::node_expr>();
+    
     if (tokens.consume_maybe(tk_lparen)) {
-        auto expr = parse_expression(tokens);
+        node = parse_expression(tokens);
         tokens.consume_only(tk_rparen);
-        return expr;
     }
-    if (tokens.peek(tk_lbracket)) {
-        auto node = std::make_unique<anzu::node_expr>();
+    else if (tokens.peek(tk_lbracket)) {
         auto& expr = node->emplace<anzu::node_list_expr>();
         expr.token = tokens.consume();
         tokens.consume_comma_separated_list(tk_rbracket, [&] {
             expr.elements.push_back(parse_expression(tokens));
         });
-        return node;
     }  
-    if (tokens.peek_next(tk_lparen)) {
-        return parse_function_call_expr(tokens);
+    else if (tokens.peek_next(tk_lparen)) {
+        node = parse_function_call_expr(tokens);
     }
-    if (tokens.curr().type == token_type::name) {
-        auto node = std::make_unique<anzu::node_expr>();
+    else if (tokens.curr().type == token_type::name) {
         auto& expr = node->emplace<anzu::node_variable_expr>();
         expr.token = tokens.consume();
         expr.name = expr.token.text;
-        return node;
+    }
+    else {
+        auto& expr = node->emplace<anzu::node_literal_expr>();
+        expr.token = tokens.curr();
+        expr.value = parse_literal(tokens);
     }
 
-    auto node = std::make_unique<anzu::node_expr>();
-    auto& expr = node->emplace<anzu::node_literal_expr>();
-    expr.token = tokens.curr();
-    expr.value = parse_literal(tokens);
+    while (tokens.peek(tk_fullstop)) {
+        auto new_node = std::make_unique<anzu::node_expr>();
+        auto& expr = new_node->emplace<anzu::node_field_expr>();
+        expr.token = tokens.consume();
+        expr.field_name = tokens.consume().text;
+        expr.expression = std::move(node);
+        node = std::move(new_node);
+    }
+
     return node;
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -280,6 +280,20 @@ auto parse_assignment_stmt(tokenstream& tokens) -> node_stmt_ptr
     return node;
 }
 
+auto parse_field_assignment_stmt(tokenstream& tokens) -> node_stmt_ptr
+{
+    auto node = std::make_unique<anzu::node_stmt>();
+    auto& stmt = node->emplace<anzu::node_field_assignment_stmt>();
+
+    stmt.name = parse_name(tokens);
+    while (tokens.consume_maybe(tk_fullstop)) {
+        stmt.fields.push_back(parse_name(tokens));
+    }
+    stmt.token = tokens.consume_only(tk_assign);
+    stmt.expr = parse_expression(tokens);
+    return node;
+}
+
 auto parse_function_call_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     return parse_function_call<anzu::node_stmt, anzu::node_function_call_stmt>(tokens);
@@ -327,6 +341,9 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
     }
     if (tokens.peek_next(tk_assign)) { // <name> '=' <expr>
         return parse_assignment_stmt(tokens);
+    }
+    if (tokens.peek_next(tk_fullstop)) {
+        return parse_field_assignment_stmt(tokens);
     }
     if (tokens.peek_next(tk_lparen)) { // <name> '('
         return parse_function_call_stmt(tokens);

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -49,7 +49,6 @@ struct op_save_local
     std::size_t size;
 };
 
-
 struct op_if
 {
 };

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -304,6 +304,9 @@ auto typecheck_expr(typecheck_context& ctx, const node_expr& expr) -> type_name
             }
             type_error(node.token, "could not find variable '{}'\n", node.name);
         },
+        [&](const node_field_expr& node) {
+            return int_type();
+        },
         [&](const node_function_call_expr& node) {
             return typecheck_function_call(ctx, node.token, node.function_name, node.args);
         },

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -373,6 +373,11 @@ auto typecheck_node(typecheck_context& ctx, const node_if_stmt& node) -> void
     }
 }
 
+auto typecheck_node(typecheck_context& ctx, const node_struct_stmt& node) -> void
+{
+
+}
+
 auto typecheck_node(typecheck_context& ctx, const node_for_stmt& node) -> void
 {
     const auto container_type = typecheck_expr(ctx, *node.container);

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -423,6 +423,11 @@ auto typecheck_node(typecheck_context& ctx, const node_assignment_stmt& node) ->
     type_error(node.token, "cannot assign to '{}', name not declared", node.name);
 }
 
+auto typecheck_node(typecheck_context& ctx, const node_field_assignment_stmt& node) -> void
+{
+    print("typechecking for node field assignment not implemented\n");
+}
+
 auto typecheck_node(typecheck_context& ctx, const node_function_def_stmt& node) -> void
 {
     ctx.functions.emplace(node.name, &node);

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -305,6 +305,14 @@ auto typecheck_expr(typecheck_context& ctx, const node_expr& expr) -> type_name
             type_error(node.token, "could not find variable '{}'\n", node.name);
         },
         [&](const node_field_expr& node) {
+            const auto parent_type = typecheck_expr(ctx, *node.expression);
+            const auto fields = ctx.registered_types.get_fields(parent_type);
+            for (const auto& field : fields) {
+                if (field.name == node.field_name) {
+                    return field.type;
+                }
+            }
+            type_error(node.token, "type '{}' has no field named '{}'\n", parent_type, node.field_name);
             return int_type();
         },
         [&](const node_function_call_expr& node) {

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -10,7 +10,7 @@ auto is_keyword(std::string_view token) -> bool
     static const std::unordered_set<std::string_view> tokens = {
         tk_break, tk_continue, tk_else, tk_false, tk_for, tk_if,
         tk_in, tk_null, tk_true, tk_while, tk_int, tk_bool, tk_str,
-        tk_list, tk_function, tk_return
+        tk_list, tk_function, tk_return, tk_struct
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -30,7 +30,7 @@ auto is_symbol(std::string_view token) -> bool
         tk_div, tk_eq, tk_ge, tk_gt, tk_lbracket, tk_le,
         tk_lparen, tk_lt, tk_mod, tk_mul, tk_ne, tk_or,
         tk_period, tk_rbracket, tk_rparen, tk_sub, tk_rarrow,
-        tk_lbrace, tk_rbrace, tk_assign, tk_declare
+        tk_lbrace, tk_rbrace, tk_assign, tk_declare, tk_fullstop
     };
     return tokens.contains(token);
 }
@@ -39,14 +39,6 @@ auto is_comparison(sv token) -> bool
 {
     static const std::unordered_set<std::string_view> tokens = {
         tk_lt, tk_le, tk_gt, tk_ge, tk_eq, tk_ne
-    };
-    return tokens.contains(token);
-}
-
-auto is_type(std::string_view token) -> bool
-{
-    static const std::unordered_set<std::string_view> tokens = {
-        tk_int, tk_bool, tk_str, tk_list, tk_null
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -51,11 +51,11 @@ constexpr auto tk_sub       = sv{"-"};
 constexpr auto tk_rarrow    = sv{"->"};
 constexpr auto tk_lbrace    = sv{"{"};
 constexpr auto tk_rbrace    = sv{"}"};
+constexpr auto tk_fullstop  = sv{"."};
 
 auto is_keyword    (sv token) -> bool;
 auto is_sentinel   (sv token) -> bool;
 auto is_symbol     (sv token) -> bool;
 auto is_comparison (sv token) -> bool;
-auto is_type       (sv token) -> bool;
 
 }

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -18,6 +18,7 @@ constexpr auto tk_true      = sv{"true"};
 constexpr auto tk_while     = sv{"while"};
 constexpr auto tk_function  = sv{"fn"};
 constexpr auto tk_return    = sv{"return"};
+constexpr auto tk_struct    = sv{"struct"};
 
 // Builtin Types
 constexpr auto tk_int       = sv{"int"};


### PR DESCRIPTION
* Make it possible to read and write to fields of objects (only vec2 exists currently).
* `node_field_expr` is the expression node for fetching the field.
* `node_field_assignment_stmt` is the statement node to writing to the field.
* The above can possibly be combined when we have references.
* Remove `builtin_first` and `builtin_second`, since we can now write `v.x` and `v.y`.
* For attribte access, `.` is obviously now a special symbol.
* `struct` is now a keyword, and added `node_struct_stmt` to the ast. It currently is unused.