### PR TITLE
Stack-based Lists

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/feature_test.az", "run"],
+            "args": ["${workspaceFolder}/examples/test.az", "run"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -72,9 +72,6 @@ x := null
 y := println(x)
 println(y)
 
-println("new_list should have 5 elements:")
-println(new_list)
-
 # Allowing functions from other functions
 fn add2(x: int, y: int) -> int
 {

--- a/examples/recursion.az
+++ b/examples/recursion.az
@@ -11,6 +11,8 @@ fn fibb(n: int) -> int
     return fibb(n - 1) + fibb(n - 2)
 }
 
-for i in range(10) {
+i := 0
+while i != 10 {
     println(fibb(i))
+    i = i + 1
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,12 +1,6 @@
+y := 4
+l := [1, 2, 3, 4, 5]
 
-struct vec2
-{
-    x: int
-    y: int
-}
-
-
-v := vec2(1, 2)
-
-v.y = 5
-println(v)
+x := 5
+l[2] = 0
+println(l)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,3 +1,5 @@
 
 
-println(5.x)
+x := [1, 2, 3, 4]
+y := 5
+println(x)

--- a/examples/test.az
+++ b/examples/test.az
@@ -5,5 +5,3 @@ struct vec2
     y: int
 }
 
-x := [1, 2, 3]
-println(size_of(&x))

--- a/examples/test.az
+++ b/examples/test.az
@@ -7,8 +7,7 @@ struct vec3
     z: int
 }
 
-l := [vec3(1, 2, 3), vec3(1, 2, 3), vec3(1, 2, 3), vec3(1, 2, 3)]
+l := [1, 2, 6, 5, 3, 4]
 
-size := size_of(l) / size_of(l[0])
+println(size_of(l) / size_of(l[0]))
 
-0 < size

--- a/examples/test.az
+++ b/examples/test.az
@@ -7,5 +7,5 @@ struct vec2
 
 x := [1, 2, 3, 4]
 
-x[1] = 4
-println(x)
+x[2] = 4
+println(x[3])

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,6 +1,14 @@
-y := 4
-l := [1, 2, 3, 4, 5]
 
-x := 5
-l[2] = 0
-println(l)
+
+struct vec3
+{
+    x: int
+    y: int
+    z: int
+}
+
+l := [vec3(1, 2, 3), vec3(1, 2, 3), vec3(1, 2, 3), vec3(1, 2, 3)]
+
+size := size_of(l) / size_of(l[0])
+
+0 < size

--- a/examples/test.az
+++ b/examples/test.az
@@ -5,7 +5,8 @@ struct vec2
     y: int
 }
 
-x := [1, 2, 3, 4]
 
-x[2] = 4
-println(x[3])
+v := vec2(1, 2)
+
+v.y = 5
+println(v)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,9 @@
 
+struct vec2
+{
+    x: int
+    y: int
+}
 
-x := [1, 2, 3, 4]
-y := 5
-println(x)
+x := [1, 2, 3]
+println(size_of(&x))

--- a/examples/test.az
+++ b/examples/test.az
@@ -5,3 +5,7 @@ struct vec2
     y: int
 }
 
+x := [1, 2, 3, 4]
+
+x[1] = 4
+println(x)

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -73,7 +73,8 @@ auto print_node(const node_expr& root, int indent) -> void
             print("{}Subscript:\n", spaces);
             print("{}- Expr:\n", spaces);
             print_node(*node.expr, indent + 1);
-            print("{}- Index: {}:\n", spaces, node.index);
+            print("{}- Index:\n", spaces);
+            print_node(*node.index, indent + 1);
         }
     }, root);
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -64,6 +64,10 @@ auto print_node(const node_expr& root, int indent) -> void
         [&](const node_deref_expr& node) {
             print("{}Deref:\n", spaces);
             print_node(*node.expr, indent + 1);
+        },
+        [&](const node_sizeof_expr& node) {
+            print("{}SizeOf:\n", spaces);
+            print_node(*node.expr, indent + 1);
         }
     }, root);
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -68,6 +68,12 @@ auto print_node(const node_expr& root, int indent) -> void
         [&](const node_sizeof_expr& node) {
             print("{}SizeOf:\n", spaces);
             print_node(*node.expr, indent + 1);
+        },
+        [&](const node_subscript_expr& node) {
+            print("{}Subscript:\n", spaces);
+            print("{}- Expr:\n", spaces);
+            print_node(*node.expr, indent + 1);
+            print("{}- Index: {}:\n", spaces, node.index);
         }
     }, root);
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -87,6 +87,13 @@ struct node_deref_expr
     anzu::token token;
 };
 
