### PR TITLE
Expression Statements

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -1,12 +1,4 @@
-struct vec2
+fn noisy() -> null
 {
-    x: int
-    y: int
+    
 }
-
-v := vec2(1, 2)
-
-v.y = 7
-v.x = 2
-
-println(v)

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -32,7 +32,7 @@ auto print_node(const node_expr& root, int indent) -> void
             print_node(*node.rhs, indent + 1);
         },
         [&](const node_function_call_expr& node) {
-            print("{}FunctionCall (Expr): {}\n", spaces, node.function_name);
+            print("{}FunctionCall: {}\n", spaces, node.function_name);
             print("{}- Args:\n", spaces);
             for (const auto& arg : node.args) {
                 print_node(*arg, indent + 1);
@@ -126,13 +126,6 @@ auto print_node(const node_stmt& root, int indent) -> void
             });
             print(") -> {}\n", node.sig.return_type);
             print_node(*node.body, indent + 1);
-        },
-        [&](const node_function_call_stmt& node) {
-            print("{}FunctionCall (Stmt): {}\n", spaces, node.function_name);
-            print("{}- Args:\n", spaces);
-            for (const auto& arg : node.args) {
-                print_node(*arg, indent + 1);
-            }
         },
         [&](const node_expression_stmt& node) {
             print("{}Expression:\n", spaces);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -134,6 +134,10 @@ auto print_node(const node_stmt& root, int indent) -> void
                 print_node(*arg, indent + 1);
             }
         },
+        [&](const node_expression_stmt& node) {
+            print("{}Expression:\n", spaces);
+            print_node(*node.expr, indent + 1);
+        },
         [&](const node_return_stmt& node) {
             print("{}Return:\n", spaces);
             print_node(*node.return_value, indent + 1);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -171,6 +171,13 @@ struct node_function_call_stmt
     anzu::token token;
 };
 
+struct node_expression_stmt
+{
+    node_expr_ptr expr;
+
+    anzu::token token;
+};
+
 struct node_return_stmt
 {
     node_expr_ptr return_value;
@@ -190,6 +197,7 @@ struct node_stmt : std::variant<
     node_assignment_stmt,
     node_function_def_stmt,
     node_function_call_stmt,
+    node_expression_stmt,
     node_return_stmt>
 {
 };

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -163,14 +163,6 @@ struct node_function_def_stmt
     anzu::token token;
 };
 
-struct node_function_call_stmt
-{
-    std::string                function_name;
-    std::vector<node_expr_ptr> args;
-
-    anzu::token token;
-};
-
 struct node_expression_stmt
 {
     node_expr_ptr expr;
@@ -196,7 +188,6 @@ struct node_stmt : std::variant<
     node_declaration_stmt,
     node_assignment_stmt,
     node_function_def_stmt,
-    node_function_call_stmt,
     node_expression_stmt,
     node_return_stmt>
 {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -575,6 +575,13 @@ void compile_node(const node_return_stmt& node, compiler_context& ctx)
     ctx.program.emplace_back(anzu::op_return{});
 }
 
+void compile_node(const node_expression_stmt& node, compiler_context& ctx)
+{
+    compile_node(*node.expr, ctx);
+    const auto type = ctx.type_info.expr_types[node.expr.get()];
+    ctx.program.emplace_back(anzu::op_pop{ .size=ctx.type_info.types.block_size(type) });
+}
+
 auto compile_node(const node_expr& expr, compiler_context& ctx) -> void
 {
     std::visit([&](const auto& node) { compile_node(expr, node, ctx); }, expr);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -563,12 +563,6 @@ void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
     std::get<anzu::op_function>(ctx.program[begin_pos]).jump = end_pos + 1;
 }
 
-void compile_node(const node_function_call_stmt& node, compiler_context& ctx)
-{
-    const auto return_size = compile_function_call(node.function_name, node.args, ctx);
-    ctx.program.emplace_back(anzu::op_pop{ .size=return_size });
-}
-
 void compile_node(const node_return_stmt& node, compiler_context& ctx)
 {
     compile_node(*node.return_value, ctx);

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -453,11 +453,6 @@ auto typecheck_node(typecheck_context& ctx, const node_function_def_stmt& node) 
     }
 }
 
-auto typecheck_node(typecheck_context& ctx, const node_function_call_stmt& node) -> void
-{
-    typecheck_function_call(ctx, node.token, node.function_name, node.args);
-}
-
 auto typecheck_node(typecheck_context& ctx, const node_return_stmt& node) -> void
 {
     if (!ctx.locals) {

--- a/src/typecheck.cpp
+++ b/src/typecheck.cpp
@@ -458,13 +458,18 @@ auto typecheck_node(typecheck_context& ctx, const node_function_call_stmt& node)
     typecheck_function_call(ctx, node.token, node.function_name, node.args);
 }
 
-auto typecheck_node(typecheck_context& ctx, const node_return_stmt& node)
+auto typecheck_node(typecheck_context& ctx, const node_return_stmt& node) -> void
 {
     if (!ctx.locals) {
         type_error(node.token, "return statements can only be within functions");
     }
     const auto& return_type = ctx.locals->at(return_key());
     verify_expression_type(ctx, *node.return_value, return_type);
+}
+
+auto typecheck_node(typecheck_context& ctx, const node_expression_stmt& node) -> void
+{
+    typecheck_expr(ctx, *node.expr);
 }
 
 auto typecheck_node(typecheck_context& ctx, const node_stmt& node) -> void


### PR DESCRIPTION
* Current parsing was brittle, as `(deref x).y` would not parse correctly, and we could also not have statements such as `get_pointer() = 5` since that would try parsing first as a function call.
* The solution here is to remove the special case for parsing function calls, and allow for parsing an expression first, then possibly checking for an assignment.
* This change allows for any expression to be written down, even if pointless. For example, writing just `3 + 4` was invalid previously, whereas now it will correctly generate code that will evaluate the result and then immediately pop it.
* Removes the `node_function_call_stmt` statement and replaces it with `node_expression_stmt`, which has much simpler logic since it just delegates to an expression node, removing duplicate code that it shared with `node_function_call_expr`.
* Overall just produces a cleaner parser.