### PR TITLE
Remove `block_uint`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/feature_test.az", "run"],
+            "args": ["${workspaceFolder}/examples/test.az", "run"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/examples/feature_test.az
+++ b/examples/feature_test.az
@@ -146,7 +146,7 @@ println(size_of(xl2) / size_of(xl2[0]))
 struct span
 {
     p: &vec2
-    size: uint
+    size: u64
 }
 
 fn test_ptr_arithmetic(s: span) -> null

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,23 +1,5 @@
 
-struct vec2
-{
-    x: i64
-    y: i64
-}
 
-fn println(v: vec2) -> null
-{
-    print("vec2 = {")
-    print(v.x)
-    print(", ")
-    print(v.y)
-    println("}")
-}
+fn foo() -> null {}
 
-xl2 := [vec2(1, 2), vec2(3, 4)]
-println("xl2 should have size 32 but length 2:")
-print("size: ")
-println(size_of(xl2))
-println(size_of(xl2[0]))
-print("length: ")
-println(size_of(xl2) / size_of(xl2[0]))
+foo()

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,8 @@
 
 
-fn foo() -> null {}
+p_value := 5
+p := &p_value
 
-foo()
+if true {} # Needed otherwise the parser tries to parse "&p_value * ptr". Need semi-colons
+
+println(*p)

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,8 +1,20 @@
+struct vec2
+{
+    x: i64
+    y: i64
+}
+
+fn println(v: vec2) -> null
+{
+    print("vec2 = {")
+    print(v.x)
+    print(", ")
+    print(v.y)
+    println("}")
+}
 
 
-p_value := 5
-p := &p_value
+l := [vec2(1, 2), vec2(3, 4)]
+p := &l[0u]
 
-if true {} # Needed otherwise the parser tries to parse "&p_value * ptr". Need semi-colons
-
-println(*p)
+println(*(p + 1u))

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -131,6 +131,14 @@ struct compiler
     type_store types;
 };
 
+template <typename T>
+auto push_literal(compiler& com, const T& value) -> void
+{
+    for (const auto& b : to_bytes(value)) {
+        com.program.emplace_back(op_load_literal{ .blk=b });
+    }
+}
+
 auto current_vars(compiler& com) -> var_locations&
 {
     return com.current_func ? com.current_func->vars : com.globals;
@@ -224,8 +232,8 @@ auto signature_args_size(const compiler& com, const signature& sig) -> std::size
 
 auto modify_ptr(compiler& com, std::size_t offset, std::size_t size) -> void
 {
-    com.program.emplace_back(op_load_literal{ .blk=block_uint{offset} });
-    com.program.emplace_back(op_load_literal{ .blk=block_uint{size} });
+    push_literal(com, offset);
+    push_literal(com, size);
     com.program.emplace_back(op_modify_ptr{});
 }
 
@@ -381,7 +389,7 @@ auto type_of_expr(const compiler& com, const node_expr& node) -> type_name
             return concrete_ptr_type(type_of_expr(com, *expr.expr));
         },
         [&](const node_sizeof_expr& expr) {
-            return uint_type();
+            return u64_type();
         },
         [&](const node_variable_expr& expr) {
             return find_variable_type(com, expr.token, expr.name);
@@ -461,9 +469,9 @@ auto compile_expr_ptr(compiler& com, const node_subscript_expr& expr) -> type_na
 
     // Push the offset (index * size)
     const auto itype = compile_expr_val(com, *expr.index);
-    compiler_assert(itype == uint_type(), expr.token, "subscript argument must be a 'uint', got '{}'", itype);
+    compiler_assert(itype == u64_type(), expr.token, "subscript argument must be a 'u64', got '{}'", itype);
 
-    com.program.emplace_back(op_load_literal{ .blk={block_uint{etype_size}} });
+    push_literal(com, etype_size);
     const auto info = resolve_binary_op({ .op="*", .lhs=itype, .rhs=itype });
     com.program.emplace_back(op_builtin_mem_op{
         .name = "uint * uint",
@@ -471,8 +479,7 @@ auto compile_expr_ptr(compiler& com, const node_subscript_expr& expr) -> type_na
     });
 
     // Push the size
-    com.program.emplace_back(op_load_literal{ .blk={block_uint{etype_size}} });
-
+    push_literal(com, etype_size);
     com.program.emplace_back(op_modify_ptr{});
     return etype;
 }