+struct node_sizeof_expr
+{
+    node_expr_ptr expr;
+
+    anzu::token token;
+};
+
 struct node_expr : std::variant<
     // Rvalue expressions
     node_literal_expr,
@@ -95,6 +102,7 @@ struct node_expr : std::variant<
     node_function_call_expr,
     node_list_expr,
     node_addrof_expr,
+    node_sizeof_expr,
 
     // Lvalue expressions
     node_variable_expr,

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -97,8 +97,8 @@ struct node_sizeof_expr
 struct node_subscript_expr
 {
     node_expr_ptr expr;
-    int           index; // TODO: Make into an expr
-
+    node_expr_ptr index;
+    
     anzu::token token;
 };
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -94,6 +94,14 @@ struct node_sizeof_expr
     anzu::token token;
 };
 
+struct node_subscript_expr
+{
+    node_expr_ptr expr;
+    int           index; // TODO: Make into an expr
+
+    anzu::token token;
+};
+
 struct node_expr : std::variant<
     // Rvalue expressions
     node_literal_expr,
@@ -108,7 +116,8 @@ struct node_expr : std::variant<
     node_variable_expr,
     node_field_expr,
     node_arrow_expr,
-    node_deref_expr>
+    node_deref_expr,
+    node_subscript_expr>
 {
 };
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -515,9 +515,6 @@ auto compile_expr_val(compiler& com, const node_sizeof_expr& node) -> type_name
 {
     const auto type = type_of_expr(com, *node.expr);
     auto size_of = com.types.size_of(type);
-    if (std::holds_alternative<type_list>(type)) {
-        size_of /= com.types.size_of(std::get<type_list>(type).inner_type[0]);
-    }
     com.program.emplace_back(op_load_literal{
         .value={ static_cast<block_int>(size_of) }
     });

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -382,14 +382,14 @@ auto compile_expr_val(compiler& com, const node_list_expr& node) -> type_name
 {
     compiler_assert(!node.elements.empty(), node.token, "currently do not support empty list literals");
 
-    auto element_view = node.elements | std::views::reverse;
-    const auto inner_type = compile_expr_val(com, *element_view.front());
-    for (const auto& element : element_view | std::views::drop(1)) {
+    const auto inner_type = compile_expr_val(com, *node.elements.front());
+    for (const auto& element : node.elements | std::views::drop(1)) {
         const auto element_type = compile_expr_val(com, *element);
         compiler_assert(element_type == inner_type, node.token, "list has mismatching element types");
     }
-    com.program.emplace_back(op_build_list{ .size = node.elements.size() });
-    return concrete_list_type(inner_type);
+    //com.program.emplace_back(op_build_list{ .size = node.elements.size() });
+    //return concrete_list_type(inner_type);
+    return type_name{type_list{ .inner_type={inner_type}, .count=node.elements.size() }};
 }
 
 auto compile_expr_val(compiler& com, const node_addrof_expr& node) -> type_name

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -11,22 +11,6 @@
 namespace anzu {
 namespace {
 
-auto builtin_list_push(std::span<const block> args) -> block
-{
-    auto& list = std::get<block_list>(args[0]);
-    auto& obj = args[1];
-    list->push_back(obj);
-    return block{block_null{}};
-}
-
-auto builtin_list_pop(std::span<const block> args) -> block
-{
-    auto& list = std::get<block_list>(args[0]);
-    auto ret = list->back();
-    list->pop_back();
-    return ret;
-}
-
 auto builtin_list_size(std::span<const block> args) -> block
 {
     const auto& list = std::get<block_list>(args[0]);
@@ -125,27 +109,6 @@ auto builtin_range(std::span<const block> args) -> block
 auto construct_builtin_map() -> std::unordered_map<std::string, builtin>
 {
     auto builtins = std::unordered_map<std::string, builtin>{};
-
-    builtins.emplace("list_push", builtin{
-        .ptr = builtin_list_push,
-        .sig = {
-            .args = {
-                { .name = "list_obj", .type = generic_list_type() },
-                { .name = "value",    .type = generic_type(0)  }
-            },
-            .return_type = null_type()
-        }
-    });
-
-    builtins.emplace("list_pop", builtin{
-        .ptr = builtin_list_pop,
-        .sig = {
-            .args = {
-                { .name = "list_obj", .type = generic_list_type() }
-            },
-            .return_type = generic_type(0)
-        }
-    });
 
     builtins.emplace("list_size", builtin{
         .ptr = builtin_list_size,

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -11,19 +11,6 @@
 namespace anzu {
 namespace {
 
-auto builtin_list_size(std::span<const block> args) -> block
-{
-    const auto& list = std::get<block_list>(args[0]);
-    return block{static_cast<int>(list->size())};
-}
-
-auto builtin_list_at(std::span<const block> args) -> block
-{
-    const auto& list = std::get<block_list>(args[0]);
-    const auto& idx = std::get<block_int>(args[1]);
-    return list->at(idx);
-}
-
 auto builtin_str_size(std::span<const block> args) -> block
 {
     const auto& str = std::get<block_str>(args[0]);
@@ -94,42 +81,11 @@ auto builtin_input(std::span<const block> args) -> block
     return block{in};
 }
 
-auto builtin_range(std::span<const block> args) -> block
-{
-    const auto& max = std::get<block_int>(args[0]);
-    auto list = std::make_shared<std::vector<block>>();
-    for (int i = 0; i != max; ++i) {
-        list->push_back(block{i});
-    }
-    return block{list};
-}
-
 }
 
 auto construct_builtin_map() -> std::unordered_map<std::string, builtin>
 {
     auto builtins = std::unordered_map<std::string, builtin>{};
-
-    builtins.emplace("list_size", builtin{
-        .ptr = builtin_list_size,
-        .sig = {
-            .args = {
-                { .name = "list_obj", .type = generic_list_type() }
-            },
-            .return_type = int_type()
-        }
-    });
-
-    builtins.emplace("list_at", builtin{
-        .ptr = builtin_list_at,
-        .sig = {
-            .args = {
-                { .name = "list_obj", .type = generic_list_type() },
-                { .name = "index",    .type = int_type() }
-            },
-            .return_type = generic_type(0)
-        }
-    });
 
     builtins.emplace("str_size", builtin{
         .ptr = builtin_str_size,
@@ -177,16 +133,6 @@ auto construct_builtin_map() -> std::unordered_map<std::string, builtin>
         .sig = {
             .args = {},
             .return_type = str_type()
-        }
-    });
-
-    builtins.emplace("range", builtin{
-        .ptr = builtin_range,
-        .sig = {
-            .args = {
-                { .name = "max", .type = int_type() }
-            },
-            .return_type = concrete_list_type(int_type())
         }
     });
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -27,7 +27,7 @@ auto to_string(const block& blk) -> std::string
     return std::visit(overloaded {
         [](const block_str& v) { return std::format("'{}'", v); },
         [](const block_list& v) { return list_repr(v); },
-        [](block_ptr ptr) { return std::format("{:x}", ptr.ptr); },
+        [](block_ptr ptr) { return std::format("[{:x}:{}]", ptr.ptr, ptr.size); },
         [](block_null) { return std::string{"null"}; },
         [](auto&& val) { return std::format("{}", val); }
     }, blk);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -15,18 +15,12 @@ auto format_error(const std::string& str) -> void
     std::exit(1);
 }
 
-auto list_repr(const block_list& list) -> std::string
-{
-    return std::format("[{}]", format_comma_separated(*list));
-}
-
 }
 
 auto to_string(const block& blk) -> std::string
 {
     return std::visit(overloaded {
         [](const block_str& v) { return std::format("'{}'", v); },
-        [](const block_list& v) { return list_repr(v); },
         [](block_ptr ptr) { return std::format("[{:x}:{}]", ptr.ptr, ptr.size); },
         [](block_null) { return std::string{"null"}; },
         [](auto&& val) { return std::format("{}", val); }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -28,7 +28,6 @@ using block_int   = int;
 using block_float = double;
 using block_bool  = bool;
 using block_str   = std::string;
-using block_list  = std::shared_ptr<std::vector<block>>;
 using block_ptr   = pointer;
 using block_null  = std::monostate;
 
@@ -40,7 +39,6 @@ struct block : std::variant<
     block_float,
     block_bool,
     block_str,
-    block_list,
     block_ptr,
     block_null
 >

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -58,7 +58,7 @@ auto resolve_binary_op(const binary_op_description& desc) -> std::optional<binar
         } else if (desc.op == tk_mul) {
             return binary_op_info{ bin_op<block_int, std::multiplies>, type };
         } else if (desc.op == tk_div) {
-            return binary_op_info{ int_division, type };
+            return binary_op_info{ int_division, float_type() };
         } else if (desc.op == tk_mod) {
             return binary_op_info{ bin_op<block_int, std::modulus>, type };
         } else if (desc.op == tk_lt) {

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -39,7 +39,7 @@ auto unary_op(std::vector<block>& mem)
 
 }
 
-auto resolve_bin_op(const bin_op_description& desc) -> std::optional<bin_op_info>
+auto resolve_binary_op(const binary_op_description& desc) -> std::optional<binary_op_info>
 {
     if (desc.lhs != desc.rhs) {
         return std::nullopt;
@@ -52,70 +52,70 @@ auto resolve_bin_op(const bin_op_description& desc) -> std::optional<bin_op_info
 
     if (type == int_type()) {
         if (desc.op == tk_add) {
-            return bin_op_info{ bin_op<block_int, std::plus>, type };
+            return binary_op_info{ bin_op<block_int, std::plus>, type };
         } else if (desc.op == tk_sub) {
-            return bin_op_info{ bin_op<block_int, std::minus>, type };
+            return binary_op_info{ bin_op<block_int, std::minus>, type };
         } else if (desc.op == tk_mul) {
-            return bin_op_info{ bin_op<block_int, std::multiplies>, type };
+            return binary_op_info{ bin_op<block_int, std::multiplies>, type };
         } else if (desc.op == tk_div) {
-            return bin_op_info{ int_division, type };
+            return binary_op_info{ int_division, type };
         } else if (desc.op == tk_mod) {
-            return bin_op_info{ bin_op<block_int, std::modulus>, type };
+            return binary_op_info{ bin_op<block_int, std::modulus>, type };
         } else if (desc.op == tk_lt) {
-            return bin_op_info{ bin_op<block_int, std::less>, bool_type() };
+            return binary_op_info{ bin_op<block_int, std::less>, bool_type() };
         } else if (desc.op == tk_le) {
-            return bin_op_info{ bin_op<block_int, std::less_equal>, bool_type() };
+            return binary_op_info{ bin_op<block_int, std::less_equal>, bool_type() };
         } else if (desc.op == tk_gt) {
-            return bin_op_info{ bin_op<block_int, std::greater>, bool_type() };
+            return binary_op_info{ bin_op<block_int, std::greater>, bool_type() };
         } else if (desc.op == tk_ge) {
-            return bin_op_info{ bin_op<block_int, std::greater_equal>, bool_type() };
+            return binary_op_info{ bin_op<block_int, std::greater_equal>, bool_type() };
         } else if (desc.op == tk_eq) {
-            return bin_op_info{ bin_op<block_int, std::equal_to>, bool_type() };
+            return binary_op_info{ bin_op<block_int, std::equal_to>, bool_type() };
         } else if (desc.op == tk_ne) {
-            return bin_op_info{ bin_op<block_int, std::not_equal_to>, bool_type() };
+            return binary_op_info{ bin_op<block_int, std::not_equal_to>, bool_type() };
         }
     }
     else if (type == float_type()) {
         if (desc.op == tk_add) {
-            return bin_op_info{ bin_op<block_float, std::plus>, type };
+            return binary_op_info{ bin_op<block_float, std::plus>, type };
         } else if (desc.op == tk_sub) {
-            return bin_op_info{ bin_op<block_float, std::minus>, type };
+            return binary_op_info{ bin_op<block_float, std::minus>, type };
         } else if (desc.op == tk_mul) {
-            return bin_op_info{ bin_op<block_float, std::multiplies>, type };
+            return binary_op_info{ bin_op<block_float, std::multiplies>, type };
         } else if (desc.op == tk_div) {
-            return bin_op_info{ bin_op<block_float, std::divides>, type };
+            return binary_op_info{ bin_op<block_float, std::divides>, type };
         } else if (desc.op == tk_lt) {
-            return bin_op_info{ bin_op<block_float, std::less>, bool_type() };
+            return binary_op_info{ bin_op<block_float, std::less>, bool_type() };
         } else if (desc.op == tk_le) {
-            return bin_op_info{ bin_op<block_float, std::less_equal>, bool_type() };
+            return binary_op_info{ bin_op<block_float, std::less_equal>, bool_type() };
         } else if (desc.op == tk_gt) {
-            return bin_op_info{ bin_op<block_float, std::greater>, bool_type() };
+            return binary_op_info{ bin_op<block_float, std::greater>, bool_type() };
         } else if (desc.op == tk_ge) {
-            return bin_op_info{ bin_op<block_float, std::greater_equal>, bool_type() };
+            return binary_op_info{ bin_op<block_float, std::greater_equal>, bool_type() };
         } else if (desc.op == tk_eq) {
-            return bin_op_info{ bin_op<block_float, std::equal_to>, bool_type() };
+            return binary_op_info{ bin_op<block_float, std::equal_to>, bool_type() };
         } else if (desc.op == tk_ne) {
-            return bin_op_info{ bin_op<block_float, std::not_equal_to>, bool_type() };
+            return binary_op_info{ bin_op<block_float, std::not_equal_to>, bool_type() };
         }
     }
     else if (type == bool_type()) {
         if (desc.op == tk_eq) {
-            return bin_op_info{ bin_op<block_bool, std::equal_to>, type };
+            return binary_op_info{ bin_op<block_bool, std::equal_to>, type };
         } else if (desc.op == tk_ne) {
-            return bin_op_info{ bin_op<block_bool, std::not_equal_to>, type };
+            return binary_op_info{ bin_op<block_bool, std::not_equal_to>, type };
         } else if (desc.op == tk_and) {
-            return bin_op_info{ bin_op<block_bool, std::logical_and>, type };
+            return binary_op_info{ bin_op<block_bool, std::logical_and>, type };
         } else if (desc.op == tk_or) {
-            return bin_op_info{ bin_op<block_bool, std::logical_or>, type };
+            return binary_op_info{ bin_op<block_bool, std::logical_or>, type };
         }
     }
     else if (type == str_type()) {
         if (desc.op == tk_add) {
-            return bin_op_info{ bin_op<block_str, std::plus>, type };
+            return binary_op_info{ bin_op<block_str, std::plus>, type };
         } else if (desc.op == tk_eq) {
-            return bin_op_info{ bin_op<block_str, std::equal_to>, bool_type() };
+            return binary_op_info{ bin_op<block_str, std::equal_to>, bool_type() };
         } else if (desc.op == tk_ne) {
-            return bin_op_info{ bin_op<block_str, std::not_equal_to>, bool_type() };
+            return binary_op_info{ bin_op<block_str, std::not_equal_to>, bool_type() };
         }
     }
 

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -46,7 +46,7 @@ auto resolve_binary_op(const binary_op_description& desc) -> std::optional<binar
     }
     const auto& type = desc.lhs;
     
-    if (match(type, generic_list_type()).has_value()) { // No support for having these in bin ops.
+    if (is_list_type(type)) { // No support for having these in bin ops.
         return std::nullopt;
     }
 

--- a/src/operators.hpp
+++ b/src/operators.hpp
@@ -10,20 +10,20 @@ namespace anzu {
 
 using builtin_mem_op = std::function<void(std::vector<block>& memory)>;
 
-struct bin_op_description
+struct binary_op_description
 {
     std::string op;
     type_name   lhs;
     type_name   rhs;
 };
 
-struct bin_op_info
+struct binary_op_info
 {
     builtin_mem_op operator_func;
     type_name      result_type;
 };
 
-auto resolve_bin_op(const bin_op_description& desc) -> std::optional<bin_op_info>;
+auto resolve_binary_op(const binary_op_description& desc) -> std::optional<binary_op_info>;
 
 struct unary_op_description
 {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -161,7 +161,7 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
         } else {
             auto& expr = new_node->emplace<node_subscript_expr>();
             expr.token = tokens.consume();
-            expr.index = tokens.consume_int();
+            expr.index = parse_expression(tokens);
             tokens.consume_only(tk_rbracket);
             expr.expr = std::move(node);
         }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -120,6 +120,13 @@ auto parse_single_factor(tokenstream& tokens) -> node_expr_ptr
         expr.token = tokens.consume();
         expr.expr = parse_single_factor(tokens);
     }
+    else if (tokens.peek(tk_size_of)) {
+        auto& expr = node->emplace<node_sizeof_expr>();
+        expr.token = tokens.consume();
+        tokens.consume_only(tk_lparen);
+        expr.expr = parse_expression(tokens);
+        tokens.consume_only(tk_rparen);
+    }
     else if (tokens.peek(tk_mul)) {
         auto& expr = node->emplace<anzu::node_deref_expr>();
         expr.token = tokens.consume();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -220,7 +220,7 @@ auto parse_type(tokenstream& tokens) -> type_name
             compound.subtypes.push_back(parse_type(tokens));
         });
         return ret;
-    }
+    } else 
     
     return { type_simple{ .name = type_name_text } };
 }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -24,9 +24,6 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_push_local_addr& op) {
             return std::format("PUSH_LOCAL_ADDR(+{}, {})", op.offset, op.size);
         },
-        [&](const op_modify_addr& op) {
-            return std::format("MODIFY_ADDR(+{}, {})", op.offset, op.new_size);
-        },
         [&](const op_modify_ptr& op) {
             return std::string{"MODIFY_PTR"};
         },

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -86,9 +86,6 @@ auto to_string(const op& op_code) -> std::string
         },
         [&](const op_builtin_mem_op& op) {
             return std::format("BUILTIN_MEM_OP({})", op.name);
-        },
-        [&](const op_build_list& op) {
-            return std::format("BUILD_LIST({})", op.size);
         }
     }, op_code);
 }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -27,6 +27,9 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_modify_addr& op) {
             return std::format("MODIFY_ADDR(+{}, {})", op.offset, op.new_size);
         },
+        [&](const op_modify_ptr& op) {
+            return std::string{"MODIFY_PTR"};
+        },
         [&](const op_load&) {
             return std::string{"LOAD"};
         },

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -119,11 +119,6 @@ struct op_return
 {
 };
 
-struct op_build_list
-{
-    std::size_t size;
-};
-
 struct op : std::variant<
     op_load_literal,
     op_push_global_addr,
@@ -145,8 +140,7 @@ struct op : std::variant<
     op_function_end,
     op_return,
     op_function_call,
-    op_builtin_call,
-    op_build_list
+    op_builtin_call
 >
 {};
 

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -28,12 +28,6 @@ struct op_push_local_addr
     std::size_t size;
 };
 
-struct op_modify_addr
-{
-    std::size_t offset;
-    std::size_t new_size;
-};
-
 struct op_modify_ptr
 {
 };
@@ -127,7 +121,6 @@ struct op : std::variant<
     op_load_literal,
     op_push_global_addr,
     op_push_local_addr,
-    op_modify_addr,
     op_modify_ptr,
     op_load,
     op_save,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -34,6 +34,10 @@ struct op_modify_addr
     std::size_t new_size;
 };
 
