### PR TITLE
Remove `block_ptr`

### DIFF
--- a/src/object.cpp
+++ b/src/object.cpp
@@ -21,7 +21,6 @@ auto to_string(const block& blk) -> std::string
 {
     return std::visit(overloaded {
         [](block_byte byte) { return std::format("{:x}", static_cast<unsigned char>(byte)); },
-        [](block_ptr ptr) { return std::format("[{:x}:{}]", ptr.ptr, ptr.size); },
         [](block_uint val) { return std::format("{}u", val); },
         [](auto&& val) { return std::format("{}", val); }
     }, blk);

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -27,8 +27,7 @@ struct block_ptr
 using block = std::variant<
     block_byte,
     block_uint,
-    block_float,
-    block_ptr
+    block_float
 >;
 
 struct object
@@ -79,7 +78,7 @@ inline auto from_bytes(const std::vector<block>& val) -> T
 
 template <> struct std::formatter<anzu::block> : std::formatter<std::string> {
     auto format(const anzu::block& blk, auto& ctx) {
-        return std::formatter<std::string>::format(to_string(blk), ctx);
+        return std::formatter<std::string>::format(anzu::to_string(blk), ctx);
     }
 };
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -32,13 +32,13 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ++ctx.prog_ptr;
         },
         [&](const op_push_global_addr& op) {
-            ctx.memory.push_back(op.position);
-            ctx.memory.push_back(op.size);
+            ctx.memory.push_back(block_uint{op.position});
+            ctx.memory.push_back(block_uint{op.size});
             ++ctx.prog_ptr;
         },
         [&](const op_push_local_addr& op) {
-            ctx.memory.push_back(ctx.base_ptr + op.offset);
-            ctx.memory.push_back(op.size);
+            ctx.memory.push_back(block_uint{ctx.base_ptr + op.offset});
+            ctx.memory.push_back(block_uint{op.size});
             ++ctx.prog_ptr;
         },
         [&](op_modify_ptr) {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -32,38 +32,38 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ++ctx.prog_ptr;
         },
         [&](const op_push_global_addr& op) {
-            const auto idx = op.position;
-            const auto ptr = block_ptr{ .ptr=idx, .size=op.size };
-            ctx.memory.push_back(ptr);
+            ctx.memory.push_back(op.position);
+            ctx.memory.push_back(op.size);
             ++ctx.prog_ptr;
         },
         [&](const op_push_local_addr& op) {
-            const auto idx = ctx.base_ptr + op.offset;
-            const auto ptr = block_ptr{ .ptr=idx, .size=op.size };
-            ctx.memory.push_back(ptr);
+            ctx.memory.push_back(ctx.base_ptr + op.offset);
+            ctx.memory.push_back(op.size);
             ++ctx.prog_ptr;
         },
         [&](op_modify_ptr) {
-            const auto size = std::get<block_uint>(pop_back(ctx.memory));
+            const auto new_size = std::get<block_uint>(pop_back(ctx.memory));
             const auto offset = std::get<block_uint>(pop_back(ctx.memory));
-            auto& ptr = std::get<block_ptr>(ctx.memory.back());
-            ptr.ptr += offset;
-            ptr.size = size;
+            pop_back(ctx.memory); // Old size
+            auto& ptr = std::get<block_uint>(ctx.memory.back());
+            ptr += offset;
+            ctx.memory.push_back(new_size);
             ++ctx.prog_ptr;
         },
         [&](op_load) {
-            const auto ptr_blk = pop_back(ctx.memory);
-            const auto ptr = std::get<block_ptr>(ptr_blk);
-            for (std::size_t i = 0; i != ptr.size; ++i) {
-                ctx.memory.push_back(ctx.memory[ptr.ptr + i]);
+            const auto size = std::get<block_uint>(pop_back(ctx.memory));
+            const auto ptr = std::get<block_uint>(pop_back(ctx.memory));
+            for (std::size_t i = 0; i != size; ++i) {
+                ctx.memory.push_back(ctx.memory[ptr + i]);
             }
             ++ctx.prog_ptr;
         },
         [&](op_save) {
-            const auto [idx, size] = std::get<block_ptr>(pop_back(ctx.memory));
-            runtime_assert(idx + size <= ctx.memory.size(), "tried to access invalid memory address {}", idx);
-            if (idx + size < ctx.memory.size()) {
-                for (const auto i : std::views::iota(idx, idx + size) | std::views::reverse) {
+            const auto size = std::get<block_uint>(pop_back(ctx.memory));
+            const auto ptr = std::get<block_uint>(pop_back(ctx.memory));
+            runtime_assert(ptr + size <= ctx.memory.size(), "tried to access invalid memory address {}", ptr);
+            if (ptr + size < ctx.memory.size()) {
+                for (const auto i : std::views::iota(ptr, ptr + size) | std::views::reverse) {
                     ctx.memory[i] = pop_back(ctx.memory);
                 }
             }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -187,6 +187,10 @@ auto type_store::size_of(const type_name& type) const -> std::size_t
         std::exit(1);
     }
 
+    if (is_ptr_type(type)) {
+        return 2; // Two unsigned int blocks, ptr and size
+    }
+
     if (type == i32_type()) {
         return 4;
     }


### PR DESCRIPTION
* Remove `block_ptr`. Instead we simplify push 2 `block_uint`s.
* Size of pointer types is now 2.
* Simplify `ptr_addition`. The type map is not needed since we didn't need to pass the size in because the ptr already had the size.
* This was mainly just a runtime change as `block_ptr` is not used in the compiler.