@@ -554,9 +561,9 @@ auto compile_expr_val(compiler& com, const node_function_call_expr& node) -> typ
         const auto& [sig, ptr] = it->second;
         static constexpr auto payload_size = std::size_t{3};
         const auto return_size = com.types.size_of(sig.return_type);
-        com.program.emplace_back(op_load_literal{ .blk=block_uint{0} }); // base ptr
-        com.program.emplace_back(op_load_literal{ .blk=block_uint{0} }); // prog ptr
-        com.program.emplace_back(op_load_literal{ .blk=block_uint{return_size} });
+        push_literal(com, std::uint64_t{0}); // base ptr
+        push_literal(com, std::uint64_t{0}); // prog ptr
+        push_literal(com, return_size);
         
         // Push the args to the stack
         std::vector<type_name> param_types;
@@ -617,9 +624,9 @@ auto compile_expr_val(compiler& com, const node_member_function_call_expr& node)
     const auto& [sig, ptr] = it->second;
     static constexpr auto payload_size = std::size_t{3};
     const auto return_size = com.types.size_of(sig.return_type);
-    com.program.emplace_back(op_load_literal{ .blk=block_uint{0} }); // base ptr
-    com.program.emplace_back(op_load_literal{ .blk=block_uint{0} }); // prog ptr
-    com.program.emplace_back(op_load_literal{ .blk=block_uint{return_size} });
+    push_literal(com, std::uint64_t{0}); // base ptr
+    push_literal(com, std::uint64_t{0}); // prog ptr
+    push_literal(com, return_size);
     
     // Push the args to the stack
     std::vector<type_name> param_types;
@@ -659,8 +666,8 @@ auto compile_expr_val(compiler& com, const node_sizeof_expr& node) -> type_name
 {
     const auto type = type_of_expr(com, *node.expr);
     const auto size = com.types.size_of(type);
-    com.program.emplace_back(op_load_literal{ .blk=block_uint{size} });
-    return uint_type();
+    push_literal(com, size);
+    return u64_type();
 }
 
 // If not implemented explicitly, assume that the given node_expr is an lvalue, in which case
@@ -787,9 +794,9 @@ void compile_stmt(compiler& com, const node_function_def_stmt& node)
     com.functions[key] = { .sig=node.sig, .ptr=begin_pos };
 
     com.current_func.emplace(current_function{ .vars={}, .return_type=node.sig.return_type });
-    declare_variable_name(com, node.token, "# old_base_ptr", uint_type()); // Store the old base ptr
-    declare_variable_name(com, node.token, "# old_prog_ptr", uint_type()); // Store the old program ptr
-    declare_variable_name(com, node.token, "# return_size", uint_type());  // Store the return size
+    declare_variable_name(com, node.token, "# old_base_ptr", u64_type()); // Store the old base ptr
+    declare_variable_name(com, node.token, "# old_prog_ptr", u64_type()); // Store the old program ptr
+    declare_variable_name(com, node.token, "# return_size", u64_type());  // Store the return size
     for (const auto& arg : node.sig.args) {
         declare_variable_name(com, node.token, arg.name, arg.type);
     }
@@ -835,9 +842,9 @@ void compile_stmt(compiler& com, const node_member_function_def_stmt& node)
     com.functions[key] = { .sig=node.sig, .ptr=begin_pos };
 
     com.current_func.emplace(current_function{ .vars={}, .return_type=node.sig.return_type });
