### PR TITLE
Generalised Assignment

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,8 @@
-x := 5
-x = 6
+struct vec2
+{
+    x: int
+    y: int
+}
 
-println(x)
+v := vec2(1, 2)
+v.y = 6

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,9 +4,10 @@ struct vec2
     y: int
 }
 
-x := 5
-xp := addrof x
+v := vec2(1, 2)
 
-deref xp = 6
+x := addrof(v.y)
 
-println(x)
+deref(x) = 8
+
+println(v)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,7 +1,4 @@
+x := 5
+x = 6
 
-fn foo() -> null {
-    x := 10
-    y := addrof x
-    z := addrof y
-    println(deref deref z)
-}
+println(x)

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,5 +4,12 @@ struct vec2
     y: int
 }
 
-y := 6
-x := addrof y
+struct wrapper
+{
+    a: vec2
+}
+
+fn foo() -> null
+{}
+
+foo() 

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,5 +4,5 @@ struct vec2
     y: int
 }
 
-v := vec2(1, 2)
-v.y = 6
+y := 6
+x := addrof y

--- a/examples/test.az
+++ b/examples/test.az
@@ -4,12 +4,9 @@ struct vec2
     y: int
 }
 
-struct wrapper
-{
-    a: vec2
-}
+x := 5
+xp := addrof x
 
-fn foo() -> null
-{}
+deref xp = 6
 
-foo() 
+println(x)

--- a/examples/test.az
+++ b/examples/test.az
@@ -6,8 +6,7 @@ struct vec2
 
 v := vec2(1, 2)
 
-x := addrof(v.y)
-
-deref(x) = 8
+v.y = 7
+v.x = 2
 
 println(v)

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -119,13 +119,6 @@ auto print_node(const node_stmt& root, int indent) -> void
             print("{}- Value:\n", spaces);
             print_node(*node.expr, indent + 1);
         },
-        [&](const node_field_assignment_stmt& node) {
-            print("{}FieldAssignment:\n", spaces);
-            print("{}- Name: {}\n", spaces, node.name);
-            print("{}- Fields: {}\n", spaces, format_comma_separated(node.fields));
-            print("{}- Value:\n", spaces);
-            print_node(*node.expr, indent + 1);
-        },
         [&](const node_function_def_stmt& node) {
             print("{}Function: {} (", spaces, node.name);
             print_comma_separated(node.sig.args, [](const auto& arg) {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -114,7 +114,8 @@ auto print_node(const node_stmt& root, int indent) -> void
         },
         [&](const node_assignment_stmt& node) {
             print("{}Assignment:\n", spaces);
-            print("{}- Name: {}\n", spaces, node.name);
+            print("{}- Name:\n", spaces);
+            print_node(*node.position, indent + 1);
             print("{}- Value:\n", spaces);
             print_node(*node.expr, indent + 1);
         },

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -154,15 +154,6 @@ struct node_assignment_stmt
     anzu::token token;
 };
 
-struct node_field_assignment_stmt
-{
-    std::string              name;
-    std::vector<std::string> fields;
-    node_expr_ptr            expr;
-
-    anzu::token token;
-};
-
 struct node_function_def_stmt
 {
     std::string   name;
@@ -197,7 +188,6 @@ struct node_stmt : std::variant<
     node_continue_stmt,
     node_declaration_stmt,
     node_assignment_stmt,
-    node_field_assignment_stmt,
     node_function_def_stmt,
     node_function_call_stmt,
     node_return_stmt>

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -148,7 +148,7 @@ struct node_declaration_stmt
 
 struct node_assignment_stmt
 {
-    std::string   name;
+    node_expr_ptr position;
     node_expr_ptr expr;
 
     anzu::token token;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -535,10 +535,6 @@ void compile_node(const node_assignment_stmt& node, compiler_context& ctx)
                 });
             }
         },
