### PR TITLE
Scopes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/aoc2015-1.az", "run"],
+            "args": ["${workspaceFolder}/examples/feature_test.az", "run"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Utility Modules (in src/utility)
 
 # TODO
 ## Focus
-* Scopes
 * Function overloading
 * Member Functions
 * Constructors

--- a/README.md
+++ b/README.md
@@ -1,20 +1,5 @@
 # anzu
-An interpreted programming language written in C++. This is just me playing around with language design, it will be unsafe and inconsistent. Who knows, maybe I'll eventually make it good!
-
-This started out a stack based language like Forth. Meaning that users would have direct access to a stack where they could push values and operations to perform actions. For example, printing the sum of 4 and 5 would be written as
-
-```
-4 5 + .
-```
-First, 4 and 5 are pushed to the stack, then `+` pops two elements off, adds them and pushes the return value, then `.` prints to the console. I could do a lot with this, and implemented basic control flow via `if`, `elif`, `else`, `while`, `break`, `continue` and `end`, as well as functions. This had the benefit of being relatively simple to implement since it didn't require an abstract syntax tree.
-
-The parser would then turn the code into a vector of op codes which somewhat resemble a bytecode that could potentially be turned into assembly code in the future.
-
-I have since added an AST on top of this and disallowed direct stack access from the code, allowing for syntax that looks similar to python. All of this translates back down to the same stack-based-op-code approach under the hood, which I have since found out is exactly how python works, which is quite cool. The above example now looks much more familiar:
-
-```
-print(4 + 5)
-```
+An interpreted programming language written in C++. This started out as a stack-based language like Forth, it then took a route similar to Python with structures programming and duck-typing, and now I am drifting towards it being more simiar to C with a lot of "compile-time" checks including static typing.
 
 ## Features so far
 * Supports `ints`, `bools`, `null` and `string-literals`.
@@ -105,24 +90,21 @@ Utility Modules (in src/utility)
 -- views.hpp       : A collection of some helper views not in C++20
 ```
 
-# Upcoming Features
-* Explicit typing in declarations.
-* Const keyword.
-* Scopes.
-* Member functions so we can write `my_list.size()` rather than `list_size(my_list)`.
-* Function overloading based on the call signature.
-* Replace `int` with `int32`, `int64` as well as promotion/narrowing builtins.
-* Add `float32` and `float64`, with promotion/narrowing builtins (and to/from ints).
-* Add `uint32` and `uint64`, similar to the above.
-* Removal of objects and types from the runtime, should run on arrays of bytes.
-* Native compilation.
-* References (like C++, no pointers).
-* Less restriction on return statements in functions.
-* Typed function pointers.
-* Variants and a basic match statement.
-* Replacing the binary operation op codes with calls to builtin functions.
-* Filesystem support.
-* A better C++ API for implementing custom functions in C++.
+# TODO
+## Focus
+* Scopes
+* Function overloading
+* Member Functions
+* Constructors
+* Const
+* Dynamic Allocation
 
-# Known Bugs
-* Generic types don't place nicely with the compiler, need to employ similar techniques that type check generic functions. Function scopes will also need to store the generic types of the inputs so they can be matched against the concrete types it is called with.
+## Low Priority
+* Making the bytecode a true bytecode that can be saved to a file and read back in, with the compiler and runtime becoming separate programs
+* References
+* Less restriction on return statements in functions
+* Function pointers
+* Variants and match statement
+* Enums
+* Filesystem support
+* A better C++ API for implementing custom functions in C++

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,8 @@
-l := [1, 2, 3]
 
-l[1u] = 5
-println(l)
+x := "hello"
+
+fn foo(x: int) -> int[6] {
+    return [1, 2, 3, 4, 5, 6]
+}
+
+foo(5)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,8 @@
 
-x := "hello"
 
-fn foo(x: int) -> int[6] {
+fn foo() -> int[6] {
+    x := 1
     return [1, 2, 3, 4, 5, 6]
 }
 
-foo(5)
+foo()

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,9 @@
 
 
-fn foo() -> int[6] {
-    x := 1
-    return [1, 2, 3, 4, 5, 6]
+
+while true {
+    x := 5
+    break
 }
 
-foo()
+y := "b"

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -53,7 +53,7 @@ public:
 
     auto declare(const std::string& name, const type_name& type, std::size_t type_size) -> bool
     {
-        const auto [iter, success] = d_scopes.back().emplace(name, var_info{d_next, type, type_size});
+        const auto [_, success] = d_scopes.back().emplace(name, var_info{d_next, type, type_size});
         if (success) {
             d_next += type_size;
         }
@@ -166,7 +166,7 @@ auto find_variable(compiler& com, const token& tok, const std::string& name) -> 
         auto& locals = com.current_func->vars;
         if (const auto info = locals.find(name); info.has_value()) {
             com.program.emplace_back(op_push_local_addr{
-                .offset=info->location, .size=com.types.size_of(info->type)
+                .offset=info->location, .size=info->type_size
             });
             return info->type;
         }
@@ -175,7 +175,7 @@ auto find_variable(compiler& com, const token& tok, const std::string& name) -> 
     auto& globals = com.globals;
     if (const auto info = globals.find(name); info.has_value()) {
         com.program.emplace_back(op_push_global_addr{
-            .position=info->location, .size=com.types.size_of(info->type)
+            .position=info->location, .size=info->type_size
         });
         return info->type;
     }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -694,7 +694,7 @@ void compile_stmt(compiler& com, const node_function_def_stmt& node)
         }
     }
     
-    std::get<anzu::op_function>(com.program[begin_pos]).jump = com.program.size() + 1;
+    std::get<anzu::op_function>(com.program[begin_pos]).jump = com.program.size();
 }
 
 void compile_stmt(compiler& com, const node_return_stmt& node)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -66,6 +66,9 @@ public:
         }
         return std::nullopt;
     }
+
+    auto push_scope() -> void {}
+    auto pop_scope() -> void {}
 };
 
 struct function_def
@@ -571,9 +574,11 @@ auto compile_expr_val(compiler& com, const auto& node) -> type_name
 
 void compile_stmt(compiler& com, const node_sequence_stmt& node)
 {
+    current_vars(com).push_scope();
     for (const auto& seq_node : node.sequence) {
         compile_stmt(com, *seq_node);
     }
+    current_vars(com).pop_scope();
 }
 
 void compile_stmt(compiler& com, const node_while_stmt& node)

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -690,18 +690,7 @@ void compile_stmt(compiler& com, const node_function_def_stmt& node)
     for (const auto& arg : node.sig.args) {
         declare_variable_name(com, node.token, arg.name, arg.type);
     }
-
-    // Rather than recursing, we explicitly fetch the sequence statement and manually
-    // evaluate here. This is because sequence statements usually create a new scope which
-    // we do not want here because globals and locals are handled separately anyway. This is
-    // a bit of a hack and we may want to introduce a scope_stmt into the ast to deal with
-    // this instead.
-    if (!std::holds_alternative<node_sequence_stmt>(*node.body)) {
-        compiler_error(node.token, "body of a function must be a sequence statement");
-    }
-    for (const auto& stmt : std::get<node_sequence_stmt>(*node.body).sequence) {
-        compile_stmt(com, *stmt);
-    }
+    compile_stmt(com, *node.body);
     com.current_func.reset();
 
     const auto end_pos = append_op(com, op_function_end{});

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -39,10 +39,16 @@ struct var_info
     type_name   type;
 };
 
-struct var_locations
+class var_locations
 {
-    std::unordered_map<std::string, var_info> info;
-    std::size_t next = 0;
+    std::unordered_map<std::string, var_info> d_info;
+    std::size_t d_next = 0;
+
+public:
+    auto contains(const std::string& name) -> bool
+    {
+        return d_info.contains(name);
+    }
 };
 
 struct function_def
@@ -617,7 +623,7 @@ void compile_stmt(compiler& com, const node_continue_stmt&)
 void compile_stmt(compiler& com, const node_declaration_stmt& node)
 {
     const auto type = compile_expr_val(com, *node.expr);
-    if (current_vars(com).info.contains(node.name)) {
+    if (current_vars(com).contains(node.name)) {
         compiler_error(node.token, "redeclaration of variable '{}'", node.name);
     }
     declare_variable_name(com, node.name, type);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -343,6 +343,10 @@ auto parse_braced_statement_list(tokenstream& tokens) -> node_stmt_ptr
 
 auto parse_statement(tokenstream& tokens) -> node_stmt_ptr
 {
+    if (tokens.peek(tk_function) || tokens.peek(tk_struct)) {
+        parser_error(tokens.curr(), "functions and structs can only be declared in the global scope");
+    }
+
     if (tokens.peek(tk_return)) {
         return parse_return_stmt(tokens);
     }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -47,7 +47,7 @@ auto to_string(const op& op_code) -> std::string
             return std::format(FORMAT2, "ELSE", jump_str);
         },
         [&](const op_loop_begin& op) {
-            return std::string{"LOBEGIN"};
+            return std::string{"LOOP_BEGIN"};
         },
         [&](const op_loop_end& op) {
             const auto jump_str = std::format("JUMP -> {}", op.jump);

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -70,9 +70,6 @@ auto to_string(const op& op_code) -> std::string
             const auto jump_str = std::format("JUMP -> {}", op.jump);
             return std::format(FORMAT2, func_str, jump_str);
         },
-        [&](const op_function_end& op) {
-            return std::string{"FUNCTION_END"};
-        },
         [&](const op_return& op) {
             return std::string{"RETURN"};
         },

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -108,10 +108,6 @@ struct op_function
     std::size_t jump;
 };
 
-struct op_function_end
-{
-};
-
 struct op_return
 {
 };
@@ -134,7 +130,6 @@ struct op : std::variant<
     op_jump_if_false,
     op_builtin_mem_op,
     op_function,
-    op_function_end,
     op_return,
     op_function_call,
     op_builtin_call

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -35,7 +35,7 @@ auto pop_frame(runtime_context& ctx) -> void
     for (std::size_t i = 0; i != return_size; ++i) {
         ctx.memory[ctx.base_ptr + i] = ctx.memory[ctx.memory.size() - return_size + i];
     }
-    for (std::size_t i = 0; i != ctx.memory.size() - ctx.base_ptr - return_size; ++i) {
+    while (ctx.memory.size() > ctx.base_ptr + return_size) {
         ctx.memory.pop_back();
     }
     ctx.base_ptr = prev_base_ptr;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -24,24 +24,6 @@ auto pop_back(std::vector<block>& vec) -> block
     return back;   
 }
 
-// Copies the return value into the correct place, cleans up all extra blocks, and
-// resets the program and base pointers back to their previous values.
-auto pop_frame(runtime_context& ctx) -> void
-{
-    const auto prev_base_ptr = std::get<block_uint>(ctx.memory[ctx.base_ptr]);
-    const auto prev_prog_ptr = std::get<block_uint>(ctx.memory[ctx.base_ptr + 1]);
-    const auto return_size = std::get<block_uint>(ctx.memory[ctx.base_ptr + 2]);
-
-    for (std::size_t i = 0; i != return_size; ++i) {
-        ctx.memory[ctx.base_ptr + i] = ctx.memory[ctx.memory.size() - return_size + i];
-    }
-    while (ctx.memory.size() > ctx.base_ptr + return_size) {
-        ctx.memory.pop_back();
-    }
-    ctx.base_ptr = prev_base_ptr;
-    ctx.prog_ptr = prev_prog_ptr;
-}
-
 auto apply_op(runtime_context& ctx, const op& op_code) -> void
 {
     std::visit(overloaded {
@@ -125,12 +107,19 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
         [&](const op_function& op) {
             ctx.prog_ptr = op.jump;
         },
-        [&](op_function_end) {
-            ctx.memory.push_back(block_null{});
-            pop_frame(ctx);
-        },
         [&](op_return) {
-            pop_frame(ctx);
+            const auto prev_base_ptr = std::get<block_uint>(ctx.memory[ctx.base_ptr]);
+            const auto prev_prog_ptr = std::get<block_uint>(ctx.memory[ctx.base_ptr + 1]);
+            const auto return_size = std::get<block_uint>(ctx.memory[ctx.base_ptr + 2]);
+
+            for (std::size_t i = 0; i != return_size; ++i) {
+                ctx.memory[ctx.base_ptr + i] = ctx.memory[ctx.memory.size() - return_size + i];
+            }
+            while (ctx.memory.size() > ctx.base_ptr + return_size) {
+                ctx.memory.pop_back();
+            }
+            ctx.base_ptr = prev_base_ptr;
+            ctx.prog_ptr = prev_prog_ptr;
         },
         [&](const op_function_call& op) {
             // Store the old base_ptr and prog_ptr so that they can be restored at the end of


### PR DESCRIPTION
* Braced brackets now create new scopes, when reaching the end of the scope deletes all variables and removes all names.
* Names in inner scopes can also be shadowed and the types don't need to match.
* Control flow may be a problem since breaking out of a loop can cause you to miss the cleanup, however the memory will get overwritten by variables declared after anyway.
* Removed `op_function_end` and replaced with just a `op_load_literal(null)` + `op_return` when necessary.