-    declare_variable_name(com, node.token, "# old_base_ptr", uint_type()); // Store the old base ptr
-    declare_variable_name(com, node.token, "# old_prog_ptr", uint_type()); // Store the old program ptr
-    declare_variable_name(com, node.token, "# return_size", uint_type());  // Store the return size
+    declare_variable_name(com, node.token, "# old_base_ptr", u64_type()); // Store the old base ptr
+    declare_variable_name(com, node.token, "# old_prog_ptr", u64_type()); // Store the old program ptr
+    declare_variable_name(com, node.token, "# return_size", u64_type());  // Store the return size
     for (const auto& arg : node.sig.args) {
         declare_variable_name(com, node.token, arg.name, arg.type);
     }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -111,6 +111,26 @@ auto builtin_println_i64(std::span<const block> args) -> std::vector<block>
     return {block{block_byte{0}}};
 }
 
+auto builtin_print_u64(std::span<const block> args) -> std::vector<block>
+{
+    auto bytes = std::array<std::byte, 8>();
+    for (std::size_t i = 0; i != 8; ++i) {
+        bytes[i] = std::get<std::byte>(args[i]);
+    }
+    print("{}", std::bit_cast<std::uint64_t>(bytes));
+    return {block{block_byte{0}}};
+}
+
+auto builtin_println_u64(std::span<const block> args) -> std::vector<block>
+{
+    auto bytes = std::array<std::byte, 8>();
+    for (std::size_t i = 0; i != 8; ++i) {
+        bytes[i] = std::get<std::byte>(args[i]);
+    }
+    print("{}\n", std::bit_cast<std::uint64_t>(bytes));
+    return {block{block_byte{0}}};
+}
+
 auto builtin_print_f64(std::span<const block> args) -> std::vector<block>
 {
     auto bytes = std::array<std::byte, 8>();
@@ -149,12 +169,12 @@ auto construct_builtin_map() -> builtin_map
     );
 
     builtins.emplace(
-        builtin_key{ .name = "print", .args = { uint_type() } },
-        builtin_val{ .ptr = builtin_print<block_uint>, .return_type = null_type() }
+        builtin_key{ .name = "print", .args = { u64_type() } },
+        builtin_val{ .ptr = builtin_print_u64, .return_type = null_type() }
     );
     builtins.emplace(
-        builtin_key{ .name = "println", .args = { uint_type() } },
-        builtin_val{ .ptr = builtin_println<block_uint>, .return_type = null_type() }
+        builtin_key{ .name = "println", .args = { u64_type() } },
+        builtin_val{ .ptr = builtin_println_u64, .return_type = null_type() }
     );
 
     builtins.emplace(

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -36,7 +36,7 @@ auto is_i64(std::string_view token) -> bool
     return is_int(token);
 }
 