+struct op_modify_ptr
+{
+};
+
 struct op_load
 {
 };
@@ -124,6 +128,7 @@ struct op : std::variant<
     op_push_global_addr,
     op_push_local_addr,
     op_modify_addr,
+    op_modify_ptr,
     op_load,
     op_save,
     op_pop,

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -95,15 +95,9 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.memory.push_back(ptr);
             program_advance(ctx);
         },
-        [&](const op_modify_addr& op) {
-            auto& ptr = std::get<block_ptr>(ctx.memory.back());
-            ptr.ptr += op.offset;
-            ptr.size = op.new_size;
-            program_advance(ctx);
-        },
         [&](op_modify_ptr) {
-            const auto offset = std::get<block_int>(pop_back(ctx.memory));
             const auto size = std::get<block_int>(pop_back(ctx.memory));
+            const auto offset = std::get<block_int>(pop_back(ctx.memory));
             auto& ptr = std::get<block_ptr>(ctx.memory.back());
             ptr.ptr += offset;
             ptr.size = size;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -183,14 +183,6 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
         [&](const op_builtin_mem_op& op) {
             op.ptr(ctx.memory);
             program_advance(ctx);
-        },
-        [&](const op_build_list& op) {
-            auto list = std::make_shared<std::vector<anzu::block>>();
-            for (std::size_t i = 0; i != op.size; ++i) {
-                list->push_back(pop_back(ctx.memory));
-            }
-            ctx.memory.push_back(block{list});
-            program_advance(ctx);
         }
     }, op_code);
 }

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -101,7 +101,15 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ptr.size = op.new_size;
             program_advance(ctx);
         },