-        [&](node_function_call_expr& n) {
-            print("assigning to a function call not currently implemented\n");
-            std::exit(1);
-        },
         [&](node_deref_expr& n) {
             compile_node(*n.expr, ctx);
             ctx.program.emplace_back(op_save_to_addr{});

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -549,8 +549,8 @@ void compile_node(const node_assignment_stmt& node, compiler_context& ctx)
             std::exit(1);
         },
         [&](node_deref_expr& n) {
-            print("assigning to a deref expr not currently implemented\n");
-            std::exit(1);
+            compile_node(*n.expr, ctx);
+            ctx.program.emplace_back(op_save_to_addr{});
         },
         [](const auto&) {
             print("invalid expression to assign to\n");

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -512,11 +512,8 @@ void compile_node(const node_declaration_stmt& node, compiler_context& ctx)
 
 void compile_node(const node_assignment_stmt& node, compiler_context& ctx)
 {
-    const auto address = address_of_expr(ctx, *node.position);
-    const auto& name = std::get<node_variable_expr>(*node.position).name;
-
     compile_node(*node.expr, ctx);
-    const auto addr = address_of(ctx, name, {});
+    const auto addr = address_of_expr(ctx, *node.position);
     if (addr.is_local) {
         ctx.program.emplace_back(op_save_local{
             .offset=addr.position, .size=ctx.type_info.types.block_size(addr.type)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -513,7 +513,12 @@ void compile_node(const node_declaration_stmt& node, compiler_context& ctx)
 void compile_node(const node_assignment_stmt& node, compiler_context& ctx)
 {
     compile_node(*node.expr, ctx);
-    save_variable(ctx, node.name);
+    if (!std::holds_alternative<node_variable_expr>(*node.position)) {
+        print("currently cannot assign to a non-variable\n");
+        std::exit(1);
+    }
+    const auto& name = std::get<node_variable_expr>(*node.position).name;
+    save_variable(ctx, name);
 }
 
 void compile_node(const node_field_assignment_stmt& node, compiler_context& ctx)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -371,9 +371,9 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
     if (tokens.peek_next(tk_declare)) { // <name> ':=' <expr>
         return parse_declaration_stmt(tokens);
     }
-    if (tokens.peek_next(tk_fullstop)) {
-        return parse_field_assignment_stmt(tokens);
-    }
+    //if (tokens.peek_next(tk_fullstop)) {
+    //    return parse_field_assignment_stmt(tokens);
+    //}
     if (tokens.peek_next(tk_lparen)) { // <name> '('
         return parse_function_call_stmt(tokens);
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -303,7 +303,7 @@ auto parse_assignment_stmt(tokenstream& tokens) -> node_stmt_ptr
     auto node = std::make_unique<anzu::node_stmt>();
     auto& stmt = node->emplace<anzu::node_assignment_stmt>();
 
-    stmt.name = parse_name(tokens);
+    stmt.position = parse_expression(tokens);
     stmt.token = tokens.consume_only(tk_assign);
     stmt.expr = parse_expression(tokens);
     return node;
@@ -371,9 +371,6 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
     if (tokens.peek_next(tk_declare)) { // <name> ':=' <expr>
         return parse_declaration_stmt(tokens);
     }
-    if (tokens.peek_next(tk_assign)) { // <name> '=' <expr>
-        return parse_assignment_stmt(tokens);
-    }
     if (tokens.peek_next(tk_fullstop)) {
         return parse_field_assignment_stmt(tokens);
     }
@@ -383,7 +380,7 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
     if (tokens.peek(tk_lbrace)) {
         return parse_braced_statement_list(tokens);
     }
-    parser_error(tokens.curr(), "unknown statement '{}'", tokens.curr().text);
+    return parse_assignment_stmt(tokens);
 }
 
 auto parse_top_level_statement(tokenstream& tokens) -> node_stmt_ptr

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -309,20 +309,6 @@ auto parse_assignment_stmt(tokenstream& tokens) -> node_stmt_ptr
     return node;
 }
 
-auto parse_field_assignment_stmt(tokenstream& tokens) -> node_stmt_ptr
-{
-    auto node = std::make_unique<anzu::node_stmt>();
-    auto& stmt = node->emplace<anzu::node_field_assignment_stmt>();
-
-    stmt.name = parse_name(tokens);
-    while (tokens.consume_maybe(tk_fullstop)) {
-        stmt.fields.push_back(parse_name(tokens));
-    }
-    stmt.token = tokens.consume_only(tk_assign);
-    stmt.expr = parse_expression(tokens);
-    return node;
-}
-
 auto parse_function_call_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     return parse_function_call<anzu::node_stmt, anzu::node_function_call_stmt>(tokens);
@@ -371,9 +357,6 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
     if (tokens.peek_next(tk_declare)) { // <name> ':=' <expr>
         return parse_declaration_stmt(tokens);
     }
-    //if (tokens.peek_next(tk_fullstop)) {
-    //    return parse_field_assignment_stmt(tokens);
-    //}
     if (tokens.peek_next(tk_lparen)) { // <name> '('
         return parse_function_call_stmt(tokens);
     }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -42,6 +42,9 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_save_local& op) {
             return std::format("OP_SAVE_LOCAL({}: +{})", op.offset, op.size);
         },
+        [&](const op_save_to_addr& op) {
+            return std::string{"OP_SAVE_TO_ADDR"};
+        },
         [&](const op_if& op) {
             return std::string{"OP_IF"};
         },

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -37,10 +37,10 @@ auto to_string(const op& op_code) -> std::string
             return std::format("OP_POP({})", op.size);
         },
         [&](const op_save_global& op) {
-            return std::format("OP_SAVE_GLOBAL({}: {})", op.name, op.position);
+            return std::format("OP_SAVE_GLOBAL({}: {})", op.position, op.size);
         },
         [&](const op_save_local& op) {
-            return std::format("OP_SAVE_LOCAL({}: +{})", op.name, op.offset);
+            return std::format("OP_SAVE_LOCAL({}: +{})", op.offset, op.size);
         },
         [&](const op_if& op) {
             return std::string{"OP_IF"};

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -63,6 +63,10 @@ struct op_save_local
     std::size_t size;
 };
 
+struct op_save_to_addr
+{
+};
+
 struct op_if
 {
 };
@@ -151,6 +155,7 @@ struct op : std::variant<
     op_pop,
     op_save_global,
     op_save_local,
+    op_save_to_addr,
     op_if,
     op_if_end,
     op_else,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -53,14 +53,12 @@ struct op_pop
 
 struct op_save_global
 {
-    std::string name;
     std::size_t position;
     std::size_t size;
 };
 
 struct op_save_local
 {
-    std::string name;
     std::size_t offset;
     std::size_t size;
 };

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -131,6 +131,12 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             save_top_at(ctx, base_ptr(ctx) + op.offset, op.size);
             program_advance(ctx);
         },
+        [&](const op_save_to_addr& op) {
+            const auto ptr_blk = pop_back(ctx.memory);
+            const auto ptr = std::get<block_ptr>(ptr_blk);
+            save_top_at(ctx, ptr.ptr, ptr.size);
+            program_advance(ctx);
+        },
         [&](const op_if& op) {
             program_advance(ctx);
         },

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -110,8 +110,7 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             program_advance(ctx);
         },
         [&](const op_deref& op) {
-            const auto ptr_blk = ctx.memory.back();
-            ctx.memory.pop_back();
+            const auto ptr_blk = pop_back(ctx.memory);
             const auto ptr = std::get<block_ptr>(ptr_blk);
             for (std::size_t i = 0; i != ptr.size; ++i) {
                 ctx.memory.push_back(ctx.memory[ptr.ptr + i]);

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -430,24 +430,30 @@ auto typecheck_node(typecheck_context& ctx, const node_declaration_stmt& node) -
 
 auto typecheck_node(typecheck_context& ctx, const node_assignment_stmt& node) -> void
 {
+    if (!std::holds_alternative<node_variable_expr>(*node.position)) {
+        print("currently cannot assign to a non-variable\n");
+        std::exit(1);
+    }
+    const auto& name = std::get<node_variable_expr>(*node.position).name;
+
     const auto expr_type = typecheck_expr(ctx, *node.expr);
     if (ctx.locals) {
-        if (auto it = ctx.locals->find(node.name); it != ctx.locals->end()) {
+        if (auto it = ctx.locals->find(name); it != ctx.locals->end()) {
             if (expr_type != it->second) {
-                type_error(node.token, "cannot assign to '{}', incorrect type", node.name);
+                type_error(node.token, "cannot assign to '{}', incorrect type", name);
             }
             return;
         }
     }
 
-    if (auto it = ctx.globals.find(node.name); it != ctx.globals.end()) {
+    if (auto it = ctx.globals.find(name); it != ctx.globals.end()) {
         if (expr_type != it->second) {
-            type_error(node.token, "cannot assign to '{}', incorrect type", node.name);
+            type_error(node.token, "cannot assign to '{}', incorrect type", name);
         }
         return;
     }
 
-    type_error(node.token, "cannot assign to '{}', name not declared", node.name);
+    type_error(node.token, "cannot assign to '{}', name not declared", name);
 }
 
 auto typecheck_node(typecheck_context& ctx, const node_field_assignment_stmt& node) -> void

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -439,57 +439,6 @@ auto typecheck_node(typecheck_context& ctx, const node_assignment_stmt& node) ->
     }
 }
 
-auto typecheck_node(typecheck_context& ctx, const node_field_assignment_stmt& node) -> void
-{
-    if (ctx.locals) {
-        if (auto it = ctx.locals->find(node.name); it != ctx.locals->end()) {
-            auto type = it->second;
-            for (const auto& field_name : node.fields) {
-                const auto& type_fields = ctx.types.types.get_fields(type);
-                const auto it = std::find_if(begin(type_fields), end(type_fields), [&](auto&& field) {
-                    return field.name == field_name;
-                });
-                if (it != type_fields.end()) {
-                    type = it->type;
-                } else {
-                    type_error(node.token, "type '{}' has no field '{}'\n", type, field_name);
-                }
-            }
-
-            const auto rhs_type = typecheck_expr(ctx, *node.expr);
-            if (rhs_type != type) {
-                type_error(
-                    node.token, "(field assignment) tried to assign '{}' to '{}'\n", rhs_type, type
-                );
-            }
-            return;
-        }
-    }
-    if (auto it = ctx.globals.find(node.name); it != ctx.globals.end()) {
-        auto type = it->second;
-        for (const auto& field_name : node.fields) {
-            const auto& type_fields = ctx.types.types.get_fields(type);
-            const auto it = std::find_if(begin(type_fields), end(type_fields), [&](auto&& field) {
-                return field.name == field_name;
-            });
-            if (it != type_fields.end()) {
-                type = it->type;
-            } else {
-                type_error(node.token, "type '{}' has no field '{}'\n", type, field_name);
-            }
-        }
-
-        const auto rhs_type = typecheck_expr(ctx, *node.expr);
-        if (rhs_type != type) {
-            type_error(
-                node.token, "(field assignment) tried to assign '{}' to '{}'\n", rhs_type, type
-            );
-        }
-        return;
-    }
-    print("typechecking for node field assignment not implemented\n");
-}
-
 auto typecheck_node(typecheck_context& ctx, const node_function_def_stmt& node) -> void
 {
     ctx.functions.emplace(node.name, &node);
@@ -502,7 +451,6 @@ auto typecheck_node(typecheck_context& ctx, const node_function_def_stmt& node) 
     else {
         typecheck_function_body_with_signature(ctx, node, node.sig);
     }
-
 }
 
 auto typecheck_node(typecheck_context& ctx, const node_function_call_stmt& node) -> void

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -430,30 +430,13 @@ auto typecheck_node(typecheck_context& ctx, const node_declaration_stmt& node) -
 
 auto typecheck_node(typecheck_context& ctx, const node_assignment_stmt& node) -> void
 {
-    if (!std::holds_alternative<node_variable_expr>(*node.position)) {
-        print("currently cannot assign to a non-variable\n");
-        std::exit(1);
+    // Should potentially verify that the lhs is an lvalue, although if it isn't, it
+    // results in a compile-time failure.
+    const auto lhs = typecheck_expr(ctx, *node.position);
+    const auto rhs = typecheck_expr(ctx, *node.expr);
+    if (lhs != rhs) {
+        type_error(node.token, "cannot assign a '{}' to a '{}'\n", rhs, lhs);
     }
-    const auto& name = std::get<node_variable_expr>(*node.position).name;
-
-    const auto expr_type = typecheck_expr(ctx, *node.expr);
-    if (ctx.locals) {
-        if (auto it = ctx.locals->find(name); it != ctx.locals->end()) {
-            if (expr_type != it->second) {
-                type_error(node.token, "cannot assign to '{}', incorrect type", name);
-            }
-            return;
-        }
-    }
-
-    if (auto it = ctx.globals.find(name); it != ctx.globals.end()) {
-        if (expr_type != it->second) {
-            type_error(node.token, "cannot assign to '{}', incorrect type", name);
-        }
-        return;
-    }
-
-    type_error(node.token, "cannot assign to '{}', name not declared", name);
 }
 
 auto typecheck_node(typecheck_context& ctx, const node_field_assignment_stmt& node) -> void


### PR DESCRIPTION
* `node_assignment_stmt` now has a `node_expr_ptr` position to store to, rather than a string name. It fails the typechecker if the position expression is a different type to the value on the right, and it fails to compile if it isn't an lvalue, which is currently only vaguely defined.
* Valid expressions on the left are `node_variable_expr`, `node_field_expr` and `node_deref_expr`, the last of which is handled differently (see further down).
* `node_field_assignment_stmt` and all related code has been deleted since the standard assignment statement can handle that case now.
* Remove the `name` attribute from the `op_save_global/local` op codes.
* Add `op_save_to_addr` which pops a pointer from the top of the stack and stores the next object at that location. Used to implement assigning to a de-referenced pointer.
* Cannot currently access a field on a de-referenced pointer, that requires a change to the parser so that `(deref x).y` is not parsed as a function call. 