### PR TITLE
Generalised Assignemt: Part 2

### DIFF
--- a/examples/test.az
+++ b/examples/test.az
@@ -9,10 +9,6 @@ struct wrapper
     w: vec2
 }
 
-v := vec2(1, 2)
-
-println(v.x + 5)
-
-t := 5
-
-println(t * 2 + t)
+w := wrapper(vec2(1, 2))
+w.w.y = 5
+println(w.w.y)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,9 +1,15 @@
-fn inc(p: ptr<int>) -> null
+struct vec2
 {
-    *p = *p + 1
+    x: int
+    y: int
 }
 
-
-if !false {
-    println("hello")
+struct wrapper
+{
+    w: vec2
 }
+
+v := wrapper(vec2(1, 2))
+
+v.w.x = 5
+println(v)

--- a/examples/test.az
+++ b/examples/test.az
@@ -9,7 +9,10 @@ struct wrapper
     w: vec2
 }
 
-v := wrapper(vec2(1, 2))
+v := vec2(1, 2)
 
-v.w.x = 5
-println(v)
+println(v.x + 5)
+
+t := 5
+
+println(t * 2 + t)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,14 +1,16 @@
+
 struct vec2
 {
     x: int
     y: int
 }
 
-struct wrapper
+fn inc_y(p: ptr<vec2>) -> null
 {
-    w: vec2
+    (*p).y = 5
 }
 
-w := wrapper(vec2(1, 2))
-w.w.y = 5
-println(w.w.y)
+v := vec2(2, 3)
+inc_y(&v)
+
+println(v)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -243,6 +243,9 @@ auto address_of_expr(const compiler_context& ctx, const node_expr& node) -> addr
     }, node);
 }
 
+auto compile_node(const node_expr& root, compiler_context& ctx) -> void;
+auto compile_node(const node_stmt& root, compiler_context& ctx) -> void;
+
 auto push_address_of(compiler_context& ctx, const node_expr& node) -> void
 {
     std::visit(overloaded{
@@ -267,7 +270,7 @@ auto push_address_of(compiler_context& ctx, const node_expr& node) -> void
             });
         },
         [&](const node_deref_expr& n) {
-            // Nothing to do, the pointer is already loaded at the top.
+            compile_node(*n.expr, ctx); // Push the address
         },
         [](const auto&) {
             print("compiler error: cannot take address of a non-lvalue\n");
@@ -300,9 +303,6 @@ auto link_up_jumps(
         }, ctx.program[idx]);
     }
 }
