### PR TITLE
Remove Generic Types

### DIFF
--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -110,14 +110,14 @@ my_vec.x = 5
 println(my_vec.x)
 
 # Pointers
-ptr_value := 5
-ptr := &ptr_value
+p_value := 5
+p := &p_value
 
-fn hack() -> null {} # Needed otherwise the parser tries to parse "&ptr_value * ptr". Need semi-colons
+fn hack() -> null {} # Needed otherwise the parser tries to parse "&p_value * ptr". Need semi-colons
 
-*ptr = 6
-println("ptr_value should now equal 6:")
-println(ptr_value)
+*p = 6
+println("p_value should now equal 6:")
+println(p_value)
 
 # Lists
 xl := [1, 2, 3, 4]

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,13 +1,13 @@
 
 
-struct vec3
+fn foo(l: ptr<list<int, 5>>) -> null
 {
-    x: int
-    y: int
-    z: int
+    idx := 0
+    while idx != 5 {
+        println((*l)[idx])
+        idx = idx + 1
+    }
 }
 
-l := [1, 2, 6, 5, 3, 4]
-
-println(size_of(l) / size_of(l[0]))
-
+l := [1, 2, 3, 4, 5]
+foo(&l)

--- a/examples/test.az
+++ b/examples/test.az
@@ -9,5 +9,7 @@ fn foo(l: ptr<list<int, 5>>) -> null
     }
 }
 
+x := 5
+
 l := [1, 2, 3, 4, 5]
 foo(&l)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -500,9 +500,7 @@ auto compile_expr_val(compiler& com, const node_list_expr& node) -> type_name
         const auto element_type = compile_expr_val(com, *element);
         compiler_assert(element_type == inner_type, node.token, "list has mismatching element types");
     }
