### PR TITLE
Function Overloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Utility Modules (in src/utility)
 
 # TODO
 ## Focus
-* Function overloading
 * Member Functions
 * Constructors
 * Const

--- a/examples/test.az
+++ b/examples/test.az
@@ -15,4 +15,5 @@ x := 5
 adder(x, x)
 
 y := 2.0
-adder(y, y, y)
+z := 5.6
+adder(y, z)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,9 +1,18 @@
 
 
 
-while true {
-    x := 5
-    break
+fn adder(x: int, y: int) -> null
+{
+    println("called adder for int!")
 }
 
-y := "b"
+fn adder(x: float, y: float) -> null
+{
+    println("called adder for float!")
+}
+
+x := 5
+adder(x, x)
+
+y := 2.0
+adder(y, y)

--- a/examples/test.az
+++ b/examples/test.az
@@ -15,4 +15,4 @@ x := 5
 adder(x, x)
 
 y := 2.0
-adder(y, y)
+adder(y, y, y)

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -150,7 +150,7 @@ struct node_if_stmt
 
 struct node_struct_stmt
 {
-    type_name   name;
+    std::string name;
     type_fields fields;
 
     anzu::token token;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -671,7 +671,7 @@ void compile_stmt(compiler& com, const node_function_def_stmt& node)
     verify_real_type(com, node.token, node.sig.return_type);
 
     const auto begin_pos = append_op(com, op_function{ .name=node.name });
-    com.functions[node.name] = { .sig=node.sig ,.ptr=begin_pos };
+    com.functions[node.name] = { .sig=node.sig, .ptr=begin_pos };
 
     com.current_func.emplace(current_function{ .vars={}, .return_type=node.sig.return_type });
     declare_variable_name(com, node.token, "# old_base_ptr", uint_type()); // Store the old base ptr

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -87,7 +87,23 @@ public:
     }
 };
 
-struct function_def
+struct function_key
+{
+    std::string            name;
+    std::vector<type_name> args;
+    auto operator==(const function_key&) const -> bool = default;
+};
+
+auto hash(const function_key& f) -> std::size_t
+{
+    auto hash_value = std::hash<std::string>{}(f.name);
+    for (const auto& arg : f.args) {
+        hash_value ^= hash(arg);
+    }
+    return hash_value;
+}
+
+struct function_val
 {
     signature   sig;
     std::size_t ptr;
@@ -105,7 +121,8 @@ struct compiler
 {
     anzu::program program;
 
-    std::unordered_map<std::string, function_def> functions;
+    using function_hash = decltype([](const function_key& f) { return hash(f); });
+    std::unordered_map<function_key, function_val, function_hash> functions;
 
     var_locations globals;
     std::optional<current_function> current_func;
@@ -202,14 +219,6 @@ auto signature_args_size(const compiler& com, const signature& sig) -> std::size
         args_size += com.types.size_of(arg.type);
     }
     return args_size;
-}
-
-auto find_function(const compiler& com, const std::string& function) -> const function_def*
-{
-    if (const auto it = com.functions.find(function); it != com.functions.end()) {
-        return &it->second;
-    }
-    return nullptr;
 }
 
 auto modify_ptr(compiler& com, std::size_t offset, std::size_t size) -> void