-
-auto compile_node(const node_expr& root, compiler_context& ctx) -> void;
-auto compile_node(const node_stmt& root, compiler_context& ctx) -> void;
 
 // Returns the size of the return type
 auto compile_function_call(

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -16,76 +16,79 @@ auto to_string(const op& op_code) -> std::string
 {
     return std::visit(overloaded {
         [&](const op_load_literal& op) {
-            return std::format("OP_LOAD_LITERAL({})", format_comma_separated(op.value));
+            return std::format("LOAD_LITERAL({})", format_comma_separated(op.value));
         },
         [&](const op_push_global_addr& op) {
-            return std::format("OP_PUSH_GLOBAL_ADDR({}, {})", op.position, op.size);
+            return std::format("PUSH_GLOBAL_ADDR({}, {})", op.position, op.size);
         },
         [&](const op_push_local_addr& op) {
-            return std::format("OP_PUSH_LOCAL_ADDR(+{}, {})", op.offset, op.size);
+            return std::format("PUSH_LOCAL_ADDR(+{}, {})", op.offset, op.size);
+        },
+        [&](const op_modify_addr& op) {
+            return std::format("MODIFY_ADDR(+{}, {})", op.offset, op.new_size);
         },
         [&](const op_load&) {
-            return std::string{"OP_LOAD"};
+            return std::string{"LOAD"};
         },
         [&](const op_save& op) {
-            return std::string{"OP_SAVE"};
+            return std::string{"SAVE"};
         },
         [&](const op_pop& op) {
-            return std::format("OP_POP({})", op.size);
+            return std::format("POP({})", op.size);
         },
         [&](const op_if& op) {
-            return std::string{"OP_IF"};
+            return std::string{"IF"};
         },
         [&](const op_if_end& op) {
-            return std::string{"OP_END_IF"};
+            return std::string{"END_IF"};
         },
         [&](const op_else& op) {
             const auto jump_str = std::format("JUMP -> {}", op.jump);
-            return std::format(FORMAT2, "OP_ELSE", jump_str);
+            return std::format(FORMAT2, "ELSE", jump_str);
         },
         [&](const op_loop_begin& op) {
-            return std::string{"OP_LOOP_BEGIN"};
+            return std::string{"LOBEGIN"};
         },
         [&](const op_loop_end& op) {
             const auto jump_str = std::format("JUMP -> {}", op.jump);
-            return std::format(FORMAT2, "OP_LOOP_END", jump_str);
+            return std::format(FORMAT2, "LOOP_END", jump_str);
         },
         [&](const op_break& op) {
             const auto jump_str = std::format("JUMP -> {}", op.jump);
-            return std::format(FORMAT2, "OP_BREAK", jump_str);
+            return std::format(FORMAT2, "BREAK", jump_str);
         },
         [&](const op_continue& op) {
             const auto jump_str = std::format("JUMP -> {}", op.jump);
-            return std::format(FORMAT2, "OP_CONTINUE", jump_str);
+            return std::format(FORMAT2, "CONTINUE", jump_str);
         },
         [&](const op_jump_if_false& op) {
             const auto jump_str = std::format("JUMP -> {} IF FALSE", op.jump);
-            return std::format(FORMAT2, "OP_JUMP_IF_FALSE", jump_str);
+            return std::format(FORMAT2, "JUMP_IF_FALSE", jump_str);
         },
         [&](const op_function& op) {
-            const auto func_str = std::format("OP_FUNCTION({})", op.name);
+            const auto func_str = std::format("FUNCTION({})", op.name);
             const auto jump_str = std::format("JUMP -> {}", op.jump);
             return std::format(FORMAT2, func_str, jump_str);
         },
         [&](const op_function_end& op) {
-            return std::string{"OP_FUNCTION_END"};
+            return std::string{"FUNCTION_END"};
         },
         [&](const op_return& op) {
-            return std::string{"OP_RETURN"};
+            return std::string{"RETURN"};
         },
         [&](const op_function_call& op) {
-            const auto func_str = std::format("OP_FUNCTION_CALL({})", op.name);
+            const auto func_str = std::format("FUNCTION_CALL({})", op.name);
             const auto jump_str = std::format("JUMP -> {}", op.ptr);
             return std::format(FORMAT2, func_str, jump_str);
         },
         [&](const op_builtin_call& op) {
-            return std::format("OP_BUILTIN_CALL({})", op.name);
+            return std::format("BUILTIN_CALL({})", op.name);
         },
         [&](const op_builtin_mem_op& op) {
-            return std::format("OP_BUILTIN_MEM_OP({})", op.name);
+            return std::format("BUILTIN_MEM_OP({})", op.name);
         },
         [&](const op_build_list& op) {
-            return std::format("OP_BUILD_LIST({})", op.size);
+            return std::format("BUILD_LIST({})", op.size);
         }
     }, op_code);
 }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -18,20 +18,20 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_load_literal& op) {
             return std::format("OP_LOAD_LITERAL({})", format_comma_separated(op.value));
         },
