### PR TITLE
User Defined Structs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/feature_test.az", "run"],
+            "args": ["${workspaceFolder}/examples/test.az", "parse"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ print(4 + 5)
         ...
     }
     ```
+* `struct` statements:
+    ```
+    struct <name>
+    {
+        <field_name> : <field_type>
+        ...
+    }
+    ```
 * All the common arithmetic, comparison and logical operators. More will be implemented.
 * Builtin functions.
 
@@ -105,7 +113,6 @@ Utility Modules (in src/utility)
 * Replace `int` with `int32`, `int64` as well as promotion/narrowing builtins.
 * Add `float32` and `float64`, with promotion/narrowing builtins (and to/from ints).
 * Add `uint32` and `uint64`, similar to the above.
-* Custom types via `class` keyword.
 * Removal of objects and types from the runtime, should run on arrays of bytes.
 * Native compilation.
 * References (like C++, no pointers).

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -112,6 +112,13 @@ fn print_one_to_ten() -> null
     }
 }
 
+# Struct definition
+struct vec2
+{
+    x: int
+    y: int
+}
+
 # Attribute access
 my_vec := vec2(1, 2)
 println(my_vec)

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,13 +4,14 @@ struct vec3
 {
     x: int
     y: int
-    z: int
+    z: vec2
 }
 
-v := vec3(7, 20, 3)
+v := vec3(7, 20, vec2(1, 3))
 println(v.x)
 println(v.y)
 println(v.z)
+println(v)
 
-v.z = v.x + v.y
-println(v.z)
+v.z.x = 12
+println(v)

--- a/examples/test.az
+++ b/examples/test.az
@@ -7,7 +7,10 @@ struct vec3
     z: int
 }
 
-v := vec3(1, 2, 3)
+v := vec3(7, 20, 3)
 println(v.x)
 println(v.y)
+println(v.z)
+
+v.z = v.x + v.y
 println(v.z)

--- a/examples/test.az
+++ b/examples/test.az
@@ -7,13 +7,7 @@ struct vec3
     z: int
 }
 
-my_vec := vec2(1, 2)
-
-fn int_x() -> null
-{
-    my_vec.x = my_vec.x + 1
-}
-
-println(my_vec)
-int_x()
-println(my_vec)
+v := vec3(1, 2, 3)
+println(v.x)
+println(v.y)
+println(v.z)

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,14 +4,11 @@ struct vec3
 {
     x: int
     y: int
-    z: vec2
+    z: int
 }
 
-v := vec3(7, 20, vec2(1, 3))
+v := vec3(7, 20, 3)
 println(v.x)
 println(v.y)
 println(v.z)
-println(v)
-
-v.z.x = 12
 println(v)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,14 +1,18 @@
 
 
-struct vec3
+struct vec2
 {
     x: int
     y: int
-    z: int
 }
 
-v := vec3(7, 20, 3)
-println(v.x)
-println(v.y)
-println(v.z)
-println(v)
+fn inc(v: vec2) -> vec2
+{
+    v.x = v.x + 1
+    return v
+}
+
+my_vec := vec2(1, 2)
+println(my_vec)
+my_vec = inc(my_vec)
+println(my_vec)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,11 +1,11 @@
 
 
-#struct vec3
-#{
-#    x: int
-#    y: int
-#    z: int
-#}
+struct vec3
+{
+    x: int
+    y: int
+    z: int
+}
 
 my_vec := vec2(1, 2)
 

--- a/src/anzu.m.cpp
+++ b/src/anzu.m.cpp
@@ -47,14 +47,14 @@ int main(int argc, char** argv)
     }
 
     anzu::print("-> Type Checking\n");
-    const auto expr_types = anzu::typecheck_ast(ast);
+    const auto type_info = anzu::typecheck_ast(ast);
     if (mode == "check") {
         print_node(*ast);
         return 0;
     }
 
     anzu::print("-> Compiling\n");
-    const auto program = anzu::compile(ast, expr_types);
+    const auto program = anzu::compile(ast, type_info);
     if (mode == "com") {
         anzu::print_program(program);
         return 0;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -81,7 +81,7 @@ auto print_node(const node_stmt& root, int indent) -> void
             print("{}- Name: {}\n", spaces, node.name);
             print("{}- Fields:\n", spaces);
             for (const auto& field : node.fields) {
-                print("{}  - {}: {}\n", field.name, field.type);
+                print("{}  - {}: {}\n", spaces, field.name, field.type);
             }
         },
         [&](const node_for_stmt& node) {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -97,8 +97,8 @@ struct node_if_stmt
 
 struct node_struct_stmt
 {
-    std::string        name;
-    std::vector<field> fields;
+    type_name   name;
+    type_fields fields;
 
     anzu::token token;
 };

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "object.hpp"
+#include "type.hpp"
 #include "functions.hpp"
 #include "token.hpp"
 
@@ -96,11 +97,6 @@ struct node_if_stmt
 
 struct node_struct_stmt
 {
-    struct field {
-        std::string name;
-        type_name   type;
-    };
-
     std::string        name;
     std::vector<field> fields;
 

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -5,6 +5,6 @@
 
 namespace anzu {
 
-auto compile(const node_stmt_ptr& root, const expr_types& types) -> anzu::program;
+auto compile(const node_stmt_ptr& root, const type_info& types) -> anzu::program;
 
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -58,11 +58,6 @@ auto make_null() -> object
     return { .data = { block_null{} }, .type = null_type() };
 }
 
-auto make_vec2(block_int x, block_int y) -> object
-{
-    return { .data = { block_int(x), block_int(y) }, .type = vec2_type() };
-}
-
 auto format_special_chars(const std::string& str) -> std::string
 {
     std::string ret;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -43,8 +43,6 @@ auto make_bool(block_bool val) -> object;
 auto make_str(const block_str& val) -> object;
 auto make_null() -> object;
 
-auto make_vec2(block_int x, block_int y) -> object;
-
 // Should be elsewhere
 auto format_special_chars(const std::string& str) -> std::string;
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -264,7 +264,7 @@ auto parse_struct_stmt(tokenstream& tokens) -> node_stmt_ptr
     auto& stmt = node->emplace<anzu::node_struct_stmt>();
 
     stmt.token = tokens.consume_only(tk_struct);
-    stmt.name = parse_name(tokens);
+    stmt.name = type_name{type_simple{ .name = parse_name(tokens) }};;
     tokens.consume_only(tk_lbrace);
     while (!tokens.consume_maybe(tk_rbrace)) {
         stmt.fields.emplace_back();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -263,6 +263,17 @@ auto parse_struct_stmt(tokenstream& tokens) -> node_stmt_ptr
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_struct_stmt>();
 
+    stmt.token = tokens.consume_only(tk_struct);
+    stmt.name = parse_name(tokens);
+    tokens.consume_only(tk_lbrace);
+    while (!tokens.consume_maybe(tk_rbrace)) {
+        stmt.fields.emplace_back();
+        auto& f = stmt.fields.back();
+        f.name = parse_name(tokens);
+        tokens.consume_only(tk_colon);
+        f.type = parse_type(tokens);
+    }
+
     return node;
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -264,7 +264,7 @@ auto parse_struct_stmt(tokenstream& tokens) -> node_stmt_ptr
     auto& stmt = node->emplace<anzu::node_struct_stmt>();
 
     stmt.token = tokens.consume_only(tk_struct);
-    stmt.name = type_name{type_simple{ .name = parse_name(tokens) }};;
+    stmt.name = make_type(parse_name(tokens));
     tokens.consume_only(tk_lbrace);
     while (!tokens.consume_maybe(tk_rbrace)) {
         stmt.fields.emplace_back();

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -266,4 +266,13 @@ auto type_store::get_fields(const type_name& t) const -> type_fields
     return {};
 }
 
+auto type_store::register_type(const type_name& name, const type_fields& fields) -> bool
+{
+    if (d_classes.contains(name)) {
+        return false;
+    }
+    d_classes.emplace(name, fields);
+    return true;
+}
+
 }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -77,11 +77,6 @@ auto generic_type(int id) -> type_name
     return {type_generic{ .id = id }};
 }
 
-auto vec2_type() -> type_name
-{
-    return {type_simple{ .name = "vec2", }};
-}
-
 auto concrete_list_type(const type_name& t) -> type_name
 {
     return {type_compound{
@@ -224,10 +219,6 @@ auto to_string(const signature& sig) -> std::string
 
 type_store::type_store()
 {
-    d_classes.emplace(vec2_type(), type_fields{
-        { .name = "x", .type = int_type() },
-        { .name = "y", .type = int_type() }
-    });
 }
 
 auto type_store::is_registered_type(const type_name& t) const -> bool

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -60,7 +60,6 @@ auto bool_type() -> type_name;
 auto str_type() -> type_name;
 auto null_type() -> type_name;
 auto generic_type(int id) -> type_name;
-auto vec2_type() -> type_name;
 
 inline auto make_type(const std::string& name) -> type_name
 {

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -108,6 +108,10 @@ public:
     auto block_size(const type_name& t) const -> std::size_t;
 
     auto get_fields(const type_name& t) const -> type_fields;
+
+    // Registers a type with the given name and fields. Returns true if successful and false
+    // if the type already exists.
+    auto register_type(const type_name& name, const type_fields& fields) -> bool;
 };
 
 }

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -62,6 +62,11 @@ auto null_type() -> type_name;
 auto generic_type(int id) -> type_name;
 auto vec2_type() -> type_name;
 
+inline auto make_type(const std::string& name) -> type_name
+{
+    return { type_simple{ .name=name } };
+}
+
 auto concrete_list_type(const type_name& t) -> type_name;
 auto generic_list_type() -> type_name;
 

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -375,7 +375,19 @@ auto typecheck_node(typecheck_context& ctx, const node_if_stmt& node) -> void
 
 auto typecheck_node(typecheck_context& ctx, const node_struct_stmt& node) -> void
 {
-
+    if (ctx.types.types.is_registered_type(node.name)) {
+        type_error(node.token, "type '{}' is already defined\n", node.name);
+    }
+    for (const auto& field : node.fields) {
+        if (!ctx.types.types.is_registered_type(field.type)) {
+            type_error(
+                node.token,
+                "unknown type '{}' of field {} for struct {}\n",
+                field.type, field.name, node.name
+            );
+        }
+    }
+    ctx.types.types.register_type(node.name, node.fields);
 }
 
 auto typecheck_node(typecheck_context& ctx, const node_for_stmt& node) -> void

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -40,7 +40,7 @@ struct typecheck_context
 
     std::unordered_map<const node_function_def_stmt*, std::unordered_set<signature>> checked_sigs;
 
-    expr_types node_types;
+    type_info types;
 };
 
 auto current_vars(typecheck_context& ctx) -> typecheck_context::var_types&
@@ -339,7 +339,7 @@ auto typecheck_expr(typecheck_context& ctx, const node_expr& expr) -> type_name
         }
     }, expr);
 
-    ctx.node_types.emplace(&expr, expr_type);
+    ctx.types.expr_types.emplace(&expr, expr_type);
     return expr_type;
 };
 
@@ -511,11 +511,11 @@ auto typecheck_node(typecheck_context& ctx, const node_stmt& node) -> void
 
 }
 
-auto typecheck_ast(const node_stmt_ptr& ast) -> expr_types
+auto typecheck_ast(const node_stmt_ptr& ast) -> type_info
 {
     auto ctx = typecheck_context{};
     typecheck_node(ctx, *ast);
-    return ctx.node_types;
+    return ctx.types;
 }
 
 }

--- a/src/typecheck.hpp
+++ b/src/typecheck.hpp
@@ -8,12 +8,16 @@
 
 namespace anzu {
 
-using expr_types = std::unordered_map<const node_expr*, type_name>;
+struct type_info
+{
+    type_store types;
+    std::unordered_map<const node_expr*, type_name> expr_types;
+};
 
 // Scans the AST and performs the following:
 //      - evaluates the type of all expressions to verify they are valid
 //      - verify that expressions passed as function arguments match the function signatures
 //      - verify that the types listed in function signatures are valid types
-auto typecheck_ast(const node_stmt_ptr& ast) -> expr_types;
+auto typecheck_ast(const node_stmt_ptr& ast) -> type_info;
 
 }


### PR DESCRIPTION
* It is now possible to define structs in anzu code with the `struct` keyword.
* `vec2` has been removed from the interpreter since it can now be added in 4 lines of a script.
* The `type_store` from the typechecker is now also passed along to the compiler with the `expr_types` so that the types do not need to be parsed again. This means that there is no logic in the compiler for struct definitions, so custom types are just as efficient as builtin ones would are.