### PR TITLE
C-style Symbols for Pointers and Logical Not

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -3,9 +3,7 @@ fn inc(p: ptr<int>) -> null
     *p = *p + 1
 }
 
-x := 5
-px := &x
 
-println(x)
-inc(px)
-println(x)
+if !false {
+    println("hello")
+}

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,1 +1,11 @@
+fn inc(p: ptr<int>) -> null
+{
+    *p = *p + 1
+}
 
+x := 5
+px := &x
+
+println(x)
+inc(px)
+println(x)

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -135,6 +135,11 @@ auto resolve_unary_op(const unary_op_description& desc) -> std::optional<unary_o
             return unary_op_info{ unary_op<block_float, std::negate>, type };
         }
     }
+    if (type == bool_type()) {
+        if (desc.op == tk_bang) {
+            return unary_op_info{ unary_op<block_bool, std::logical_not>, type };
+        }
+    }
     return std::nullopt;
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -115,15 +115,15 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
         expr.token = tokens.consume();
         expr.expr = parse_single_factor(tokens);
     }
-    else if (tokens.peek(tk_addrof)) {
+    else if (tokens.peek(tk_ampersand)) {
         auto& expr = node->emplace<anzu::node_addrof_expr>();
         expr.token = tokens.consume();
-        expr.expr = parse_expression(tokens);
+        expr.expr = parse_single_factor(tokens);
     }
     else if (tokens.peek(tk_deref)) {
         auto& expr = node->emplace<anzu::node_deref_expr>();
         expr.token = tokens.consume();
-        expr.expr = parse_expression(tokens);
+        expr.expr = parse_single_factor(tokens);
     }
     else if (tokens.peek_next(tk_lparen)) {
         node = parse_function_call(tokens);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -120,7 +120,7 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
         expr.token = tokens.consume();
         expr.expr = parse_single_factor(tokens);
     }
-    else if (tokens.peek(tk_deref)) {
+    else if (tokens.peek(tk_mul)) {
         auto& expr = node->emplace<anzu::node_deref_expr>();
         expr.token = tokens.consume();
         expr.expr = parse_single_factor(tokens);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -110,7 +110,7 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
             expr.elements.push_back(parse_expression(tokens));
         });
     }
-    else if (tokens.peek(tk_sub)) {
+    else if (tokens.peek(tk_sub) || tokens.peek(tk_bang)) {
         auto& expr = node->emplace<node_unary_op_expr>();
         expr.token = tokens.consume();
         expr.expr = parse_single_factor(tokens);

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -99,14 +99,14 @@ auto generic_list_type() -> type_name
 auto concrete_ptr_type(const type_name& t) -> type_name
 {
     return {type_compound{
-        .name = "ptr", .subtypes = { t }
+        .name = std::string{tk_ptr}, .subtypes = { t }
     }};
 }
 
 auto generic_ptr_type() -> type_name
 {
     return {type_compound{
-        .name = "ptr", .subtypes = { generic_type(0) }
+        .name = std::string{tk_ptr}, .subtypes = { generic_type(0) }
     }};
 }
 

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -10,7 +10,7 @@ auto is_keyword(std::string_view token) -> bool
     static const std::unordered_set<std::string_view> tokens = {
         tk_break, tk_continue, tk_else, tk_false, tk_for, tk_if,
         tk_in, tk_null, tk_true, tk_while, tk_int, tk_float, tk_bool,
-        tk_str, tk_list, tk_function, tk_return, tk_struct, tk_deref
+        tk_str, tk_list, tk_function, tk_return, tk_struct
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -31,7 +31,8 @@ auto is_symbol(std::string_view token) -> bool
         tk_div, tk_eq, tk_ge, tk_gt, tk_lbracket, tk_le,
         tk_lparen, tk_lt, tk_mod, tk_mul, tk_ne, tk_or,
         tk_period, tk_rbracket, tk_rparen, tk_sub, tk_rarrow,
-        tk_lbrace, tk_rbrace, tk_assign, tk_declare, tk_fullstop
+        tk_lbrace, tk_rbrace, tk_assign, tk_declare, tk_fullstop,
+        tk_bang, tk_ampersand
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -10,8 +10,7 @@ auto is_keyword(std::string_view token) -> bool
     static const std::unordered_set<std::string_view> tokens = {
         tk_break, tk_continue, tk_else, tk_false, tk_for, tk_if,
         tk_in, tk_null, tk_true, tk_while, tk_int, tk_float, tk_bool,
-        tk_str, tk_list, tk_function, tk_return, tk_struct, tk_addrof,
-        tk_deref
+        tk_str, tk_list, tk_function, tk_return, tk_struct, tk_deref
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -19,7 +19,6 @@ constexpr auto tk_while     = sv{"while"};
 constexpr auto tk_function  = sv{"fn"};
 constexpr auto tk_return    = sv{"return"};
 constexpr auto tk_struct    = sv{"struct"};
-constexpr auto tk_deref     = sv{"deref"};
 
 // Builtin Types
 constexpr auto tk_int       = sv{"int"};
@@ -27,6 +26,7 @@ constexpr auto tk_float     = sv{"float"};
 constexpr auto tk_bool      = sv{"bool"};
 constexpr auto tk_str       = sv{"str"};
 constexpr auto tk_list      = sv{"list"};
+constexpr auto tk_ptr       = sv{"ptr"};
 
 // Symbols
 constexpr auto tk_add       = sv{"+"};

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -56,6 +56,8 @@ constexpr auto tk_rarrow    = sv{"->"};
 constexpr auto tk_lbrace    = sv{"{"};
 constexpr auto tk_rbrace    = sv{"}"};
 constexpr auto tk_fullstop  = sv{"."};
+constexpr auto tk_bang      = sv{"!"};
+constexpr auto tk_ampersand = sv{"&"};
 
 auto is_keyword    (sv token) -> bool;
 auto is_sentinel   (sv token) -> bool;

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -19,7 +19,6 @@ constexpr auto tk_while     = sv{"while"};
 constexpr auto tk_function  = sv{"fn"};
 constexpr auto tk_return    = sv{"return"};
 constexpr auto tk_struct    = sv{"struct"};
-constexpr auto tk_addrof    = sv{"addrof"};
 constexpr auto tk_deref     = sv{"deref"};
 
 // Builtin Types


### PR DESCRIPTION
* Replace `addrof` keyword with `&`.
* Replace `deref` keyword with `*`.
* Introduce `!` which parses as a `node_unary_op_expr` for logical not. Only usable for bools.
* Fix precedence for address of and dereference operators. Previously the argument for the operator was parsed as an entire expression, really it should be a single factor (you can apply it to an entire expression using parens). This fix was spotted when implementing arithmetic negation.
* Make `ptr` a keyword.