-    //com.program.emplace_back(op_build_list{ .size = node.elements.size() });
-    //return concrete_list_type(inner_type);
-    return type_name{type_list{ .inner_type={inner_type}, .count=node.elements.size() }};
+    return concrete_list_type(inner_type, node.elements.size());
 }
 
 auto compile_expr_val(compiler& com, const node_addrof_expr& node) -> type_name

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -78,7 +78,7 @@ auto current_vars(compiler& com) -> var_locations&
 
 auto verify_real_type(const compiler& com, const token& tok, const type_name& t) -> void
 {
-    if (!com.types.is_valid(t)) {
+    if (!com.types.contains(t)) {
         compiler_error(tok, "{} is not a recognised type", t);
     }
 }
@@ -452,7 +452,7 @@ auto compile_expr_val(compiler& com, const node_function_call_expr& node) -> typ
     // If this is the name of a simple type, then this is a constructor call, so
     // there is currently nothing to do since the arguments are already pushed to
     // the stack.
-    if (const auto type = make_type(node.function_name); com.types.is_valid(type)) {
+    if (const auto type = make_type(node.function_name); com.types.contains(type)) {
         const auto sig = make_constructor_sig(com, type);
         verify_sig(node.token, sig, param_types);
         return type;
@@ -567,18 +567,18 @@ void compile_stmt(compiler& com, const node_if_stmt& node)
 
 void compile_stmt(compiler& com, const node_struct_stmt& node)
 {
-    compiler_assert(!com.types.is_valid(node.name), node.token, "type {} already defined", node.name);
+    compiler_assert(!com.types.contains(node.name), node.token, "type {} already defined", node.name);
 
     for (const auto& field : node.fields) {
         compiler_assert(
-            com.types.is_valid(field.type),
+            com.types.contains(field.type),
             node.token, 
             "unknown type {} of field {} for struct {}\n",
             field.type, field.name, node.name
         );
     }
 
-    com.types.register_type(node.name, node.fields);
+    com.types.add(node.name, node.fields);
 }
 
 void compile_stmt(compiler& com, const node_break_stmt&)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -81,9 +81,6 @@ auto verify_real_type(const compiler& com, const token& tok, const type_name& t)
     if (!com.types.is_valid(t)) {
         compiler_error(tok, "{} is not a recognised type", t);
     }
-    if (!is_type_complete(t)) {
-        compiler_error(tok, "generic function definitions currently disallowed ({})", t);
-    }
 }
 
 template <typename T>

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -112,7 +112,7 @@ auto construct_builtin_map() -> std::unordered_map<std::string, builtin>
         .ptr = builtin_print,
         .sig = {
             .args = {
-                { .name = "obj", .type = generic_type(0) }
+                { .name = "obj", .type = int_type() }
             },
             .return_type = null_type()
         }
@@ -122,7 +122,7 @@ auto construct_builtin_map() -> std::unordered_map<std::string, builtin>
         .ptr = builtin_println,
         .sig = {
             .args = {
-                { .name = "obj", .type = generic_type(0) }
+                { .name = "obj", .type = int_type() }
             },
             .return_type = null_type()
         }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -206,9 +206,7 @@ auto parse_name(tokenstream& tokens)
 
 auto parse_type(tokenstream& tokens) -> type_name
 {
-    if (tokens.peek(tk_list)) {
-        print("in tk_list\n");
-        tokens.consume_only(tk_list);
+    if (tokens.consume_maybe(tk_list)) {
         tokens.consume_only(tk_lt);
         const auto inner_type = parse_type(tokens);
         tokens.consume_only(tk_comma);
@@ -218,8 +216,7 @@ auto parse_type(tokenstream& tokens) -> type_name
             .inner_type = {inner_type}, .count=static_cast<std::size_t>(count)
         }};
     }
-    else if (tokens.peek(tk_ptr)) {
-        tokens.consume_only(tk_ptr);
+    if (tokens.consume_maybe(tk_ptr)) {
         tokens.consume_only(tk_lt);
         const auto inner_type = parse_type(tokens);
         tokens.consume_only(tk_gt);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -206,7 +206,9 @@ auto parse_name(tokenstream& tokens)
 
 auto parse_type(tokenstream& tokens) -> type_name
 {
-    if (tokens.consume_maybe(tk_list)) {
+    if (tokens.peek(tk_list)) {
+        print("in tk_list\n");
+        tokens.consume_only(tk_list);
         tokens.consume_only(tk_lt);
         const auto inner_type = parse_type(tokens);
         tokens.consume_only(tk_comma);
@@ -216,12 +218,14 @@ auto parse_type(tokenstream& tokens) -> type_name
             .inner_type = {inner_type}, .count=static_cast<std::size_t>(count)
         }};
     }
-    else if (tokens.consume_maybe(tk_ptr)) {
+    else if (tokens.peek(tk_ptr)) {
+        tokens.consume_only(tk_ptr);
         tokens.consume_only(tk_lt);
-        return {type_ptr{
-            .inner_type = { parse_type(tokens) }
-        }};
+        const auto inner_type = parse_type(tokens);
         tokens.consume_only(tk_gt);
+        return {type_ptr{
+            .inner_type = { inner_type }
+        }};
     }
     return {type_simple{.name=tokens.consume().text}};
 }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -142,11 +142,16 @@ auto to_string(const signature& sig) -> std::string
     return std::format("({}) -> {}", format_comma_separated(sig.args, proj), sig.return_type);
 }
 
-type_store::type_store()
+auto type_store::add(const type_name& name, const type_fields& fields) -> bool
 {
+    if (d_classes.contains(name)) {
+        return false;
+    }
+    d_classes.emplace(name, fields);
+    return true;
 }
 
-auto type_store::is_valid(const type_name& type) const -> bool
+auto type_store::contains(const type_name& type) const -> bool
 {
     return d_classes.contains(type)
         || type == int_type()
@@ -185,15 +190,6 @@ auto type_store::fields_of(const type_name& t) const -> type_fields
         return it->second;
     }
     return {};
-}
-
-auto type_store::register_type(const type_name& name, const type_fields& fields) -> bool
-{
-    if (d_classes.contains(name)) {
-        return false;
-    }
-    d_classes.emplace(name, fields);
-    return true;
 }
 
 }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -28,17 +28,6 @@ auto to_string(const type_ptr& type) -> std::string
     return std::format("&{}", to_string(type.inner_type[0]));
 }
 
-auto to_string(const type_compound& type) -> std::string
-{
-    const auto subtypes = format_comma_separated(type.subtypes);
-    return std::format("{}<{}>", type.name, subtypes);
-}
-
-auto to_string(const type_generic& type) -> std::string
-{
-    return std::format("[{}]", type.id);
-}
-
 auto hash(const type_name& type) -> std::size_t
 {
     return std::visit([](const auto& t) { return hash(t); }, type);
@@ -57,21 +46,6 @@ auto hash(const type_list& type) -> std::size_t
 auto hash(const type_ptr& type) -> std::size_t
 {
     return hash(type.inner_type[0]) ^ std::hash<std::size_t>{}(100);
-}
-
-
-auto hash(const type_compound& type) -> std::size_t
-{
-    auto hash_value = std::hash<std::string>{}(type.name);
-    for (const auto& subtype : type.subtypes) {
-        hash_value ^= hash(subtype);
-    }
-    return hash_value;
-}
-
-auto hash(const type_generic& type) -> std::size_t
-{
-    return std::hash<int>{}(type.id);
 }
 
 auto int_type()  -> type_name
@@ -99,16 +73,9 @@ auto null_type() -> type_name
     return {type_simple{ .name = std::string{tk_null} }};
 }
 
