### PR TITLE
`value_ptr` for Type Variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,14 @@ Common Modules
 -- object.hpp      : Definition of an object in anzu
 -- type.hpp        : Definition of a type in anzu
 -- vocabulary.hpp  : Definitions of keywords and symbols
--- views.hpp       : A collection of some helper views not in C++20
 
 Utility Modules (in src/utility)
--- print.hpp       : Wrapper for std::format, similar to {fmt}
--- peekstream.hpp  : A data structure used in the lexer
 -- overloaded.hpp  : A helper class to make std::visit simpler
+-- peekstream.hpp  : A data structure used in the lexer
+-- print.hpp       : Wrapper for std::format, similar to {fmt}
 -- score_timer.hpp : An RAII class for timing a block of code
+-- value_ptr.hpp   : A value-semantic smart pointer
+-- views.hpp       : A collection of some helper views not in C++20
 ```
 
 # Upcoming Features

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -332,7 +332,7 @@ auto type_of_expr(const compiler& com, const node_expr& node) -> type_name
             if (!std::holds_alternative<type_list>(ltype)) {
                 compiler_error(expr.token, "cannot use subscript operator on non-list type '{}'", ltype);
             }
-            return std::get<type_list>(ltype).inner_type[0];
+            return *std::get<type_list>(ltype).inner_type;
         }
     }, node);
 }
@@ -372,7 +372,7 @@ auto compile_expr_ptr(compiler& com, const node_subscript_expr& expr) -> type_na
     if (!std::holds_alternative<type_list>(ltype)) {
         compiler_error(expr.token, "cannot use subscript operator on non-list type '{}'", ltype);
     }
-    const auto etype = std::get<type_list>(ltype).inner_type[0];
+    const auto etype = *std::get<type_list>(ltype).inner_type;
     const auto etype_size = com.types.size_of(etype);
 
     // Push the offset (index * size)

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -20,12 +20,12 @@ auto to_string(const type_simple& type) -> std::string
 
 auto to_string(const type_list& type) -> std::string
 {
-    return std::format("{}[{}]", to_string(type.inner_type[0]), type.count);
+    return std::format("{}[{}]", to_string(*type.inner_type), type.count);
 }
 
 auto to_string(const type_ptr& type) -> std::string
 {
-    return std::format("&{}", to_string(type.inner_type[0]));
+    return std::format("&{}", to_string(*type.inner_type));
 }
 
 auto hash(const type_name& type) -> std::size_t
@@ -40,12 +40,12 @@ auto hash(const type_simple& type) -> std::size_t
 
 auto hash(const type_list& type) -> std::size_t
 {
-    return hash(type.inner_type[0]) ^ std::hash<std::size_t>{}(type.count);
+    return hash(*type.inner_type) ^ std::hash<std::size_t>{}(type.count);
 }
 
 auto hash(const type_ptr& type) -> std::size_t
 {
-    return hash(type.inner_type[0]) ^ std::hash<std::size_t>{}(100);
+    return hash(*type.inner_type) ^ std::hash<std::size_t>{}(100);
 }
 
 auto int_type()  -> type_name
@@ -96,10 +96,10 @@ auto is_ptr_type(const type_name& t) -> bool
 auto inner_type(const type_name& t) -> type_name
 {
     if (is_list_type(t)) {
-        return std::get<type_list>(t).inner_type[0];
+        return *std::get<type_list>(t).inner_type;
     }
     if (is_ptr_type(t)) {
-        return std::get<type_ptr>(t).inner_type[0];
+        return *std::get<type_ptr>(t).inner_type;
     }
     print("OH NO MY TYPE\n");
     std::exit(1);
@@ -177,7 +177,7 @@ auto type_store::size_of(const type_name& type) const -> std::size_t
             return size;
         },
         [&](const type_list& t) {
-            return size_of(t.inner_type[0]) * t.count;
+            return size_of(*t.inner_type) * t.count;
         },
         [](const type_ptr&) {
             return std::size_t{1};

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -20,12 +20,12 @@ auto to_string(const type_simple& type) -> std::string
 
 auto to_string(const type_list& type) -> std::string
 {
-    return std::format("{}[{}]", to_string(*type.inner_type), type.count);
+    return std::format("{}<{}, {}>", tk_list, to_string(*type.inner_type), type.count);
 }
 
 auto to_string(const type_ptr& type) -> std::string
 {
-    return std::format("&{}", to_string(*type.inner_type));
+    return std::format("{}<{}>", tk_ptr, to_string(*type.inner_type));
 }
 
 auto hash(const type_name& type) -> std::size_t

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -110,7 +110,6 @@ public:
 
     auto size_of(const type_name& t) const -> std::size_t;
     auto fields_of(const type_name& t) const -> type_fields;
-
 };
 
 }

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "vocabulary.hpp"
+#include "utility/value_ptr.hpp"
 
 #include <string>
 #include <variant>
@@ -22,14 +23,14 @@ struct type_simple
 
 struct type_list
 {
-    std::vector<type_name> inner_type; // Should be a value_ptr
-    std::size_t            count;
+    value_ptr<type_name> inner_type;
+    std::size_t          count;
     auto operator==(const type_list&) const -> bool = default;
 };
 
 struct type_ptr
 {
-    std::vector<type_name> inner_type; // Should be a value_ptr
+    value_ptr<type_name> inner_type;
     auto operator==(const type_ptr&) const -> bool = default;
 };
 

--- a/src/utility/value_ptr.hpp
+++ b/src/utility/value_ptr.hpp
@@ -9,15 +9,9 @@ class value_ptr
     std::unique_ptr<T> d_value;
 
 public:
-    value_ptr(T* value)
-        : d_value(std::unique_ptr<T>(value))
-    {
-    }
-
-    value_ptr(const value_ptr& other)
-        : d_value(std::make_unique<T>(*other))
-    {
-    }
+    value_ptr(T* value) : d_value(std::unique_ptr<T>(value)) {}
+    value_ptr(const value_ptr& other) : d_value(std::make_unique<T>(*other)) {}
+    value_ptr(const T& val) : d_value(std::make_unique<T>(val)) {}
 
     value_ptr& operator=(const value_ptr& other)
     {
@@ -25,30 +19,24 @@ public:
         return *this;
     }
 
-    value_ptr(const T& val)
-        : d_value(std::make_unique<T>(val))
-    {
-    }
-
-    value_ptr& operator=(value_ptr&& other)
+    auto operator=(value_ptr&& other) -> value_ptr&
     {
         d_value = std::move(other.d_value);
-        other.d_value.reset();
         return *this;
     }
 
-    T& operator*() { return *d_value; }
-    const T& operator*() const { return *d_value; }
+    auto operator*() -> T& { return *d_value; }
+    auto operator*() const -> const T& { return *d_value; }
 
-    T* operator->() { return d_value.get(); }
-    const T* operator->() const { return d_value.get(); }
+    auto operator->() -> T* { return d_value.get(); }
+    auto operator->() const -> const T* { return d_value.get(); }
 
-    T* get() { return d_value.get(); }
-    const T* get() const { return d_value.get(); }
+    auto get() -> T* { return d_value.get(); }
+    auto get() const -> const T* { return d_value.get(); }
 
     void reset() { d_value = nullptr; }
 
-    bool operator==(const value_ptr& other) const
+    auto operator==(const value_ptr& other) const -> bool
     {
         return *d_value == *other.d_value;
     }

--- a/src/utility/value_ptr.hpp
+++ b/src/utility/value_ptr.hpp
@@ -1,0 +1,63 @@
+#pragma once
+#include <memory>
+
+namespace anzu {
+
+template <typename T>
+class value_ptr
+{
+    std::unique_ptr<T> d_value;
+
+public:
+    value_ptr(T* value)
+        : d_value(std::unique_ptr<T>(value))
+    {
+    }
+
+    value_ptr(const value_ptr& other)
+        : d_value(std::make_unique<T>(*other))
+    {
+    }
+
+    value_ptr& operator=(const value_ptr& other)
+    {
+        *d_value = *other.d_value;
+        return *this;
+    }
+
+    value_ptr(const T& val)
+        : d_value(std::make_unique<T>(val))
+    {
+    }
+
+    value_ptr& operator=(value_ptr&& other)
+    {
+        d_value = std::move(other.d_value);
+        other.d_value.reset();
+        return *this;
+    }
+
+    T& operator*() { return *d_value; }
+    const T& operator*() const { return *d_value; }
+
+    T* operator->() { return d_value.get(); }
+    const T* operator->() const { return d_value.get(); }
+
+    T* get() { return d_value.get(); }
+    const T* get() const { return d_value.get(); }
+
+    void reset() { d_value = nullptr; }
+
+    bool operator==(const value_ptr& other) const
+    {
+        return *d_value == *other.d_value;
+    }
+};
+
+template <typename T, typename... Args>
+auto make_value(Args&&... args) -> value_ptr<T>
+{
+    return value_ptr(new T{std::forward<Args>(args)...});
+}
+
+}


### PR DESCRIPTION
* Added `value_ptr`, a smart pointer with value semantics.
* `value_ptr` is used in the type variant for recursive types, rather than using a vector which was a hack.