### PR TITLE
`size_t` instead of `intptr_t`

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -43,8 +43,8 @@ struct compiler_context
 
     struct function_def
     {
-        signature     sig;
-        std::intptr_t ptr;
+        signature   sig;
+        std::size_t ptr;
     };
 
     std::unordered_map<std::string, function_def> functions;
@@ -70,10 +70,10 @@ auto penult(std::vector<T>& elements) -> T&
 }
 
 template <typename T>
-auto append_op(compiler_context& ctx, T&& op) -> std::intptr_t
+auto append_op(compiler_context& ctx, T&& op) -> std::size_t
 {
     ctx.program.emplace_back(std::forward<T>(op));
-    return std::ssize(ctx.program) - 1;
+    return std::size(ctx.program) - 1;
 }
 
 // Registers the given name in the current scope
@@ -224,9 +224,9 @@ auto address_of_expr(const compiler_context& ctx, const node_expr& node) -> addr
 // jump past the end, and makes continues jump back to the beginning.
 auto link_up_jumps(
     compiler_context& ctx,
-    std::intptr_t loop_begin,
-    std::intptr_t loop_do,
-    std::intptr_t loop_end
+    std::size_t loop_begin,
+    std::size_t loop_do,
+    std::size_t loop_end
 )
     -> void
 {
@@ -234,13 +234,13 @@ auto link_up_jumps(
     std::get<op_jump_if_false>(ctx.program[loop_do]).jump = loop_end + 1;
         
     // Only set unset jumps, there may be other already set from nested loops
-    for (std::intptr_t idx = loop_do + 1; idx != loop_end; ++idx) {
+    for (std::size_t idx = loop_do + 1; idx != loop_end; ++idx) {
         std::visit(overloaded{
             [&](op_break& op) {
-                if (op.jump == -1) { op.jump = loop_end + 1; }
+                if (op.jump == 0) { op.jump = loop_end + 1; }
             },
             [&](op_continue& op) {
-                if (op.jump == -1) { op.jump = loop_begin; }
+                if (op.jump == 0) { op.jump = loop_begin; }
             },
             [](auto&&) {}
         }, ctx.program[idx]);
@@ -423,10 +423,10 @@ void compile_node(const node_if_stmt& node, compiler_context& ctx)
         compile_node(*node.else_body, ctx);
         ctx.program.emplace_back(anzu::op_if_end{});
         std::get<op_jump_if_false>(ctx.program[jump_pos]).jump = else_pos + 1; // Jump into the else block if false
-        std::get<op_else>(ctx.program[else_pos]).jump = std::ssize(ctx.program); // Jump past the end if false
+        std::get<op_else>(ctx.program[else_pos]).jump = std::size(ctx.program); // Jump past the end if false
     } else {
         ctx.program.emplace_back(anzu::op_if_end{});
-        std::get<op_jump_if_false>(ctx.program[jump_pos]).jump = std::ssize(ctx.program); // Jump past the end if false
+        std::get<op_jump_if_false>(ctx.program[jump_pos]).jump = std::size(ctx.program); // Jump past the end if false
     }
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -73,7 +73,7 @@ template <typename T>
 auto append_op(compiler_context& ctx, T&& op) -> std::size_t
 {
     ctx.program.emplace_back(std::forward<T>(op));
-    return std::size(ctx.program) - 1;
+    return ctx.program.size() - 1;
 }
 
 // Registers the given name in the current scope
@@ -410,10 +410,10 @@ void compile_node(const node_if_stmt& node, compiler_context& ctx)
         compile_node(*node.else_body, ctx);
         ctx.program.emplace_back(anzu::op_if_end{});
         std::get<op_jump_if_false>(ctx.program[jump_pos]).jump = else_pos + 1; // Jump into the else block if false
-        std::get<op_else>(ctx.program[else_pos]).jump = std::size(ctx.program); // Jump past the end if false
+        std::get<op_else>(ctx.program[else_pos]).jump = ctx.program.size(); // Jump past the end if false
     } else {
         ctx.program.emplace_back(anzu::op_if_end{});
-        std::get<op_jump_if_false>(ctx.program[jump_pos]).jump = std::size(ctx.program); // Jump past the end if false
+        std::get<op_jump_if_false>(ctx.program[jump_pos]).jump = ctx.program.size(); // Jump past the end if false
     }
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -297,11 +297,7 @@ auto compile_function_call(
 
 void compile_node(const node_expr& expr, const node_literal_expr& node, compiler_context& ctx)
 {
-    if (node.value.data.size() != 1) {
-        anzu::print("Objects with block-size != 1 not currently supported\n");
-        std::exit(1);
-    }
-    ctx.program.emplace_back(anzu::op_load_literal{ .value=node.value });
+    ctx.program.emplace_back(anzu::op_load_literal{ .value=node.value.data });
 }
 
 void compile_node(const node_expr& expr, const node_variable_expr& node, compiler_context& ctx)
@@ -441,7 +437,7 @@ void compile_node(const node_for_stmt& node, compiler_context& ctx)
 
     // Push the counter to the stack
     ctx.program.emplace_back(anzu::op_load_literal{
-        .value=make_int(0)
+        .value=make_int(0).data
     });
     declare_variable_name(ctx, index_name, int_type());
     save_variable(ctx, index_name);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -113,7 +113,6 @@ auto load_variable(compiler_context& ctx, const std::string& name) -> void
     if (ctx.locals) {
         if (auto it = ctx.locals->info.find(name); it != ctx.locals->info.end()) {
             ctx.program.emplace_back(anzu::op_load_local{
-                .name=name,
                 .offset=it->second.location,
                 .size=ctx.type_info.types.block_size(it->second.type)
             });
@@ -122,7 +121,6 @@ auto load_variable(compiler_context& ctx, const std::string& name) -> void
     }
     if (auto it = ctx.globals.info.find(name); it != ctx.globals.info.end()) {
         ctx.program.emplace_back(anzu::op_load_global{
-            .name=name,
             .position=it->second.location,
             .size=ctx.type_info.types.block_size(it->second.type)
         });
@@ -223,24 +221,21 @@ auto address_of_expr(const compiler_context& ctx, const node_expr& node) -> addr
 // This function links the do to jump to one past the end if false, makes breaks
 // jump past the end, and makes continues jump back to the beginning.
 auto link_up_jumps(
-    compiler_context& ctx,
-    std::size_t loop_begin,
-    std::size_t loop_do,
-    std::size_t loop_end
+    compiler_context& ctx, std::size_t begin, std::size_t jump, std::size_t end
 )
     -> void
 {
     // Jump past the end if false
-    std::get<op_jump_if_false>(ctx.program[loop_do]).jump = loop_end + 1;
+    std::get<op_jump_if_false>(ctx.program[jump]).jump = end + 1;
         
     // Only set unset jumps, there may be other already set from nested loops
-    for (std::size_t idx = loop_do + 1; idx != loop_end; ++idx) {
+    for (std::size_t idx = jump + 1; idx != end; ++idx) {
         std::visit(overloaded{
             [&](op_break& op) {
-                if (op.jump == 0) { op.jump = loop_end + 1; }
+                if (op.jump == 0) { op.jump = end + 1; }
             },
             [&](op_continue& op) {
-                if (op.jump == 0) { op.jump = loop_begin; }
+                if (op.jump == 0) { op.jump = begin; }
             },
             [](auto&&) {}
         }, ctx.program[idx]);
@@ -323,15 +318,11 @@ void compile_node(const node_expr& expr, const node_field_expr& node, compiler_c
     const auto type_size = ctx.type_info.types.block_size(addr_of.type);
     if (addr_of.is_local) {
         ctx.program.emplace_back(op_load_local{
-            .name = std::format("{}.{}", var_name, node.field_name),
-            .offset = addr_of.position,
-            .size = type_size
+            .offset = addr_of.position, .size = type_size
         });
     } else {
         ctx.program.emplace_back(op_load_global{
-            .name = std::format("{}.{}", var_name, node.field_name),
-            .position = addr_of.position,
-            .size = type_size
+            .position = addr_of.position, .size = type_size
         });
     }
 }
@@ -548,7 +539,7 @@ void compile_node(const node_assignment_stmt& node, compiler_context& ctx)
 
 void compile_node(const node_function_def_stmt& node, compiler_context& ctx)
 {
-    const auto begin_pos = append_op(ctx, op_function{ .name=node.name, .sig=node.sig });
+    const auto begin_pos = append_op(ctx, op_function{ .name=node.name });
     ctx.functions[node.name] = { .sig=node.sig ,.ptr=begin_pos };
 
     ctx.locals.emplace();

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -16,7 +16,7 @@ auto to_string(const op& op_code) -> std::string
 {
     return std::visit(overloaded {
         [&](const op_load_literal& op) {
-            return std::format("OP_LOAD_LITERAL({})", op.value);
+            return std::format("OP_LOAD_LITERAL({})", format_comma_separated(op.value));
         },
         [&](const op_load_global& op) {
             return std::format("OP_LOAD_GLOBAL({}: {})", op.position, op.size);

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -19,10 +19,10 @@ auto to_string(const op& op_code) -> std::string
             return std::format("OP_LOAD_LITERAL({})", op.value);
         },
         [&](const op_load_global& op) {
-            return std::format("OP_LOAD_GLOBAL({}: {})", op.name, op.position);
+            return std::format("OP_LOAD_GLOBAL({}: {})", op.position, op.size);
         },
         [&](const op_load_local& op) {
-            return std::format("OP_LOAD_LOCAL({}: +{})", op.name, op.offset);
+            return std::format("OP_LOAD_LOCAL({}: +{})", op.offset, op.size);
         },
         [&](const op_load_addr_of_global& op) {
             return std::format("OP_LOAD_ADDR_OF_GLOBAL({}, {})", op.position, op.size);

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -77,7 +77,7 @@ struct op_if_end
 
 struct op_else
 {
-    std::intptr_t jump = -1;
+    std::size_t jump;
 };
 
 struct op_loop_begin
@@ -86,30 +86,30 @@ struct op_loop_begin
 
 struct op_loop_end
 {
-    std::intptr_t jump = -1;
+    std::size_t jump;
 };
 
 struct op_break
 {
-    std::intptr_t jump = -1;
+    std::size_t jump;
 };
 
 struct op_continue
 {
-    std::intptr_t jump = -1;
+    std::size_t jump;
 };
 
 struct op_jump_if_false
 {
-    std::intptr_t jump = -1;
+    std::size_t jump;
 };
 
 struct op_function_call
 {
-    std::string   name;
-    std::intptr_t ptr;
-    std::size_t   args_size;
-    std::size_t   return_size;
+    std::string name;
+    std::size_t ptr;
+    std::size_t args_size;
+    std::size_t return_size;
 };
 
 struct op_builtin_call
@@ -127,9 +127,9 @@ struct op_builtin_mem_op
 
 struct op_function
 {
-    std::string   name;
-    signature     sig;
-    std::intptr_t jump;
+    std::string name;
+    signature   sig;
+    std::size_t jump;
 };
 
 struct op_function_end

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -18,14 +18,12 @@ struct op_load_literal
 
 struct op_load_global
 {
-    std::string name;
     std::size_t position;
     std::size_t size;
 };
 
 struct op_load_local
 {
-    std::string name;
     std::size_t offset;
     std::size_t size;
 };
@@ -128,7 +126,6 @@ struct op_builtin_mem_op
 struct op_function
 {
     std::string name;
-    signature   sig;
     std::size_t jump;
 };
 

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -13,7 +13,7 @@ namespace anzu {
 
 struct op_load_literal
 {
-    object value;
+    std::vector<block> value;
 };
 
 struct op_load_global

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -78,7 +78,7 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
 {
     std::visit(overloaded {
         [&](const op_load_literal& op) {
-            for (const auto& block : op.value.data) {
+            for (const auto& block : op.value) {
                 ctx.memory.push_back(block);
             }
             program_advance(ctx);

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -68,7 +68,7 @@ auto pop_frame(runtime_context& ctx) -> void
     for (std::size_t i = 0; i != return_size; ++i) {
         ctx.memory[base_ptr(ctx) + i] = ctx.memory[ctx.memory.size() - return_size + i];
     }
-    while (std::size(ctx.memory) > base_ptr(ctx) + return_size) {
+    while (ctx.memory.size() > base_ptr(ctx) + return_size) {
         ctx.memory.pop_back();
     }
     ctx.frames.pop_back();
@@ -217,7 +217,7 @@ auto run_program(const anzu::program& program) -> void
 
     runtime_context ctx;
     ctx.frames.emplace_back();
-    while (program_ptr(ctx) < std::size(program)) {
+    while (program_ptr(ctx) < program.size()) {
         apply_op(ctx, program[program_ptr(ctx)]);
     }
 }
@@ -228,7 +228,7 @@ auto run_program_debug(const anzu::program& program) -> void
 
     runtime_context ctx;
     ctx.frames.emplace_back();
-    while (program_ptr(ctx) < std::size(program)) {
+    while (program_ptr(ctx) < program.size()) {
         const auto& op = program[program_ptr(ctx)];
         anzu::print("{:>4} - {}\n", program_ptr(ctx), op);
         apply_op(ctx, program[program_ptr(ctx)]);

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -30,17 +30,17 @@ auto program_advance(runtime_context& ctx) -> void
     ctx.frames.back().program_ptr += 1;
 }
 
-auto program_jump_to(runtime_context& ctx, std::intptr_t idx) -> void
+auto program_jump_to(runtime_context& ctx, std::size_t idx) -> void
 {
     ctx.frames.back().program_ptr = idx;
 }
 
-auto program_ptr(const runtime_context& ctx) -> std::intptr_t
+auto program_ptr(const runtime_context& ctx) -> std::size_t
 {
     return ctx.frames.back().program_ptr;
 }
 
-auto base_ptr(const runtime_context& ctx) -> std::intptr_t
+auto base_ptr(const runtime_context& ctx) -> std::size_t
 {
     return ctx.frames.back().base_ptr;
 }
@@ -68,7 +68,7 @@ auto pop_frame(runtime_context& ctx) -> void
     for (std::size_t i = 0; i != return_size; ++i) {
         ctx.memory[base_ptr(ctx) + i] = ctx.memory[ctx.memory.size() - return_size + i];
     }
-    while (std::ssize(ctx.memory) > base_ptr(ctx) + (intptr_t)return_size) {
+    while (std::size(ctx.memory) > base_ptr(ctx) + return_size) {
         ctx.memory.pop_back();
     }
     ctx.frames.pop_back();
@@ -217,7 +217,7 @@ auto run_program(const anzu::program& program) -> void
 
     runtime_context ctx;
     ctx.frames.emplace_back();
-    while (program_ptr(ctx) < std::ssize(program)) {
+    while (program_ptr(ctx) < std::size(program)) {
         apply_op(ctx, program[program_ptr(ctx)]);
     }
 }
@@ -228,7 +228,7 @@ auto run_program_debug(const anzu::program& program) -> void
 
     runtime_context ctx;
     ctx.frames.emplace_back();
-    while (program_ptr(ctx) < std::ssize(program)) {
+    while (program_ptr(ctx) < std::size(program)) {
         const auto& op = program[program_ptr(ctx)];
         anzu::print("{:>4} - {}\n", program_ptr(ctx), op);
         apply_op(ctx, program[program_ptr(ctx)]);

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -8,9 +8,9 @@ namespace anzu {
 
 struct frame
 {
-    std::intptr_t program_ptr = 0;
-    std::intptr_t base_ptr = 0;
-    std::size_t   return_size = 1;
+    std::size_t program_ptr = 0;
+    std::size_t base_ptr = 0;
+    std::size_t return_size = 1;
 };
 
 struct runtime_context


### PR DESCRIPTION
* In all the places in the runtime where an `intptr_t` was used, use `size_t` instead since we don't need signed values.
* Small simplification in some places.
* For jump op codes, the unset value is now 0 instead of -1, which is also fine because a jump of 0 would be an infinite loop, so its definitely an unused value.
* When compiling a `node_literal_expr`, remove the assert than an object just only have one value, I don't think there's any harm in an op code having more than one block, even if it can't currently happen.
* Remove the `name` field from some of the op codes that didn't need it.
* `op_load_literal` now stores a `std::vector<block>` rather than an `object`, removing all type info from the runtime.