-auto generic_type(int id) -> type_name
-{
-    return {type_generic{ .id = id }};
-}
-
 auto concrete_list_type(const type_name& t, std::size_t size) -> type_name
 {
-    return {type_list{
-        .inner_type = { t }, .count = size
-    }};
+    return {type_list{ .inner_type = { t }, .count = size }};
 }
 
 auto is_list_type(const type_name& t) -> bool
@@ -118,38 +85,25 @@ auto is_list_type(const type_name& t) -> bool
 
 auto concrete_ptr_type(const type_name& t) -> type_name
 {
-    return {type_compound{
-        .name = std::string{tk_ptr}, .subtypes = { t }
-    }};
+    return {type_ptr{ .inner_type = { t } }};
 }
 
 auto is_ptr_type(const type_name& t) -> bool
 {
-    return std::holds_alternative<type_compound>(t) && std::get<type_compound>(t).name == tk_ptr;
+    return std::holds_alternative<type_ptr>(t);
 }
 
 auto inner_type(const type_name& t) -> type_name
 {
-    return std::get<type_compound>(t).subtypes.front();
-}
-
-auto is_type_complete(const type_name& t) -> bool
-{
-    return std::visit(overloaded {
-        [](const type_simple&) { return true; },
-        [](const type_generic&) { return false; },
-        [](const type_list& t) {
-            return is_type_complete(t.inner_type[0]);
-        },
-        [](const type_ptr& t) {
-            return is_type_complete(t.inner_type[0]);
-        },
-        [](const type_compound& t) {
-            return std::all_of(begin(t.subtypes), end(t.subtypes), [](const auto& st) {
-                return is_type_complete(st);
-            });
-        }
-    }, t);
+    if (is_list_type(t)) {
+        return std::get<type_list>(t).inner_type[0];
+    }
+    if (is_ptr_type(t)) {
+        return std::get<type_ptr>(t).inner_type[0];
+    }
+    print("OH NO MY TYPE\n");
+    std::exit(1);
+    return {};
 }
 
 auto is_type_fundamental(const type_name& type) -> bool
@@ -182,86 +136,6 @@ auto update(
     return true;
 }
 