-        [&](const op_load_addr_of_global& op) {
-            return std::format("OP_LOAD_ADDR_OF_GLOBAL({}, {})", op.position, op.size);
+        [&](const op_push_global_addr& op) {
+            return std::format("OP_PUSH_GLOBAL_ADDR({}, {})", op.position, op.size);
         },
-        [&](const op_load_addr_of_local& op) {
-            return std::format("OP_LOAD_ADDR_OF_LOCAL(+{}, {})", op.offset, op.size);
+        [&](const op_push_local_addr& op) {
+            return std::format("OP_PUSH_LOCAL_ADDR(+{}, {})", op.offset, op.size);
         },
-        [&](const op_deref&) {
-            return std::string{"OP_DEREF"};
+        [&](const op_load&) {
+            return std::string{"OP_LOAD"};
+        },
+        [&](const op_save& op) {
+            return std::string{"OP_SAVE"};
         },
         [&](const op_pop& op) {
             return std::format("OP_POP({})", op.size);
-        },
-        [&](const op_save_to_addr& op) {
-            return std::string{"OP_SAVE_TO_ADDR"};
         },
         [&](const op_if& op) {
             return std::string{"OP_IF"};

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -18,12 +18,6 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_load_literal& op) {
             return std::format("OP_LOAD_LITERAL({})", format_comma_separated(op.value));
         },
-        [&](const op_load_global& op) {
-            return std::format("OP_LOAD_GLOBAL({}: {})", op.position, op.size);
-        },
-        [&](const op_load_local& op) {
-            return std::format("OP_LOAD_LOCAL({}: +{})", op.offset, op.size);
-        },
         [&](const op_load_addr_of_global& op) {
             return std::format("OP_LOAD_ADDR_OF_GLOBAL({}, {})", op.position, op.size);
         },

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -36,12 +36,6 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_pop& op) {
             return std::format("OP_POP({})", op.size);
         },
-        [&](const op_save_global& op) {
-            return std::format("OP_SAVE_GLOBAL({}: {})", op.position, op.size);
-        },
-        [&](const op_save_local& op) {
-            return std::format("OP_SAVE_LOCAL({}: +{})", op.offset, op.size);
-        },
         [&](const op_save_to_addr& op) {
             return std::string{"OP_SAVE_TO_ADDR"};
         },

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -28,6 +28,12 @@ struct op_push_local_addr
     std::size_t size;
 };
 
+struct op_modify_addr
+{
+    std::size_t offset;
+    std::size_t new_size;
+};
+
 struct op_load
 {
 };
@@ -122,6 +128,7 @@ struct op : std::variant<
     op_load_literal,
     op_push_global_addr,
     op_push_local_addr,
+    op_modify_addr,
     op_load,
     op_save,
     op_pop,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -16,29 +16,29 @@ struct op_load_literal
     std::vector<block> value;
 };
 
-struct op_load_addr_of_global
+struct op_push_global_addr
 {
     std::size_t position;
     std::size_t size;
 };
 
-struct op_load_addr_of_local
+struct op_push_local_addr
 {
     std::size_t offset;
     std::size_t size;
 };
 
-struct op_deref
+struct op_load
+{
+};
+
+struct op_save
 {
 };
 
 struct op_pop
 {
     std::size_t size;
-};
-
-struct op_save_to_addr
-{
 };
 
 struct op_if
@@ -120,11 +120,11 @@ struct op_build_list
 
 struct op : std::variant<
     op_load_literal,
-    op_load_addr_of_global,
-    op_load_addr_of_local,
-    op_deref,
+    op_push_global_addr,
+    op_push_local_addr,
+    op_load,
+    op_save,
     op_pop,
-    op_save_to_addr,
     op_if,
     op_if_end,
     op_else,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -16,18 +16,6 @@ struct op_load_literal
     std::vector<block> value;
 };
 
-struct op_load_global
-{
-    std::size_t position;
-    std::size_t size;
-};
-
-struct op_load_local
-{
-    std::size_t offset;
-    std::size_t size;
-};
-
 struct op_load_addr_of_global
 {
     std::size_t position;
@@ -132,8 +120,6 @@ struct op_build_list
 
 struct op : std::variant<
     op_load_literal,
-    op_load_global,
-    op_load_local,
     op_load_addr_of_global,
     op_load_addr_of_local,
     op_deref,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -49,18 +49,6 @@ struct op_pop
     std::size_t size;
 };
 
-struct op_save_global
-{
-    std::size_t position;
-    std::size_t size;
-};
-
-struct op_save_local
-{
-    std::size_t offset;
-    std::size_t size;
-};
-
 struct op_save_to_addr
 {
 };
@@ -150,8 +138,6 @@ struct op : std::variant<
     op_load_addr_of_local,
     op_deref,
     op_pop,
-    op_save_global,
-    op_save_local,
     op_save_to_addr,
     op_if,
     op_if_end,

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -99,6 +99,7 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             auto& ptr = std::get<block_ptr>(ctx.memory.back());
             ptr.ptr += op.offset;
             ptr.size = op.new_size;
+            program_advance(ctx);
         },
         [&](const op_load& op) {
             const auto ptr_blk = pop_back(ctx.memory);

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -83,19 +83,19 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             }
             program_advance(ctx);
         },