-auto is_uint(std::string_view token) -> bool
+auto is_u64(std::string_view token) -> bool
 {
     const auto has_suffix = token.ends_with("u");
     if (!has_suffix) {
@@ -164,8 +164,8 @@ auto lex_line(
                 else if (is_i64(token)) {
                     push_token(token, col, token_type::i64);
                 }
-                else if (is_uint(token)) {
-                    push_token(token, col, token_type::uinteger);
+                else if (is_u64(token)) {
+                    push_token(token, col, token_type::u64);
                 }
                 else if (is_f64(token)) {
                     push_token(token, col, token_type::f64);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -20,8 +20,7 @@ auto format_error(const std::string& str) -> void
 auto to_string(const block& blk) -> std::string
 {
     return std::visit(overloaded {
-        [](block_byte byte) { return std::format("{:x}", static_cast<unsigned char>(byte)); },
-        [](block_uint val) { return std::format("{}u", val); },
+        [](block_byte byte) { return std::format("{:X}", static_cast<unsigned char>(byte)); },
         [](auto&& val) { return std::format("{}", val); }
     }, blk);
 }
@@ -41,19 +40,19 @@ auto make_i64(std::int64_t val) -> object
     return { .data = to_bytes(val), .type = i64_type() };
 }
 
-auto make_uint(std::uint64_t val) -> object
+auto make_u64(std::uint64_t val) -> object
 {
-    return { .data = { val }, .type = uint_type() };
-}
-
-auto make_char(char val) -> object
-{
-    return { .data = { static_cast<std::byte>(val) }, .type = char_type() };
+    return { .data = to_bytes(val), .type = u64_type() };
 }
 
 auto make_f64(double val) -> object
 {
     return { .data = to_bytes(val), .type = f64_type() };
+}
+
+auto make_char(char val) -> object
+{
+    return { .data = { static_cast<std::byte>(val) }, .type = char_type() };
 }
 
 auto make_bool(bool val) -> object

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -12,11 +12,10 @@ namespace anzu {
 
 // Want these to be equivalent since we want uints available in the runtime but we also want
 // to use it as indexes into C++ vectors which use size_t.
-static_assert(sizeof(std::uint64_t) == sizeof(std::size_t));
+static_assert(std::is_same_v<std::uint64_t, std::size_t>);
 
 using block_byte  = std::byte;
-using block_uint  = std::uint64_t;
-using block = std::variant<block_byte, block_uint>;
+using block = std::variant<block_byte>;
 
 struct object
 {
@@ -29,9 +28,9 @@ auto to_string(const object& object) -> std::string;
 
 auto make_i32(std::int32_t val) -> object;
 auto make_i64(std::int64_t val) -> object;
-auto make_uint(std::uint64_t val) -> object;
-auto make_char(char val) -> object;
+auto make_u64(std::uint64_t val) -> object;
 auto make_f64(double val) -> object;
+auto make_char(char val) -> object;
 auto make_bool(bool val) -> object;
 auto make_null() -> object;
 

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -85,7 +85,7 @@ auto ptr_addition(std::vector<block>& mem)
     const auto size = pop_u64(mem);
     const auto ptr = pop_u64(mem);
 
-    push_u64(mem, ptr + offset);
+    push_u64(mem, ptr + offset * size);
     push_u64(mem, size);
 }
 

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -56,15 +56,37 @@ auto bin_op_bytes(std::vector<block>& mem) -> void
     }
 }
 
+// TODO: Dedeup this, also appears in runtime
+auto push_u64(std::vector<block>& mem, std::uint64_t value) -> void
+{
+    for (const auto& b : std::bit_cast<std::array<std::byte, sizeof(std::uint64_t)>>(value)) {
+        mem.push_back(b);
+    }
+}
+
+// TODO: Dedeup this, also appears in runtime
+auto pop_u64(std::vector<block>& mem) -> std::uint64_t
+{
+    auto bytes = std::array<std::byte, sizeof(std::uint64_t)>{};
+    for (std::size_t i = 0; i != sizeof(std::uint64_t); ++i) {
+        bytes[i] = std::get<std::byte>(mem[mem.size() - sizeof(std::uint64_t) + i]);
+    }
+    for (std::size_t i = 0; i != sizeof(std::uint64_t); ++i) {
+        mem.pop_back();
+    }
+    return std::bit_cast<std::uint64_t>(bytes);
+}
+
 // Top of stack: [ptr], [size], [offset]
 // offset is popped, size stays the same, ptr is modified
 auto ptr_addition(std::vector<block>& mem)
 {
-    const auto offset = get_back<block_uint>(mem, 0);
-    const auto size = get_back<block_uint>(mem, 1);
-    auto& ptr = get_back<block_uint>(mem, 2);
-    mem.pop_back();
-    ptr += offset * size;
+    const auto offset = pop_u64(mem);
+    const auto size = pop_u64(mem);
+    const auto ptr = pop_u64(mem);
+
+    push_u64(mem, ptr + offset);
+    push_u64(mem, size);
 }
 
 // TODO: use memcmp here when we have just bytes
@@ -141,7 +163,7 @@ auto bool_negate(std::vector<block>& mem)
 
 auto resolve_binary_op(const binary_op_description& desc) -> std::optional<binary_op_info>
 {
-    if (is_ptr_type(desc.lhs) && desc.rhs == uint_type()) {
+    if (is_ptr_type(desc.lhs) && desc.rhs == u64_type()) {
         return binary_op_info{ ptr_addition, desc.lhs };
     }
 
@@ -205,29 +227,29 @@ auto resolve_binary_op(const binary_op_description& desc) -> std::optional<binar
             return binary_op_info{ bin_op_bytes<std::int64_t, std::not_equal_to>, bool_type() };
         }
     }
-    else if (type == uint_type()) {
+    else if (type == u64_type()) {
         if (desc.op == tk_add) {
-            return binary_op_info{ bin_op<block_uint, std::plus>(), type };
+            return binary_op_info{ bin_op_bytes<std::uint64_t, std::plus>, type };
         } else if (desc.op == tk_sub) {
-            return binary_op_info{ bin_op<block_uint, std::minus>(), type };
+            return binary_op_info{ bin_op_bytes<std::uint64_t, std::minus>, type };
         } else if (desc.op == tk_mul) {
-            return binary_op_info{ bin_op<block_uint, std::multiplies>(), type };
+            return binary_op_info{ bin_op_bytes<std::uint64_t, std::multiplies>, type };
         } else if (desc.op == tk_div) {
-            return binary_op_info{ bin_op<block_uint, std::divides>(), type };
+            return binary_op_info{ bin_op_bytes<std::uint64_t, std::divides>, type };
         } else if (desc.op == tk_mod) {
-            return binary_op_info{ bin_op<block_uint, std::modulus>(), type };
+            return binary_op_info{ bin_op_bytes<std::uint64_t, std::modulus>, type };
         } else if (desc.op == tk_lt) {
-            return binary_op_info{ bin_op<block_uint, std::less>(), bool_type() };
+            return binary_op_info{ bin_op_bytes<std::uint64_t, std::less>, bool_type() };
         } else if (desc.op == tk_le) {
-            return binary_op_info{ bin_op<block_uint, std::less_equal>(), bool_type() };
+            return binary_op_info{ bin_op_bytes<std::uint64_t, std::less_equal>, bool_type() };
         } else if (desc.op == tk_gt) {
-            return binary_op_info{ bin_op<block_uint, std::greater>(), bool_type() };
+            return binary_op_info{ bin_op_bytes<std::uint64_t, std::greater>, bool_type() };
         } else if (desc.op == tk_ge) {
-            return binary_op_info{ bin_op<block_uint, std::greater_equal>(), bool_type() };
+            return binary_op_info{ bin_op_bytes<std::uint64_t, std::greater_equal>, bool_type() };
         } else if (desc.op == tk_eq) {
-            return binary_op_info{ bin_op<block_uint, std::equal_to>(), bool_type() };
+            return binary_op_info{ bin_op_bytes<std::uint64_t, std::equal_to>, bool_type() };
         } else if (desc.op == tk_ne) {
-            return binary_op_info{ bin_op<block_uint, std::not_equal_to>(), bool_type() };
+            return binary_op_info{ bin_op_bytes<std::uint64_t, std::not_equal_to>, bool_type() };
         }
     }
     else if (type == f64_type()) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -54,10 +54,14 @@ auto to_i64(std::string_view token) -> std::int64_t
     return result;
 }
 
-auto to_uint(std::string_view token) -> block_uint
+auto to_u64(std::string_view token) -> std::uint64_t
 {
-    token.remove_suffix(1); // Strip 'u'
-    auto result = block_uint{};
+    if (token.ends_with(tk_u64)) {
+        token.remove_suffix(tk_u64.size());
+    } else if (token.ends_with('u')) {
+        token.remove_suffix(1);
+    }
+    auto result = std::uint64_t{};
     const auto [ptr, ec] = std::from_chars(token.data(), token.data() + token.size(), result);
     if (ec != std::errc{}) {
         print("type error: cannot convert '{}' to uint\n", token);
@@ -88,8 +92,8 @@ auto parse_literal(tokenstream& tokens) -> object
     if (tokens.curr().type == token_type::i64) {
         return make_i64(to_i64(tokens.consume().text));
     }
-    if (tokens.curr().type == token_type::uinteger) {
-        return make_uint(to_uint(tokens.consume().text));
+    if (tokens.curr().type == token_type::u64) {
+        return make_u64(to_u64(tokens.consume().text));
     }
     if (tokens.curr().type == token_type::f64) {
         return make_f64(to_f64(tokens.consume().text));

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -97,7 +97,6 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
         [&](op_save) {
             const auto size = pop_u64(ctx);
             const auto ptr = pop_u64(ctx);
-            print("size = {}, ptr = {}\n", size, ptr);
             runtime_assert(ptr + size <= ctx.memory.size(), "tried to access invalid memory address {}", ptr);
             if (ptr + size < ctx.memory.size()) {
                 for (const auto i : std::views::iota(ptr, ptr + size) | std::views::reverse) {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -24,6 +24,43 @@ auto pop_back(std::vector<block>& vec) -> block
     return back;   
 }
 
+auto push_u64(runtime_context& ctx, std::uint64_t value) -> void
+{
+    for (const auto& b : std::bit_cast<std::array<std::byte, sizeof(std::uint64_t)>>(value)) {
+        ctx.memory.push_back(b);
+    }
+}
+
+auto pop_u64(runtime_context& ctx) -> std::uint64_t
+{
+    auto bytes = std::array<std::byte, sizeof(std::uint64_t)>{};
+    for (std::size_t i = 0; i != sizeof(std::uint64_t); ++i) {
+        bytes[i] = std::get<std::byte>(ctx.memory[ctx.memory.size() - sizeof(std::uint64_t) + i]);
+    }
+    for (std::size_t i = 0; i != sizeof(std::uint64_t); ++i) {
+        ctx.memory.pop_back();
+    }
+    return std::bit_cast<std::uint64_t>(bytes);
+}
+
+auto write_u64(runtime_context& ctx, std::size_t ptr, std::uint64_t value) -> void
+{
+    auto bytes = to_bytes(value);
+    for (std::size_t i = 0; i != sizeof(std::uint64_t); ++i) {
+        bytes[i] = std::get<std::byte>(ctx.memory[ptr + i]);
+        ctx.memory[ptr + i] = bytes[i]; 
+    }
+}
+
+auto read_u64(runtime_context& ctx, std::size_t ptr) -> std::uint64_t
+{
+    auto bytes = std::array<std::byte, sizeof(std::uint64_t)>{};
+    for (std::size_t i = 0; i != sizeof(std::uint64_t); ++i) {
+        bytes[i] = std::get<std::byte>(ctx.memory[ptr + i]);
+    }
+    return std::bit_cast<std::uint64_t>(bytes);
+}
+
 auto apply_op(runtime_context& ctx, const op& op_code) -> void
 {
     std::visit(overloaded {
@@ -32,35 +69,35 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ++ctx.prog_ptr;
         },
         [&](const op_push_global_addr& op) {
-            ctx.memory.push_back(block_uint{op.position});
-            ctx.memory.push_back(block_uint{op.size});
+            push_u64(ctx, op.position);
+            push_u64(ctx, op.size);
             ++ctx.prog_ptr;
         },
         [&](const op_push_local_addr& op) {
-            ctx.memory.push_back(block_uint{ctx.base_ptr + op.offset});
-            ctx.memory.push_back(block_uint{op.size});
+            push_u64(ctx, ctx.base_ptr + op.offset);
+            push_u64(ctx, op.size);
             ++ctx.prog_ptr;
         },
         [&](op_modify_ptr) {
-            const auto new_size = std::get<block_uint>(pop_back(ctx.memory));
-            const auto offset = std::get<block_uint>(pop_back(ctx.memory));
-            pop_back(ctx.memory); // Old size
-            auto& ptr = std::get<block_uint>(ctx.memory.back());
-            ptr += offset;
-            ctx.memory.push_back(new_size);
+            const auto new_size = pop_u64(ctx);
+            const auto offset = pop_u64(ctx);
+            pop_u64(ctx); // Old size
+            const auto ptr = pop_u64(ctx);
+            push_u64(ctx, ptr + offset);
+            push_u64(ctx, new_size);
             ++ctx.prog_ptr;
         },
         [&](op_load) {
-            const auto size = std::get<block_uint>(pop_back(ctx.memory));
-            const auto ptr = std::get<block_uint>(pop_back(ctx.memory));
+            const auto size = pop_u64(ctx);
+            const auto ptr = pop_u64(ctx);
             for (std::size_t i = 0; i != size; ++i) {
                 ctx.memory.push_back(ctx.memory[ptr + i]);
             }
             ++ctx.prog_ptr;
         },
         [&](op_save) {
-            const auto size = std::get<block_uint>(pop_back(ctx.memory));
-            const auto ptr = std::get<block_uint>(pop_back(ctx.memory));
+            const auto size = pop_u64(ctx);
+            const auto ptr = pop_u64(ctx);
             runtime_assert(ptr + size <= ctx.memory.size(), "tried to access invalid memory address {}", ptr);
             if (ptr + size < ctx.memory.size()) {
                 for (const auto i : std::views::iota(ptr, ptr + size) | std::views::reverse) {
@@ -108,9 +145,9 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.prog_ptr = op.jump;
         },
         [&](op_return) {
-            const auto prev_base_ptr = std::get<block_uint>(ctx.memory[ctx.base_ptr]);
-            const auto prev_prog_ptr = std::get<block_uint>(ctx.memory[ctx.base_ptr + 1]);
-            const auto return_size = std::get<block_uint>(ctx.memory[ctx.base_ptr + 2]);
+            const auto prev_base_ptr = read_u64(ctx, ctx.base_ptr);
+            const auto prev_prog_ptr = read_u64(ctx, ctx.base_ptr + sizeof(std::uint64_t));
+            const auto return_size = read_u64(ctx, ctx.base_ptr + 2*sizeof(std::uint64_t));
 
             for (std::size_t i = 0; i != return_size; ++i) {
                 ctx.memory[ctx.base_ptr + i] = ctx.memory[ctx.memory.size() - return_size + i];
@@ -126,8 +163,8 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             // the function. Note that the return size is stored at new_base_ptr + 2 but and has
             // already been written in.
             const auto new_base_ptr = ctx.memory.size() - op.args_size;
-            ctx.memory[new_base_ptr] = block_uint{ctx.base_ptr};  
-            ctx.memory[new_base_ptr + 1] = block_uint{ctx.prog_ptr + 1}; // Pos after function call
+            write_u64(ctx, new_base_ptr, ctx.base_ptr);
+            write_u64(ctx, new_base_ptr + sizeof(std::uint64_t), ctx.prog_ptr + 1); // Pos after function call
             ctx.base_ptr = new_base_ptr;
             ctx.prog_ptr = op.ptr; // Jump into the function
         },

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -17,11 +17,11 @@ auto to_string(token_type type) -> std::string
         break; case token_type::keyword:   { return "keyword"; };
         break; case token_type::symbol:    { return "symbol"; };
         break; case token_type::name:      { return "name"; };
-        break; case token_type::uinteger:  { return "uinteger"; };
         break; case token_type::character: { return "character"; };
         break; case token_type::string:    { return "string"; };
         break; case token_type::i32:       { return "i32"; };
         break; case token_type::i64:       { return "i64"; };
+        break; case token_type::u64:       { return "u64"; };
         break; case token_type::f64:       { return "f64"; };
         break; default:                    { return "UNKNOWN"; };
     }
@@ -76,13 +76,13 @@ auto tokenstream::consume_i64() -> std::int64_t
     return std::stoll(consume().text);
 }
 
-auto tokenstream::consume_uint() -> std::uint64_t
+auto tokenstream::consume_u64() -> std::uint64_t
 {
     if (!valid()) {
         anzu::print("[ERROR] (EOF) expected a uint\n");
         std::exit(1);
     }
-    if (curr().type != token_type::uinteger) {
+    if (curr().type != token_type::u64) {
         const auto [tok_text, line, col, type] = curr();
         anzu::print("[ERROR] ({}:{}) expected a uint, got '{}\n", line, col, tok_text);
         std::exit(1);

--- a/src/token.hpp
+++ b/src/token.hpp
@@ -13,10 +13,10 @@ enum class token_type
     keyword,
     symbol,
     name,
-    uinteger,
     character,
     i32,
     i64,
+    u64,
     f64,
     string
 };
@@ -39,7 +39,7 @@ public:
     auto consume_maybe(std::string_view text) -> bool;
     auto consume_only(std::string_view text) -> token;
     auto consume_i64() -> std::int64_t;
-    auto consume_uint() -> std::uint64_t;
+    auto consume_u64() -> std::uint64_t;
 
     template <typename Func>
     auto consume_comma_separated_list(std::string_view sentinel, Func&& callback) -> void

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -183,7 +183,7 @@ auto type_store::size_of(const type_name& type) const -> std::size_t
     }
 
     if (is_ptr_type(type)) {
-        return 2; // Two unsigned int blocks, ptr and size
+        return 16; // Two unsigned ints, ptr and size
     }
 
     if (type == i32_type()) {

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -59,9 +59,9 @@ auto i64_type() -> type_name
     return {type_simple{ .name = std::string{tk_i64} }};
 }
 
-auto uint_type() -> type_name
+auto u64_type() -> type_name
 {
-    return {type_simple{ .name = std::string{tk_uint} }};
+    return {type_simple{ .name = std::string{tk_u64} }};
 }
 
 auto char_type() -> type_name
@@ -126,9 +126,9 @@ auto is_type_fundamental(const type_name& type) -> bool
 {
     return type == i32_type()
         || type == i64_type()
-        || type == uint_type()
-        || type == char_type()
+        || type == u64_type()
         || type == f64_type()
+        || type == char_type()
         || type == bool_type()
         || type == null_type();
 }
@@ -190,7 +190,7 @@ auto type_store::size_of(const type_name& type) const -> std::size_t
         return 4;
     }
 
-    if (type == i64_type() || type == f64_type()) {
+    if (type == i64_type() || type == f64_type() || type == u64_type()) {
         return 8;
     }
 

--- a/src/type.hpp
+++ b/src/type.hpp
@@ -64,9 +64,9 @@ auto hash(const type_simple& type) -> std::size_t;
 
 auto i32_type() -> type_name;
 auto i64_type() -> type_name;
-auto uint_type() -> type_name;
-auto char_type() -> type_name;
+auto u64_type() -> type_name;
 auto f64_type() -> type_name;
+auto char_type() -> type_name;
 auto bool_type() -> type_name;
 auto null_type() -> type_name;
 auto str_literal_type(std::size_t length) -> type_name;

--- a/src/vocabulary.cpp
+++ b/src/vocabulary.cpp
@@ -9,8 +9,8 @@ auto is_keyword(std::string_view token) -> bool
 {
     static const std::unordered_set<std::string_view> tokens = {
         tk_break, tk_continue, tk_else, tk_false, tk_for, tk_if, tk_in, tk_null, tk_true,
-        tk_while, tk_bool, tk_str, tk_function, tk_return, tk_struct, tk_size_of, tk_uint,
-        tk_char, tk_i32, tk_i64, tk_f64
+        tk_while, tk_bool, tk_str, tk_function, tk_return, tk_struct, tk_size_of, tk_char,
+        tk_i32, tk_i64, tk_u64, tk_f64
     };
     return tokens.contains(token);
 }

--- a/src/vocabulary.hpp
+++ b/src/vocabulary.hpp
@@ -24,9 +24,9 @@ constexpr auto tk_size_of   = sv{"size_of"};
 // Builtin Types
 constexpr auto tk_i32       = sv{"i32"};
 constexpr auto tk_i64       = sv{"i64"};
-constexpr auto tk_uint      = sv{"uint"};
-constexpr auto tk_char      = sv{"char"};
+constexpr auto tk_u64       = sv{"u64"};
 constexpr auto tk_f64       = sv{"f64"};
+constexpr auto tk_char      = sv{"char"};
 constexpr auto tk_bool      = sv{"bool"};
 constexpr auto tk_str       = sv{"str"};
 


### PR DESCRIPTION
* Everything is now stored as bytes.
* The bytes are still wrapped in a variant, which we can remove next.
* Replaced `uint` as a type with `u64`.