### PR TITLE
Remove For Loops

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -72,23 +72,6 @@ x := null
 y := println(x)
 println(y)
 
-# For loops
-println("list test, 3 elements with a break after the second, should only see two")
-println("additionally, there is a while loop with its own break statement which should be fine")
-for elem in [1, 2, 3] {
-    println(elem)
-    if elem == 2 {
-        while true {
-            break # To make sure that this break is not affected by the for
-        }
-        break
-    }
-}
-
-new_list := [[1, 2, 3, 4]]
-for l in new_list {
-    list_push(l, 5)
-}
 println("new_list should have 5 elements:")
 println(new_list)
 
@@ -107,8 +90,10 @@ println(add3(1, 2, 3))
 
 fn print_one_to_ten() -> null
 {
-    for i in range(10) {
+    i := 0
+    while i < 10 {
         println(i)
+        i = i + 1
     }
 }
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -104,14 +104,6 @@ auto print_node(const node_stmt& root, int indent) -> void
                 print("{}  - {}: {}\n", spaces, field.name, field.type);
             }
         },
-        [&](const node_for_stmt& node) {
-            print("{}For:\n", spaces);
-            print("{}- Bind: {}\n",spaces, node.var);
-            print("{}- Container:\n",spaces);
-            print_node(*node.container, indent + 1);
-            print("{}- Body:\n",spaces);
-            print_node(*node.body, indent + 1);
-        },
         [&](const node_break_stmt& node) {
             print("{}Break\n", spaces);
         },

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -139,15 +139,6 @@ struct node_struct_stmt
     anzu::token token;
 };
 
-struct node_for_stmt
-{
-    std::string   var;
-    node_expr_ptr container;
-    node_stmt_ptr body;
-
-    anzu::token token;
-};
-
 struct node_break_stmt
 {
     anzu::token token;
@@ -202,7 +193,6 @@ struct node_stmt : std::variant<
     node_while_stmt,
     node_if_stmt,
     node_struct_stmt,
-    node_for_stmt,
     node_break_stmt,
     node_continue_stmt,
     node_declaration_stmt,

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -275,19 +275,6 @@ auto parse_if_stmt(tokenstream& tokens) -> node_stmt_ptr
     return node;
 }
 
-auto parse_for_stmt(tokenstream& tokens) -> node_stmt_ptr
-{
-    auto node = std::make_unique<anzu::node_stmt>();
-    auto& stmt = node->emplace<anzu::node_for_stmt>();
-
-    stmt.token = tokens.consume_only(tk_for);
-    stmt.var = parse_name(tokens);
-    tokens.consume_only(tk_in);
-    stmt.container = parse_expression(tokens);
-    stmt.body = parse_statement(tokens);
-    return node;
-}
-
 auto parse_struct_stmt(tokenstream& tokens) -> node_stmt_ptr
 {
     auto node = std::make_unique<anzu::node_stmt>();
@@ -352,9 +339,6 @@ auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
     }
     if (tokens.peek(tk_if)) {
         return parse_if_stmt(tokens);
-    }
-    if (tokens.peek(tk_for)) {
-        return parse_for_stmt(tokens);
     }
     if (tokens.peek(tk_struct)) {
         return parse_struct_stmt(tokens);


### PR DESCRIPTION
* For loops have been temporarily removed.
* This is because lists are completely broken for types of size 1, with size 1 types only working via a hack.
* When lists are working properly, for loops can be added back, for now they just serve as more stuff that need updating.