@@ -325,7 +334,13 @@ auto type_of_expr(const compiler& com, const node_expr& node) -> type_name
             return r->result_type;
         },
         [&](const node_function_call_expr& expr) {
-            return com.functions.at(expr.function_name).sig.return_type;
+            auto key = function_key{};
+            key.name = expr.function_name;
+            key.args.reserve(expr.args.size());
+            for (const auto& arg : expr.args) {
+                key.args.push_back(type_of_expr(com, *arg));
+            }
+            return com.functions.at(key).sig.return_type;
         },
         [&](const node_list_expr& expr) {
             return type_name{type_list{
@@ -497,10 +512,19 @@ auto compile_expr_val(compiler& com, const node_function_call_expr& node) -> typ
         verify_sig(node.token, sig, param_types);
         return type;
     }
+
     // Otherwise, it may be a custom function.
-    else if (const auto function_def = find_function(com, node.function_name)) {
+    auto key = function_key{};
+    key.name = node.function_name;
+    key.args.reserve(node.args.size());
+    for (const auto& arg : node.args) {
+        key.args.push_back(type_of_expr(com, *arg));
+    }
+    
+    if (auto it = com.functions.find(key); it != com.functions.end()) {
+        const auto& [sig, ptr] = it->second;
         static constexpr auto payload_size = std::size_t{3};
-        const auto return_size = com.types.size_of(function_def->sig.return_type);
+        const auto return_size = com.types.size_of(sig.return_type);
         com.program.emplace_back(op_load_literal{ .blk=block_uint{0} }); // base ptr
         com.program.emplace_back(op_load_literal{ .blk=block_uint{0} }); // prog ptr
         com.program.emplace_back(op_load_literal{ .blk=block_uint{return_size} });
@@ -510,13 +534,13 @@ auto compile_expr_val(compiler& com, const node_function_call_expr& node) -> typ
         for (const auto& arg : node.args) {
             param_types.emplace_back(compile_expr_val(com, *arg));
         }
-        verify_sig(node.token, function_def->sig, param_types);
+        verify_sig(node.token, sig, param_types);
         com.program.emplace_back(anzu::op_function_call{
             .name=node.function_name,
-            .ptr=function_def->ptr + 1, // Jump into the function
-            .args_size=signature_args_size(com, function_def->sig) + payload_size
+            .ptr=ptr + 1, // Jump into the function
+            .args_size=signature_args_size(com, sig) + payload_size
         });
-        return function_def->sig.return_type;
+        return sig.return_type;
     }
 
     // Otherwise, it must be a builtin function.
@@ -665,13 +689,17 @@ void compile_stmt(compiler& com, const node_assignment_stmt& node)
 
 void compile_stmt(compiler& com, const node_function_def_stmt& node)
 {
+    auto key = function_key{};
+    key.name = node.name;
+    key.args.reserve(node.sig.args.size());
     for (const auto& arg : node.sig.args) {
         verify_real_type(com, node.token, arg.type);
+        key.args.push_back(arg.type);
     }
     verify_real_type(com, node.token, node.sig.return_type);
 
     const auto begin_pos = append_op(com, op_function{ .name=node.name });
-    com.functions[node.name] = { .sig=node.sig, .ptr=begin_pos };
+    com.functions[key] = { .sig=node.sig, .ptr=begin_pos };
 
     com.current_func.emplace(current_function{ .vars={}, .return_type=node.sig.return_type });
     declare_variable_name(com, node.token, "# old_base_ptr", uint_type()); // Store the old base ptr

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -244,7 +244,7 @@ auto parse_function_def_stmt(tokenstream& tokens) -> node_stmt_ptr
     stmt.name = parse_name(tokens);
     tokens.consume_only(tk_lparen);
     tokens.consume_comma_separated_list(tk_rparen, [&]{
-        auto arg = signature::arg{};
+        auto arg = function_arg{};
         arg.name = parse_name(tokens);
         tokens.consume_only(tk_colon);
         arg.type = parse_type(tokens);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -304,7 +304,7 @@ auto parse_struct_stmt(tokenstream& tokens) -> node_stmt_ptr
     auto& stmt = node->emplace<node_struct_stmt>();
 
     stmt.token = tokens.consume_only(tk_struct);
-    stmt.name = make_type(parse_name(tokens));
+    stmt.name = parse_name(tokens);
     tokens.consume_only(tk_lbrace);
     while (!tokens.consume_maybe(tk_rbrace)) {
         stmt.fields.emplace_back();

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -84,17 +84,18 @@ auto is_ptr_type(const type_name& t) -> bool;
 // type with a single subtype.
 auto inner_type(const type_name& t) -> type_name;
 
+struct function_arg
+{
+    std::string name;
+    type_name   type;
+    auto operator==(const function_arg&) const -> bool = default;
+};
+using function_args = std::vector<function_arg>;
+
 struct signature
 {
-    struct arg
-    {
-        std::string name;
-        type_name   type;
-        auto operator==(const arg&) const -> bool = default;
-    };
-
-    std::vector<arg> args;
-    type_name        return_type;
+    function_args args;
+    type_name     return_type;
     auto operator==(const signature&) const -> bool = default;
 };
 


### PR DESCRIPTION
* Function definitions are now stored with the arg types in the hash as well, allowing for function overloading.
* Added compiler checks to make sure that structs and functions cannot share names.
* Compiling function calls is a bit messy and could do with a cleanup.