-auto match(const type_name& concrete, const type_name& pattern) -> std::optional<match_result>
-{
-    // Pre-condition, concrete must be a complete type (non-generic and no generic subtypes)
-    if (!is_type_complete(concrete)) {
-        return std::nullopt;
-    }
-
-    // Check 1: Trivial case - pattern is generic, matches entire concrete type
-    if (const auto inner = std::get_if<type_generic>(&pattern)) {
-        return match_result{
-            { inner->id, concrete }
-        };
-    }
-
-    // At this point, neither 'concrete' nor 'pattern' are generic
-
-    // Check 2: Trivial case - equality implies match
-    if (concrete == pattern) {
-        return match_result{};
-    }
-
-    // If either are simple, there there is no match because:
-    //   - if both are simple, they are not equal (check 2)
-    //   - simple cannot match compound and vice versa
-    if (std::holds_alternative<type_simple>(pattern) || std::holds_alternative<type_simple>(concrete)) {
-        return std::nullopt; // No match
-    }
-
-    // At this point, both 'concrete' and 'pattern' are compound
-    const auto& p = std::get<type_compound>(pattern);
-    const auto& c = std::get<type_compound>(concrete);
-    if (p.name != c.name || p.subtypes.size() != c.subtypes.size()) {
-        return std::nullopt;
-    }
-
-    auto matches = match_result{};
-
-    // Loop through the subtypes and do pairwise matches. Any successful matches should be
-    // lifted into our match map. If an index is already in our map with a different type,
-    // the match fails and we return nullopt.
-    for (const auto& [ct, pt] : zip(c.subtypes, p.subtypes)) {
-        const auto submatch = match(ct, pt);
-        if (!submatch.has_value() || !update(matches, submatch.value())) {
-            return std::nullopt;
-        }
-    }
-
-    return matches;
-}
-
-auto replace(type_name& ret, const match_result& matches) -> void
-{
-    std::visit(overloaded {
-        [&](type_simple&) {},
-        [&](type_list& type) {
-            replace(type.inner_type[0], matches);
-        },
-        [&](type_ptr& type) {
-            replace(type.inner_type[0], matches);
-        },
-        [&](type_generic& type) {
-            if (auto it = matches.find(type.id); it != matches.end()) {
-                ret = it->second;
-            }
-        },
-        [&](type_compound& type) {
-            for (auto& subtype : type.subtypes) {
-                replace(subtype, matches);
-            }
-        }
-    }, ret);
-}
-
-auto bind_generics(const type_name& incomplete, const std::unordered_map<int, type_name>& matches) -> type_name
-{
-    auto ret_type = incomplete;
-    replace(ret_type, matches);
-    return ret_type;
-}
-
 auto to_string(const signature& sig) -> std::string
 {
     const auto proj = [](const auto& arg) { return arg.type; };
@@ -279,13 +153,12 @@ auto type_store::is_valid(const type_name& t) const -> bool
 
 auto type_store::size_of(const type_name& t) const -> std::size_t
 {
-    if (!is_type_complete(t)) {
-        return 1; // Hack to make lists work (for fundamentals) for now. Should be 0 or exception
-    }
-
     if (std::holds_alternative<type_list>(t)) {
         const auto& list = std::get<type_list>(t);
         return size_of(list.inner_type[0]) * list.count;
+    }
+    if (std::holds_alternative<type_ptr>(t)) {
+        return 1;
     }
 
     if (auto it = d_classes.find(t); it != d_classes.end()) {

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -146,9 +146,16 @@ type_store::type_store()
 {
 }
 
-auto type_store::is_valid(const type_name& t) const -> bool
+auto type_store::is_valid(const type_name& type) const -> bool
 {
-    return is_type_fundamental(t) || d_classes.contains(t);
+    return d_classes.contains(type)
+        || type == int_type()
+        || type == float_type()
+        || type == bool_type()
+        || type == str_type()
+        || type == null_type()
+        || is_list_type(type)
+        || is_ptr_type(type);
 }
 
 auto type_store::size_of(const type_name& t) const -> std::size_t
@@ -176,9 +183,6 @@ auto type_store::fields_of(const type_name& t) const -> type_fields
 {
     if (auto it = d_classes.find(t); it != d_classes.end()) {
         return it->second;
-    }
-    if (is_type_fundamental(t)) {
-        return {{ .name = "blk", .type = t }};
     }
     return {};
 }

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -27,6 +27,12 @@ struct type_list
     auto operator==(const type_list&) const -> bool = default;
 };
 
+struct type_ptr
+{
+    std::vector<type_name> inner_type; // Should be a value_ptr
+    auto operator==(const type_ptr&) const -> bool = default;
+};
+
 struct type_compound
 {
     std::string            name;
@@ -43,6 +49,7 @@ struct type_generic
 struct type_name : public std::variant<
     type_simple,
     type_list,
+    type_ptr,
     type_compound,
     type_generic>
 {
@@ -60,12 +67,14 @@ using type_fields = std::vector<field>;
 
 auto to_string(const type_name& type) -> std::string;
 auto to_string(const type_list& type) -> std::string;
+auto to_string(const type_ptr& type) -> std::string;
 auto to_string(const type_simple& type) -> std::string;
 auto to_string(const type_compound& type) -> std::string;
 auto to_string(const type_generic& type) -> std::string;
 
 auto hash(const type_name& type) -> std::size_t;
 auto hash(const type_list& type) -> std::size_t;
+auto hash(const type_ptr& type) -> std::size_t;
 auto hash(const type_simple& type) -> std::size_t;
 auto hash(const type_compound& type) -> std::size_t;
 auto hash(const type_generic& type) -> std::size_t;
@@ -83,11 +92,9 @@ inline auto make_type(const std::string& name) -> type_name
 }
 
 auto concrete_list_type(const type_name& t, std::size_t size) -> type_name;
-auto generic_list_type(std::size_t size) -> type_name;
 auto is_list_type(const type_name& t) -> bool;
 
 auto concrete_ptr_type(const type_name& t) -> type_name;
-auto generic_ptr_type() -> type_name;
 auto is_ptr_type(const type_name& t) -> bool;
 
 // Extracts the single inner type of the given t. Undefined if the given t is not a compound

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -38,6 +38,7 @@ struct type_name : public std::variant<
     type_list,
     type_ptr>
 {
+    using variant::variant;
 };
 
 

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -81,9 +81,6 @@ auto is_ptr_type(const type_name& t) -> bool;
 // type with a single subtype.
 auto inner_type(const type_name& t) -> type_name;
 
-// Returns true if and only if the type is not a class type.
-auto it_type_fundamental(const type_name& t) -> bool;
-
 struct signature
 {
     struct arg

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -103,19 +103,12 @@ class type_store
     std::unordered_map<type_name, type_fields, type_hash> d_classes;
 
 public:
-    type_store();
+    auto add(const type_name& name, const type_fields& fields) -> bool;
+    auto contains(const type_name& t) const -> bool;
 
-    // Checks if the given type is registered or matches a registered generic.
-    auto is_valid(const type_name& t) const -> bool;
-
-    // Given a type name, return the size of the type in blocks.
     auto size_of(const type_name& t) const -> std::size_t;
-
     auto fields_of(const type_name& t) const -> type_fields;
 
-    // Registers a type with the given name and fields. Returns true if successful and false
-    // if the type already exists.
-    auto register_type(const type_name& name, const type_fields& fields) -> bool;
 };
 
 }

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -33,25 +33,10 @@ struct type_ptr
     auto operator==(const type_ptr&) const -> bool = default;
 };
 
-struct type_compound
-{
-    std::string            name;
-    std::vector<type_name> subtypes;
-    auto operator==(const type_compound&) const -> bool = default;
-};
-
-struct type_generic
-{
-    int id;
-    auto operator==(const type_generic&) const -> bool = default;
-};
-
 struct type_name : public std::variant<
     type_simple,
     type_list,
-    type_ptr,
-    type_compound,
-    type_generic>
+    type_ptr>
 {
 };
 
@@ -69,22 +54,17 @@ auto to_string(const type_name& type) -> std::string;
 auto to_string(const type_list& type) -> std::string;
 auto to_string(const type_ptr& type) -> std::string;
 auto to_string(const type_simple& type) -> std::string;
-auto to_string(const type_compound& type) -> std::string;
-auto to_string(const type_generic& type) -> std::string;
 
 auto hash(const type_name& type) -> std::size_t;
 auto hash(const type_list& type) -> std::size_t;
 auto hash(const type_ptr& type) -> std::size_t;
 auto hash(const type_simple& type) -> std::size_t;
-auto hash(const type_compound& type) -> std::size_t;
-auto hash(const type_generic& type) -> std::size_t;
 
 auto int_type() -> type_name;
 auto float_type() -> type_name;
 auto bool_type() -> type_name;
 auto str_type() -> type_name;
 auto null_type() -> type_name;
-auto generic_type(int id) -> type_name;
 
 inline auto make_type(const std::string& name) -> type_name
 {
@@ -101,17 +81,8 @@ auto is_ptr_type(const type_name& t) -> bool;
 // type with a single subtype.
 auto inner_type(const type_name& t) -> type_name;
 
-auto is_type_complete(const type_name& t) -> bool;
-
 // Returns true if and only if the type is not a class type.
 auto it_type_fundamental(const type_name& t) -> bool;
-
-using match_result = std::unordered_map<int, type_name>;
-auto match(const type_name& concrete, const type_name& pattern) -> std::optional<match_result>;
-
-// Given an incomplete type and a map of types, replace the generics in the incomplete type
-// with those from the map.
-auto bind_generics(const type_name& incomplete, const match_result& matches) -> type_name;
 
 struct signature
 {

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -10,7 +10,8 @@ auto is_keyword(std::string_view token) -> bool
     static const std::unordered_set<std::string_view> tokens = {
         tk_break, tk_continue, tk_else, tk_false, tk_for, tk_if,
         tk_in, tk_null, tk_true, tk_while, tk_int, tk_float, tk_bool,
-        tk_str, tk_list, tk_function, tk_return, tk_struct, tk_size_of
+        tk_str, tk_list, tk_function, tk_return, tk_struct, tk_size_of,
+        tk_ptr
     };
     return tokens.contains(token);
 }


### PR DESCRIPTION
* Generic types are completely broken and unworkable, so this strips it out so we can revisit it later.
* Added `type_ptr` to the type variant.
* Removed `type_compound` and `type_generic`.