-        [&](const op_load& op) {
+        [&](op_modify_ptr) {
+            const auto offset = std::get<block_int>(pop_back(ctx.memory));
+            const auto size = std::get<block_int>(pop_back(ctx.memory));
+            auto& ptr = std::get<block_ptr>(ctx.memory.back());
+            ptr.ptr += offset;
+            ptr.size = size;
+            program_advance(ctx);
+        },
+        [&](op_load) {
             const auto ptr_blk = pop_back(ctx.memory);
             const auto ptr = std::get<block_ptr>(ptr_blk);
             for (std::size_t i = 0; i != ptr.size; ++i) {
@@ -109,7 +117,7 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             }
             program_advance(ctx);
         },
-        [&](const op_save& op) {
+        [&](op_save) {
             const auto ptr_blk = pop_back(ctx.memory);
             const auto ptr = std::get<block_ptr>(ptr_blk);
             save_top_at(ctx, ptr.ptr, ptr.size);

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -280,6 +280,11 @@ auto type_store::size_of(const type_name& t) const -> std::size_t
         return 1; // Hack to make lists work (for fundamentals) for now. Should be 0 or exception
     }
 
+    if (std::holds_alternative<type_list>(t)) {
+        const auto& list = std::get<type_list>(t);
+        return size_of(list.inner_type[0]) * list.count;
+    }
+
     if (auto it = d_classes.find(t); it != d_classes.end()) {
         auto size = std::size_t{0};
         for (const auto& field : it->second) {

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -93,23 +93,23 @@ auto generic_type(int id) -> type_name
     return {type_generic{ .id = id }};
 }
 
-auto concrete_list_type(const type_name& t) -> type_name
+auto concrete_list_type(const type_name& t, std::size_t size) -> type_name
 {
-    return {type_compound{
-        .name = std::string{tk_list}, .subtypes = { t }
+    return {type_list{
+        .inner_type = { t }, .count = size
     }};
 }
 
-auto generic_list_type() -> type_name
+auto generic_list_type(std::size_t size) -> type_name
 {
-    return {type_compound{
-        .name = std::string{tk_list}, .subtypes = { generic_type(0) }
+    return {type_list{
+        .inner_type = { generic_type(0) }, .count = size
     }};
 }
 
 auto is_list_type(const type_name& t) -> bool
 {
-    return std::holds_alternative<type_compound>(t) && std::get<type_compound>(t).name == tk_list;
+    return std::holds_alternative<type_list>(t);
 }
 
 auto concrete_ptr_type(const type_name& t) -> type_name
@@ -159,8 +159,8 @@ auto is_type_fundamental(const type_name& type) -> bool
         || type == bool_type()
         || type == str_type()
         || type == null_type()
-        || match(type, generic_list_type())
-        || match(type, generic_ptr_type());
+        || is_list_type(type)
+        || is_ptr_type(type);
 }
 
 // Loads each key/value pair from src into dst. If the key already exists in dst and has a

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -20,9 +20,16 @@ struct type_simple
     auto operator==(const type_simple&) const -> bool = default;
 };
 
+struct type_list
+{
+    std::vector<type_name> inner_type; // Should be a value_ptr
+    std::size_t            count;
+    auto operator==(const type_list&) const -> bool = default;
+};
+
 struct type_compound
 {
-    std::string       name;
+    std::string            name;
     std::vector<type_name> subtypes;
     auto operator==(const type_compound&) const -> bool = default;
 };
@@ -33,7 +40,13 @@ struct type_generic
     auto operator==(const type_generic&) const -> bool = default;
 };
 
-struct type_name : public std::variant<type_simple, type_compound, type_generic> {};
+struct type_name : public std::variant<
+    type_simple,
+    type_list,
+    type_compound,
+    type_generic>
+{
+};
 
 
 struct field
@@ -46,11 +59,13 @@ struct field
 using type_fields = std::vector<field>;
 
 auto to_string(const type_name& type) -> std::string;
+auto to_string(const type_list& type) -> std::string;
 auto to_string(const type_simple& type) -> std::string;
 auto to_string(const type_compound& type) -> std::string;
 auto to_string(const type_generic& type) -> std::string;
 
 auto hash(const type_name& type) -> std::size_t;
+auto hash(const type_list& type) -> std::size_t;
 auto hash(const type_simple& type) -> std::size_t;
 auto hash(const type_compound& type) -> std::size_t;
 auto hash(const type_generic& type) -> std::size_t;

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -82,8 +82,8 @@ inline auto make_type(const std::string& name) -> type_name
     return { type_simple{ .name=name } };
 }
 
-auto concrete_list_type(const type_name& t) -> type_name;
-auto generic_list_type() -> type_name;
+auto concrete_list_type(const type_name& t, std::size_t size) -> type_name;
+auto generic_list_type(std::size_t size) -> type_name;
 auto is_list_type(const type_name& t) -> bool;
 
 auto concrete_ptr_type(const type_name& t) -> type_name;

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -10,7 +10,7 @@ auto is_keyword(std::string_view token) -> bool
     static const std::unordered_set<std::string_view> tokens = {
         tk_break, tk_continue, tk_else, tk_false, tk_for, tk_if,
         tk_in, tk_null, tk_true, tk_while, tk_int, tk_float, tk_bool,
-        tk_str, tk_list, tk_function, tk_return, tk_struct
+        tk_str, tk_list, tk_function, tk_return, tk_struct, tk_size_of
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -19,6 +19,7 @@ constexpr auto tk_while     = sv{"while"};
 constexpr auto tk_function  = sv{"fn"};
 constexpr auto tk_return    = sv{"return"};
 constexpr auto tk_struct    = sv{"struct"};
+constexpr auto tk_size_of   = sv{"size_of"};
 
 // Builtin Types
 constexpr auto tk_int       = sv{"int"};


### PR DESCRIPTION
* `block_list` is now gone, with lists being stored directly in memory on the stack.
* Added `type_list` to the type variant. The next step will be to remove all generic stuff since it is completely broken, and bake lists and pointers into the language type system properly.
* Lists now act like arrays in that they cannot be resized.
* Added in `type_of_expr` to the compiler, which works out the type of an expression without evaluating it. This duplicates a bit of code which can hopefully be cleaned up later.
* Remove all the list builtin functions.
* Remove `op_build_list`.
* Replace `op_modify_addr` with `op_modify_ptr`. These do the same thing, except that `op_modify_ptr` fetches the offset and size from the stack, rather than it being baked into the op code. This allows for modifying a pointer with runtime values. Used in the subscription operator below.
* Added `node_subscript_expr`, a lvalue expression of the form `x[y]`. Here, `x` can be any expression that results in a list, and `y` can be any expression resulting in an int.
* Added `node_sizeof_expr`  an rvalue expression of the form `size_of(x)`. Here `x` can be any expression.
* The size_of operator can be used to work out the length of a list via `size_of(l) / size_of(l[0])` like in C, however this currently results in a float and we have no way of casting between types or comparing ints and floats just yet, so it is a bit useless.