-        [&](const op_load_addr_of_global& op) {
+        [&](const op_push_global_addr& op) {
             const auto idx = op.position;
             const auto ptr = block_ptr{ .ptr=idx, .size=op.size };
             ctx.memory.push_back(ptr);
             program_advance(ctx);
         },
-        [&](const op_load_addr_of_local& op) {
+        [&](const op_push_local_addr& op) {
             const auto idx = base_ptr(ctx) + op.offset;
             const auto ptr = block_ptr{ .ptr=idx, .size=op.size };
             ctx.memory.push_back(ptr);
             program_advance(ctx);
         },
-        [&](const op_deref& op) {
+        [&](const op_load& op) {
             const auto ptr_blk = pop_back(ctx.memory);
             const auto ptr = std::get<block_ptr>(ptr_blk);
             for (std::size_t i = 0; i != ptr.size; ++i) {
@@ -103,16 +103,16 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             }
             program_advance(ctx);
         },
+        [&](const op_save& op) {
+            const auto ptr_blk = pop_back(ctx.memory);
+            const auto ptr = std::get<block_ptr>(ptr_blk);
+            save_top_at(ctx, ptr.ptr, ptr.size);
+            program_advance(ctx);
+        },
         [&](const op_pop& op) {
             for (std::size_t i = 0; i != op.size; ++i) {
                 ctx.memory.pop_back();
             }
-            program_advance(ctx);
-        },
-        [&](const op_save_to_addr& op) {
-            const auto ptr_blk = pop_back(ctx.memory);
-            const auto ptr = std::get<block_ptr>(ptr_blk);
-            save_top_at(ctx, ptr.ptr, ptr.size);
             program_advance(ctx);
         },
         [&](const op_if& op) {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -83,20 +83,6 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             }
             program_advance(ctx);
         },
-        [&](const op_load_global& op) {
-            const auto idx = op.position;
-            for (std::size_t i = 0; i != op.size; ++i) {
-                ctx.memory.push_back(ctx.memory[idx + i]);
-            }
-            program_advance(ctx);
-        },
-        [&](const op_load_local& op) {
-            const auto idx = base_ptr(ctx) + op.offset;
-            for (std::size_t i = 0; i != op.size; ++i) {
-                ctx.memory.push_back(ctx.memory[idx + i]);
-            }
-            program_advance(ctx);
-        },
         [&](const op_load_addr_of_global& op) {
             const auto idx = op.position;
             const auto ptr = block_ptr{ .ptr=idx, .size=op.size };

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -95,6 +95,11 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.memory.push_back(ptr);
             program_advance(ctx);
         },
+        [&](const op_modify_addr& op) {
+            auto& ptr = std::get<block_ptr>(ctx.memory.back());
+            ptr.ptr += op.offset;
+            ptr.size = op.new_size;
+        },
         [&](const op_load& op) {
             const auto ptr_blk = pop_back(ctx.memory);
             const auto ptr = std::get<block_ptr>(ptr_blk);

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -123,14 +123,6 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             }
             program_advance(ctx);
         },
-        [&](const op_save_global& op) {
-            save_top_at(ctx, op.position, op.size);
-            program_advance(ctx);
-        },
-        [&](const op_save_local& op) {
-            save_top_at(ctx, base_ptr(ctx) + op.offset, op.size);
-            program_advance(ctx);
-        },
         [&](const op_save_to_addr& op) {
             const auto ptr_blk = pop_back(ctx.memory);
             const auto ptr = std::get<block_ptr>(ptr_blk);

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -15,7 +15,7 @@ struct frame
 
 struct runtime_context
 {
-    std::vector<frame>  frames;
+    std::vector<frame> frames;
     std::vector<block> memory;
 };
 


### PR DESCRIPTION
* The main problem solved by this PR is that statements such as `(*v).x = 5` were invalid as we couldn't access fields on deref expressions. This is because all the load op codes needed the positions known at compile time, which requires knowing the values of pointers at compile time, and we don't store value info.
* Completely changed how we save and load to memory to lean more heavily on pointers.
* Now, if we want to save, we must first load the position in memory onto the stack and use one of the op codes for storing to an address. Similarly for loading, we now always push a memory location and then deref it.
* Renamed and added/removed a lot of op codes:
* `op_load_addr_of_global` renamed to `op_push_global_addr`.
* `op_load_addr_of_local` renamed to `op_push_local_addr`.
* `op_load_global` removed.
* `op_load_local` removed.
* `op_save_global` removed.
* `op_save_local` removed.
* `op_deref` renamed to `op_load`.
* `op_save_to_addr` renamed to `op_save`.
* Added `op_modify_addr`. This is used to apply offsets to the pointer on the top of the stack as well as changing the size. This allows for resolving the addresses of fields of objects in a neat way, and allows for handling multiple field accesses at last; `v.x.y = 5` is now valid!
* Remove `address_of` and `address_of_expr`, replace with `push_address_of` which can also handle pointers. This unifies a lot of the compiler code.