### PR TITLE
Remove `block` Variant

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -134,7 +134,8 @@ struct compiler
 template <typename T>
 auto push_literal(compiler& com, const T& value) -> void
 {
-    com.program.emplace_back(op_load_bytes{to_bytes(value)});
+    const auto bytes = as_bytes(value);
+    com.program.emplace_back(op_load_bytes{{bytes.begin(), bytes.end()}});
 }
 
 auto current_vars(compiler& com) -> var_locations&

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -807,7 +807,7 @@ void compile_stmt(compiler& com, const node_function_def_stmt& node)
         // A function returning null does not need a final return statement, and in this case
         // we manually add a return value of null here.
         if (node.sig.return_type == null_type()) {
-            com.program.emplace_back(op_load_literal{block_byte{0}});
+            com.program.emplace_back(op_load_literal{std::byte{0}});
             com.program.emplace_back(op_return{});
         } else {
             compiler_error(node.token, "function '{}' does not end in a return statement", node.name);
@@ -855,7 +855,7 @@ void compile_stmt(compiler& com, const node_member_function_def_stmt& node)
         // A function returning null does not need a final return statement, and in this case
         // we manually add a return value of null here.
         if (node.sig.return_type == null_type()) {
-            com.program.emplace_back(op_load_literal{block_byte{0}});
+            com.program.emplace_back(op_load_literal{std::byte{0}});
             com.program.emplace_back(op_return{});
         } else {
             compiler_error(node.token, "function '{}' does not end in a return statement", qualified_name);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -134,9 +134,7 @@ struct compiler
 template <typename T>
 auto push_literal(compiler& com, const T& value) -> void
 {
-    for (const auto& b : to_bytes(value)) {
-        com.program.emplace_back(op_load_literal{ .blk=b });
-    }
+    com.program.emplace_back(op_load_bytes{to_bytes(value)});
 }
 
 auto current_vars(compiler& com) -> var_locations&
@@ -496,13 +494,9 @@ auto compile_expr_ptr(compiler& com, const node_expr& node) -> type_name
     return std::visit([&](const auto& expr) { return compile_expr_ptr(com, expr); }, node);
 }
 
-
-
 auto compile_expr_val(compiler& com, const node_literal_expr& node) -> type_name
 {
-    for (const auto& blk : node.value.data) {
-        com.program.emplace_back(anzu::op_load_literal{ .blk=blk });
-    }
+    com.program.emplace_back(op_load_bytes{node.value.data});
     return node.value.type;
 }
 
@@ -807,7 +801,7 @@ void compile_stmt(compiler& com, const node_function_def_stmt& node)
         // A function returning null does not need a final return statement, and in this case
         // we manually add a return value of null here.
         if (node.sig.return_type == null_type()) {
-            com.program.emplace_back(op_load_literal{std::byte{0}});
+            com.program.emplace_back(op_load_bytes{{std::byte{0}}});
             com.program.emplace_back(op_return{});
         } else {
             compiler_error(node.token, "function '{}' does not end in a return statement", node.name);
@@ -855,7 +849,7 @@ void compile_stmt(compiler& com, const node_member_function_def_stmt& node)
         // A function returning null does not need a final return statement, and in this case
         // we manually add a return value of null here.
         if (node.sig.return_type == null_type()) {
-            com.program.emplace_back(op_load_literal{std::byte{0}});
+            com.program.emplace_back(op_load_bytes{{std::byte{0}}});
             com.program.emplace_back(op_return{});
         } else {
             compiler_error(node.token, "function '{}' does not end in a return statement", qualified_name);

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -62,83 +62,25 @@ auto builtin_println_null(std::vector<std::byte>& mem) -> void
     mem.back() = std::byte{0}; // returns null
 }
 
-auto builtin_print_i32(std::vector<std::byte>& mem) -> void
+template <typename T>
+auto builtin_print(std::vector<std::byte>& mem) -> void
 {
-    auto bytes = std::array<std::byte, SIZE32>();
-    std::memcpy(bytes.data(), mem.data(), SIZE32);
-    print("{}", std::bit_cast<std::int32_t>(bytes));
+    auto bytes = std::array<std::byte, sizeof(T)>();
+    std::memcpy(bytes.data(), mem.data() + mem.size() - sizeof(T), sizeof(T));
+    print("{}", std::bit_cast<T>(bytes));
 
-    mem.resize(mem.size() - SIZE32);
+    mem.resize(mem.size() - sizeof(T));
     mem.push_back(std::byte{0}); // returns null
 }
 
-auto builtin_println_i32(std::vector<std::byte>& mem) -> void
+template <typename T>
+auto builtin_println(std::vector<std::byte>& mem) -> void
 {
-    auto bytes = std::array<std::byte, SIZE32>();
-    std::memcpy(bytes.data(), mem.data(), SIZE32);
-    print("{}\n", std::bit_cast<std::int32_t>(bytes));
+    auto bytes = std::array<std::byte, sizeof(T)>();
+    std::memcpy(bytes.data(), mem.data() + mem.size() - sizeof(T), sizeof(T));
+    print("{}\n", std::bit_cast<T>(bytes));
 
-    mem.resize(mem.size() - SIZE32);
-    mem.push_back(std::byte{0}); // returns null
-}
-
-auto builtin_print_i64(std::vector<std::byte>& mem) -> void
-{
-    auto bytes = std::array<std::byte, SIZE64>();
-    std::memcpy(bytes.data(), mem.data(), SIZE64);
-    print("{}", std::bit_cast<std::int64_t>(bytes));
-
-    mem.resize(mem.size() - SIZE64);
-    mem.push_back(std::byte{0}); // returns null
-}
-
-auto builtin_println_i64(std::vector<std::byte>& mem) -> void
-{
-    auto bytes = std::array<std::byte, SIZE64>();
-    std::memcpy(bytes.data(), mem.data(), SIZE64);
-    print("{}\n", std::bit_cast<std::int64_t>(bytes));
-
-    mem.resize(mem.size() - SIZE64);
-    mem.push_back(std::byte{0}); // returns null
-}
-
-auto builtin_print_u64(std::vector<std::byte>& mem) -> void
-{
-    auto bytes = std::array<std::byte, SIZE64>();
-    std::memcpy(bytes.data(), mem.data(), SIZE64);
-    print("{}", std::bit_cast<std::uint64_t>(bytes));
-
-    mem.resize(mem.size() - SIZE64);
-    mem.push_back(std::byte{0}); // returns null
-}
-
-auto builtin_println_u64(std::vector<std::byte>& mem) -> void
-{
-    auto bytes = std::array<std::byte, SIZE64>();
-    std::memcpy(bytes.data(), mem.data(), SIZE64);
-    print("{}\n", std::bit_cast<std::uint64_t>(bytes));
-
-    mem.resize(mem.size() - SIZE64);
-    mem.push_back(std::byte{0}); // returns null
-}
-
-auto builtin_print_f64(std::vector<std::byte>& mem) -> void
-{
-    auto bytes = std::array<std::byte, SIZE64>();
-    std::memcpy(bytes.data(), mem.data(), SIZE64);
-    print("{}", std::bit_cast<double>(bytes));
-
-    mem.resize(mem.size() - SIZE64);
-    mem.push_back(std::byte{0}); // returns null
-}
-
-auto builtin_println_f64(std::vector<std::byte>& mem) -> void
-{
-    auto bytes = std::array<std::byte, SIZE64>();
-    std::memcpy(bytes.data(), mem.data(), SIZE64);
-    print("{}\n", std::bit_cast<double>(bytes));
-
-    mem.resize(mem.size() - SIZE64);
+    mem.resize(mem.size() - sizeof(T));
     mem.push_back(std::byte{0}); // returns null
 }
 
@@ -155,65 +97,65 @@ auto construct_builtin_map() -> builtin_map
 
     builtins.emplace(
         builtin_key{ .name = "print", .args = { u64_type() } },
-        builtin_val{ .ptr = builtin_print_u64, .return_type = null_type() }
+        builtin_val{ .ptr = builtin_print<std::uint64_t>, .return_type = null_type() }
     );
     builtins.emplace(
         builtin_key{ .name = "println", .args = { u64_type() } },
-        builtin_val{ .ptr = builtin_println_u64, .return_type = null_type() }
+        builtin_val{ .ptr = builtin_println<std::uint64_t>, .return_type = null_type() }
     );
 
     builtins.emplace(
         builtin_key{ .name = "print", .args = { char_type() } },
-        builtin_val{ .ptr = builtin_print_char, .return_type = null_type() }
+        builtin_val{ .ptr = builtin_print<char>, .return_type = null_type() }
     );
     builtins.emplace(
         builtin_key{ .name = "println", .args = { char_type() } },
-        builtin_val{ .ptr = builtin_println_char, .return_type = null_type() }
+        builtin_val{ .ptr = builtin_println<char>, .return_type = null_type() }
     );
 
     builtins.emplace(
         builtin_key{ .name = "print", .args = { f64_type() } },
-        builtin_val{ .ptr = builtin_print_f64, .return_type = null_type() }
+        builtin_val{ .ptr = builtin_print<double>, .return_type = null_type() }
     );
     builtins.emplace(
         builtin_key{ .name = "println", .args = { f64_type() } },
-        builtin_val{ .ptr = builtin_println_f64, .return_type = null_type() }
+        builtin_val{ .ptr = builtin_println<double>, .return_type = null_type() }
     );
 
     builtins.emplace(
         builtin_key{ .name = "print", .args = { bool_type() } },
-        builtin_val{ .ptr = builtin_print_bool, .return_type = null_type() }
+        builtin_val{ .ptr = builtin_print<bool>, .return_type = null_type() }
     );
     builtins.emplace(
         builtin_key{ .name = "println", .args = { bool_type() } },
-        builtin_val{ .ptr = builtin_println_bool, .return_type = null_type() }
+        builtin_val{ .ptr = builtin_println<bool>, .return_type = null_type() }
     );
 
     builtins.emplace(
         builtin_key{ .name = "print", .args = { null_type() } },
-        builtin_val{ .ptr = builtin_print_null, .return_type = null_type() }
+        builtin_val{ .ptr = builtin_print<std::byte>, .return_type = null_type() }
     );
     builtins.emplace(
         builtin_key{ .name = "println", .args = { null_type() } },
-        builtin_val{ .ptr = builtin_println_null, .return_type = null_type() }
+        builtin_val{ .ptr = builtin_println<std::byte>, .return_type = null_type() }
     );
 
     builtins.emplace(
         builtin_key{ .name = "print", .args = { i32_type() } },
-        builtin_val{ .ptr = builtin_print_i32, .return_type = null_type() }
+        builtin_val{ .ptr = builtin_print<std::int32_t>, .return_type = null_type() }
     );
     builtins.emplace(
         builtin_key{ .name = "println", .args = { i32_type() } },
-        builtin_val{ .ptr = builtin_println_i32, .return_type = null_type() }
+        builtin_val{ .ptr = builtin_println<std::int32_t>, .return_type = null_type() }
     );
 
     builtins.emplace(
         builtin_key{ .name = "print", .args = { i64_type() } },
-        builtin_val{ .ptr = builtin_print_i64, .return_type = null_type() }
+        builtin_val{ .ptr = builtin_print<std::int64_t>, .return_type = null_type() }
     );
     builtins.emplace(
         builtin_key{ .name = "println", .args = { i64_type() } },
-        builtin_val{ .ptr = builtin_println_i64, .return_type = null_type() }
+        builtin_val{ .ptr = builtin_println<std::int64_t>, .return_type = null_type() }
     );
 
     return builtins;

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -12,134 +12,134 @@
 namespace anzu {
 namespace {
 
-auto builtin_sqrt(std::span<const std::byte> args) -> std::vector<std::byte>
+static constexpr auto SIZE32 = sizeof(std::uint32_t);
+static constexpr auto SIZE64 = sizeof(std::uint64_t);
+
+auto builtin_sqrt(std::vector<std::byte>& mem) -> void
 {
-    auto bytes = std::array<std::byte, sizeof(std::uint64_t)>();
-    std::memcpy(bytes.data(), args.data(), sizeof(std::uint64_t));
+    auto bytes = std::array<std::byte, SIZE64>();
+    std::memcpy(bytes.data(), mem.data(), SIZE64);
+
     const auto val = std::sqrt(std::bit_cast<double>(bytes));
-    return to_bytes(val);
+    bytes = std::bit_cast<std::array<std::byte, SIZE64>>(val);
+
+    std::memcpy(mem.data(), bytes.data(), SIZE64);
 }
 
-auto builtin_print_char(std::span<const std::byte> args) -> std::vector<std::byte>
+auto builtin_print_char(std::vector<std::byte>& mem) -> void
 {
-    print("{}", static_cast<char>(args[0]));
-    return std::vector{std::byte{0}};
+    print("{}", static_cast<char>(mem.back()));
+    mem.back() = std::byte{0}; // returns null
 }
 
-auto builtin_println_char(std::span<const std::byte> args) -> std::vector<std::byte>
+auto builtin_println_char(std::vector<std::byte>& mem) -> void
 {
-    print("{}\n", static_cast<char>(args[0]));
-    return std::vector{std::byte{0}};
+    print("{}\n", static_cast<char>(mem.back()));
+    mem.back() = std::byte{0}; // returns null
 }
 
-auto builtin_print_bool(std::span<const std::byte> args) -> std::vector<std::byte>
+auto builtin_print_bool(std::vector<std::byte>& mem) -> void
 {
-    print("{}", args[0] == std::byte{1});
-    return std::vector{std::byte{0}};
+    print("{}", mem.back() == std::byte{1});
+    mem.back() = std::byte{0}; // returns null
 }
 
-auto builtin_println_bool(std::span<const std::byte> args) -> std::vector<std::byte>
+auto builtin_println_bool(std::vector<std::byte>& mem) -> void
 {
-    print("{}\n", args[0] == std::byte{1});
-    return std::vector{std::byte{0}};
+    print("{}\n", mem.back() == std::byte{1});
+    mem.back() = std::byte{0}; // returns null
 }
 
-auto builtin_print_null(std::span<const std::byte> args) -> std::vector<std::byte>
+auto builtin_print_null(std::vector<std::byte>& mem) -> void
 {
     print("null");
-    return std::vector{std::byte{0}};
+    mem.back() = std::byte{0}; // returns null
 }
 
-auto builtin_println_null(std::span<const std::byte> args) -> std::vector<std::byte>
+auto builtin_println_null(std::vector<std::byte>& mem) -> void
 {
     print("null\n");
-    return std::vector{std::byte{0}};
+    mem.back() = std::byte{0}; // returns null
 }
 
-auto builtin_print_i32(std::span<const std::byte> args) -> std::vector<std::byte>
+auto builtin_print_i32(std::vector<std::byte>& mem) -> void
 {
-    auto bytes = std::array<std::byte, 4>();
-    for (std::size_t i = 0; i != 4; ++i) {
-        bytes[i] = args[i];
-    }
+    auto bytes = std::array<std::byte, SIZE32>();
+    std::memcpy(bytes.data(), mem.data(), SIZE32);
     print("{}", std::bit_cast<std::int32_t>(bytes));
-    return std::vector{std::byte{0}};
+
+    mem.resize(mem.size() - SIZE32);
+    mem.push_back(std::byte{0}); // returns null
 }
 
-auto builtin_println_i32(std::span<const std::byte> args) -> std::vector<std::byte>
+auto builtin_println_i32(std::vector<std::byte>& mem) -> void
 {
-    auto bytes = std::array<std::byte, 4>();
-    for (std::size_t i = 0; i != 4; ++i) {
-        bytes[i] = args[i];
-    }
+    auto bytes = std::array<std::byte, SIZE32>();
+    std::memcpy(bytes.data(), mem.data(), SIZE32);
     print("{}\n", std::bit_cast<std::int32_t>(bytes));
-    return std::vector{std::byte{0}};
+
+    mem.resize(mem.size() - SIZE32);
+    mem.push_back(std::byte{0}); // returns null
 }
 
-auto builtin_print_i64(std::span<const std::byte> args) -> std::vector<std::byte>
+auto builtin_print_i64(std::vector<std::byte>& mem) -> void
 {
-    auto bytes = std::array<std::byte, 8>();
-    for (std::size_t i = 0; i != 8; ++i) {
-        bytes[i] = args[i];
-    }
+    auto bytes = std::array<std::byte, SIZE64>();
+    std::memcpy(bytes.data(), mem.data(), SIZE64);
     print("{}", std::bit_cast<std::int64_t>(bytes));
-    return std::vector{std::byte{0}};
+
+    mem.resize(mem.size() - SIZE64);
+    mem.push_back(std::byte{0}); // returns null
 }
 
-auto builtin_println_i64(std::span<const std::byte> args) -> std::vector<std::byte>
+auto builtin_println_i64(std::vector<std::byte>& mem) -> void
 {
-    auto bytes = std::array<std::byte, 8>();
-    for (std::size_t i = 0; i != 8; ++i) {
-        bytes[i] = args[i];
-    }
+    auto bytes = std::array<std::byte, SIZE64>();
+    std::memcpy(bytes.data(), mem.data(), SIZE64);
     print("{}\n", std::bit_cast<std::int64_t>(bytes));
-    return std::vector{std::byte{0}};
+
+    mem.resize(mem.size() - SIZE64);
+    mem.push_back(std::byte{0}); // returns null
 }
 
-auto builtin_print_u64(std::span<const std::byte> args) -> std::vector<std::byte>
+auto builtin_print_u64(std::vector<std::byte>& mem) -> void
 {
-    auto bytes = std::array<std::byte, 8>();
-    for (std::size_t i = 0; i != 8; ++i) {
-        bytes[i] = args[i];
-    }
+    auto bytes = std::array<std::byte, SIZE64>();
+    std::memcpy(bytes.data(), mem.data(), SIZE64);
     print("{}", std::bit_cast<std::uint64_t>(bytes));
-    return std::vector{std::byte{0}};
+
+    mem.resize(mem.size() - SIZE64);
+    mem.push_back(std::byte{0}); // returns null
 }
 
-auto builtin_println_u64(std::span<const std::byte> args) -> std::vector<std::byte>
+auto builtin_println_u64(std::vector<std::byte>& mem) -> void
 {
-    auto bytes = std::array<std::byte, 8>();
-    for (std::size_t i = 0; i != 8; ++i) {
-        bytes[i] = args[i];
-    }
+    auto bytes = std::array<std::byte, SIZE64>();
+    std::memcpy(bytes.data(), mem.data(), SIZE64);
     print("{}\n", std::bit_cast<std::uint64_t>(bytes));
-    return std::vector{std::byte{0}};
+
+    mem.resize(mem.size() - SIZE64);
+    mem.push_back(std::byte{0}); // returns null
 }
 
-auto builtin_print_f64(std::span<const std::byte> args) -> std::vector<std::byte>
+auto builtin_print_f64(std::vector<std::byte>& mem) -> void
 {
-    auto bytes = std::array<std::byte, 8>();
-    for (std::size_t i = 0; i != 8; ++i) {
-        bytes[i] = args[i];
-    }
+    auto bytes = std::array<std::byte, SIZE64>();
+    std::memcpy(bytes.data(), mem.data(), SIZE64);
     print("{}", std::bit_cast<double>(bytes));
-    return std::vector{std::byte{0}};
+
+    mem.resize(mem.size() - SIZE64);
+    mem.push_back(std::byte{0}); // returns null
 }
 
-auto builtin_println_f64(std::span<const std::byte> args) -> std::vector<std::byte>
+auto builtin_println_f64(std::vector<std::byte>& mem) -> void
 {
-    auto bytes = std::array<std::byte, 8>();
-    for (std::size_t i = 0; i != 8; ++i) {
-        bytes[i] = args[i];
-    }
+    auto bytes = std::array<std::byte, SIZE64>();
+    std::memcpy(bytes.data(), mem.data(), SIZE64);
     print("{}\n", std::bit_cast<double>(bytes));
-    return std::vector{std::byte{0}};
-}
 
-auto builtin_put(std::span<const std::byte> args) -> std::vector<std::byte>
-{
-    anzu::print("{}", static_cast<char>(args[0]));
-    return std::vector{std::byte{0}};
+    mem.resize(mem.size() - SIZE64);
+    mem.push_back(std::byte{0}); // returns null
 }
 
 }
@@ -214,11 +214,6 @@ auto construct_builtin_map() -> builtin_map
     builtins.emplace(
         builtin_key{ .name = "println", .args = { i64_type() } },
         builtin_val{ .ptr = builtin_println_i64, .return_type = null_type() }
-    );
-
-    builtins.emplace(
-        builtin_key{ .name = "put", .args = { char_type() } },
-        builtin_val{ .ptr = builtin_put, .return_type = null_type() }
     );
 
     return builtins;

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -7,154 +7,139 @@
 #include <unordered_map>
 #include <string>
 #include <functional>
+#include <utility>
 
 namespace anzu {
 namespace {
 
-auto builtin_sqrt(std::span<const block> args) -> std::vector<block>
+auto builtin_sqrt(std::span<const std::byte> args) -> std::vector<std::byte>
 {
-    auto bytes = std::array<std::byte, 8>();
-    for (std::size_t i = 0; i != 8; ++i) {
-        bytes[i] = std::get<std::byte>(args[i]);
-    }
+    auto bytes = std::array<std::byte, sizeof(std::uint64_t)>();
+    std::memcpy(bytes.data(), args.data(), sizeof(std::uint64_t));
     const auto val = std::sqrt(std::bit_cast<double>(bytes));
     return to_bytes(val);
 }
 
-template <typename T>
-auto builtin_print(std::span<const block> args) -> std::vector<block>
+auto builtin_print_char(std::span<const std::byte> args) -> std::vector<std::byte>
 {
-    print("{}", std::get<T>(args[0]));
-    return {block{block_byte{0}}};
+    print("{}", static_cast<char>(args[0]));
+    return std::vector{std::byte{0}};
 }
 
-template <typename T>
-auto builtin_println(std::span<const block> args) -> std::vector<block>
+auto builtin_println_char(std::span<const std::byte> args) -> std::vector<std::byte>
 {
-    print("{}\n", std::get<T>(args[0]));
-    return {block{block_byte{0}}};
+    print("{}\n", static_cast<char>(args[0]));
+    return std::vector{std::byte{0}};
 }
 
-auto builtin_print_char(std::span<const block> args) -> std::vector<block>
+auto builtin_print_bool(std::span<const std::byte> args) -> std::vector<std::byte>
 {
-    print("{}", static_cast<char>(std::get<block_byte>(args[0])));
-    return {block{block_byte{0}}};
+    print("{}", args[0] == std::byte{1});
+    return std::vector{std::byte{0}};
 }
 
-auto builtin_println_char(std::span<const block> args) -> std::vector<block>
+auto builtin_println_bool(std::span<const std::byte> args) -> std::vector<std::byte>
 {
-    print("{}\n", static_cast<char>(std::get<block_byte>(args[0])));
-    return {block{block_byte{0}}};
+    print("{}\n", args[0] == std::byte{1});
+    return std::vector{std::byte{0}};
 }
 
-auto builtin_print_bool(std::span<const block> args) -> std::vector<block>
-{
-    print("{}", std::get<block_byte>(args[0]) == block_byte{1});
-    return {block{block_byte{0}}};
-}
-
-auto builtin_println_bool(std::span<const block> args) -> std::vector<block>
-{
-    print("{}\n", std::get<block_byte>(args[0]) == block_byte{1});
-    return {block{block_byte{0}}};
-}
-
-auto builtin_print_null(std::span<const block> args) -> std::vector<block>
+auto builtin_print_null(std::span<const std::byte> args) -> std::vector<std::byte>
 {
     print("null");
-    return {block{block_byte{0}}};
+    return std::vector{std::byte{0}};
 }
 
-auto builtin_println_null(std::span<const block> args) -> std::vector<block>
+auto builtin_println_null(std::span<const std::byte> args) -> std::vector<std::byte>
 {
     print("null\n");
-    return {block{block_byte{0}}};
+    return std::vector{std::byte{0}};
 }
 
-auto builtin_print_i32(std::span<const block> args) -> std::vector<block>
+auto builtin_print_i32(std::span<const std::byte> args) -> std::vector<std::byte>
 {
     auto bytes = std::array<std::byte, 4>();
     for (std::size_t i = 0; i != 4; ++i) {
-        bytes[i] = std::get<std::byte>(args[i]);
+        bytes[i] = args[i];
     }
     print("{}", std::bit_cast<std::int32_t>(bytes));
-    return {block{block_byte{0}}};
+    return std::vector{std::byte{0}};
 }
 
-auto builtin_println_i32(std::span<const block> args) -> std::vector<block>
+auto builtin_println_i32(std::span<const std::byte> args) -> std::vector<std::byte>
 {
     auto bytes = std::array<std::byte, 4>();
     for (std::size_t i = 0; i != 4; ++i) {
-        bytes[i] = std::get<std::byte>(args[i]);
+        bytes[i] = args[i];
     }
     print("{}\n", std::bit_cast<std::int32_t>(bytes));
-    return {block{block_byte{0}}};
+    return std::vector{std::byte{0}};
 }
 
-auto builtin_print_i64(std::span<const block> args) -> std::vector<block>
+auto builtin_print_i64(std::span<const std::byte> args) -> std::vector<std::byte>
 {
     auto bytes = std::array<std::byte, 8>();
     for (std::size_t i = 0; i != 8; ++i) {
-        bytes[i] = std::get<std::byte>(args[i]);
+        bytes[i] = args[i];
     }
     print("{}", std::bit_cast<std::int64_t>(bytes));
-    return {block{block_byte{0}}};
+    return std::vector{std::byte{0}};
 }
 
-auto builtin_println_i64(std::span<const block> args) -> std::vector<block>
+auto builtin_println_i64(std::span<const std::byte> args) -> std::vector<std::byte>
 {
     auto bytes = std::array<std::byte, 8>();
     for (std::size_t i = 0; i != 8; ++i) {
-        bytes[i] = std::get<std::byte>(args[i]);
+        bytes[i] = args[i];
     }
     print("{}\n", std::bit_cast<std::int64_t>(bytes));
-    return {block{block_byte{0}}};
+    return std::vector{std::byte{0}};
 }
 
-auto builtin_print_u64(std::span<const block> args) -> std::vector<block>
+auto builtin_print_u64(std::span<const std::byte> args) -> std::vector<std::byte>
 {
     auto bytes = std::array<std::byte, 8>();
     for (std::size_t i = 0; i != 8; ++i) {
-        bytes[i] = std::get<std::byte>(args[i]);
+        bytes[i] = args[i];
     }
     print("{}", std::bit_cast<std::uint64_t>(bytes));
-    return {block{block_byte{0}}};
+    return std::vector{std::byte{0}};
 }
 
-auto builtin_println_u64(std::span<const block> args) -> std::vector<block>
+auto builtin_println_u64(std::span<const std::byte> args) -> std::vector<std::byte>
 {
     auto bytes = std::array<std::byte, 8>();
     for (std::size_t i = 0; i != 8; ++i) {
-        bytes[i] = std::get<std::byte>(args[i]);
+        bytes[i] = args[i];
     }
     print("{}\n", std::bit_cast<std::uint64_t>(bytes));
-    return {block{block_byte{0}}};
+    return std::vector{std::byte{0}};
 }
 
-auto builtin_print_f64(std::span<const block> args) -> std::vector<block>
+auto builtin_print_f64(std::span<const std::byte> args) -> std::vector<std::byte>
 {
     auto bytes = std::array<std::byte, 8>();
     for (std::size_t i = 0; i != 8; ++i) {
-        bytes[i] = std::get<std::byte>(args[i]);
+        bytes[i] = args[i];
     }
     print("{}", std::bit_cast<double>(bytes));
-    return {block{block_byte{0}}};
+    return std::vector{std::byte{0}};
 }
 
-auto builtin_println_f64(std::span<const block> args) -> std::vector<block>
+auto builtin_println_f64(std::span<const std::byte> args) -> std::vector<std::byte>
 {
     auto bytes = std::array<std::byte, 8>();
     for (std::size_t i = 0; i != 8; ++i) {
-        bytes[i] = std::get<std::byte>(args[i]);
+        bytes[i] = args[i];
     }
     print("{}\n", std::bit_cast<double>(bytes));
-    return {block{block_byte{0}}};
+    return std::vector{std::byte{0}};
 }
 
-auto builtin_put(std::span<const block> args) -> std::vector<block>
+auto builtin_put(std::span<const std::byte> args) -> std::vector<std::byte>
 {
-    anzu::print("{}", static_cast<char>(std::get<block_byte>(args[0])));
-    return {block{block_byte{0}}};
+    anzu::print("{}", static_cast<char>(args[0]));
+    return std::vector{std::byte{0}};
 }
 
 }
@@ -265,14 +250,14 @@ auto fetch_builtin(const std::string& name, const std::vector<type_name>& args) 
         const auto newline = name == "println";
         const auto length = std::get<type_list>(args[0]).count;
         return builtin_val{
-            .ptr = [=](std::span<const block> data) -> std::vector<block> {
+            .ptr = [=](std::span<const std::byte> data) -> std::vector<std::byte> {
                 for (const auto& datum : data) {
-                    print("{}", static_cast<char>(std::get<block_byte>(datum)));
+                    print("{}", static_cast<char>(datum));
                 }
                 if (newline) {
                     print("\n");
                 }
-                return {block{block_byte{0}}};
+                return std::vector{std::byte{0}};
             },
             .return_type = null_type()
         };

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -3,6 +3,7 @@
 #include "runtime.hpp"
 #include "utility/print.hpp"
 #include "utility/overloaded.hpp"
+#include "utility/memory.hpp"
 
 #include <unordered_map>
 #include <string>
@@ -11,30 +12,6 @@
 
 namespace anzu {
 namespace {
-
-static constexpr auto SIZE64 = sizeof(std::uint64_t);
-
-auto pop_n(std::vector<std::byte>& mem, std::size_t count) -> void
-{
-    mem.resize(mem.size() - count);
-}
-
-template <typename T>
-auto pop_value(std::vector<std::byte>& mem) -> T
-{
-    auto ret = T{};
-    std::memcpy(&ret, &mem[mem.size() - sizeof(T)], sizeof(T));
-    mem.resize(mem.size() - sizeof(T));
-    return ret;
-}
-
-template <typename T>
-auto push_value(std::vector<std::byte>& mem, const T& value) -> void
-{
-    for (const auto& b : as_bytes(value)) {
-        mem.push_back(b);
-    }
-}
 
 auto builtin_sqrt(std::vector<std::byte>& mem) -> void
 {

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -9,7 +9,7 @@
 
 namespace anzu {
 
-using builtin_function = std::function<std::vector<std::byte>(std::span<const std::byte>)>;
+using builtin_function = std::function<void(std::vector<std::byte>&)>;
 
 struct builtin_key
 {

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -9,7 +9,7 @@
 
 namespace anzu {
 
-using builtin_function = std::function<std::vector<block>(std::span<const block>)>;
+using builtin_function = std::function<std::vector<std::byte>(std::span<const std::byte>)>;
 
 struct builtin_key
 {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -17,14 +17,6 @@ auto format_error(const std::string& str) -> void
 
 }
 
-auto to_string(const block& blk) -> std::string
-{
-    return std::visit(overloaded {
-        [](block_byte byte) { return std::format("{:X}", static_cast<unsigned char>(byte)); },
-        [](auto&& val) { return std::format("{}", val); }
-    }, blk);
-}
-
 auto to_string(const object& object) -> std::string
 {
     return std::format("{}({})", object.type, format_comma_separated(object.data));
@@ -57,13 +49,13 @@ auto make_char(char val) -> object
 
 auto make_bool(bool val) -> object
 {
-    const auto v = val ? block_byte{1} : block_byte{0};
+    const auto v = val ? std::byte{1} : std::byte{0};
     return { .data = { v }, .type = bool_type() };
 }
 
 auto make_null() -> object
 {
-    return { .data = { block_byte{0} }, .type = null_type() };
+    return { .data = { std::byte{0} }, .type = null_type() };
 }
 
 auto format_special_chars(const std::string& str) -> std::string

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -24,22 +24,26 @@ auto to_string(const object& object) -> std::string
 
 auto make_i32(std::int32_t val) -> object
 {
-    return { .data = to_bytes(val), .type = i32_type() };
+    const auto bytes = as_bytes(val);
+    return { .data = {bytes.begin(), bytes.end()}, .type = i32_type() };
 }
 
 auto make_i64(std::int64_t val) -> object
 {
-    return { .data = to_bytes(val), .type = i64_type() };
+    const auto bytes = as_bytes(val);
+    return { .data = {bytes.begin(), bytes.end()}, .type = i64_type() };
 }
 
 auto make_u64(std::uint64_t val) -> object
 {
-    return { .data = to_bytes(val), .type = u64_type() };
+    const auto bytes = as_bytes(val);
+    return { .data = {bytes.begin(), bytes.end()}, .type = u64_type() };
 }
 
 auto make_f64(double val) -> object
 {
-    return { .data = to_bytes(val), .type = f64_type() };
+    const auto bytes = as_bytes(val);
+    return { .data = {bytes.begin(), bytes.end()}, .type = f64_type() };
 }
 
 auto make_char(char val) -> object

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -34,27 +34,9 @@ auto make_null() -> object;
 auto format_special_chars(const std::string& str) -> std::string;
 
 template <typename T>
-inline auto to_bytes(const T& val) -> std::vector<std::byte>
+inline auto as_bytes(const T& val) -> std::array<std::byte, sizeof(T)>
 {
-    auto ret = std::vector<std::byte>{};
-    for (const auto b : std::bit_cast<std::array<std::byte, sizeof(T)>>(val)) {
-        ret.push_back(b);
-    }
-    return ret;
-}
-
-template <typename T>
-inline auto from_bytes(const std::vector<std::byte>& val) -> T
-{
-    if (val.size() != sizeof(T)) {
-        print("oh no, size = {}\n", val.size());
-        std::exit(1);
-    }
-    auto bytes = std::array<std::byte, sizeof(T)>{};
-    for (std::size_t i = 0; i != sizeof(T); ++i) {
-        bytes[i] = val[i];
-    }
-    return std::bit_cast<T>(bytes);
+    return std::bit_cast<std::array<std::byte, sizeof(T)>>(val);
 }
 
 }

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -7,12 +7,6 @@
 namespace anzu {
 namespace {
 
-auto pop_n(std::vector<std::byte>& mem, std::size_t n) -> void
-{
-    mem.resize(mem.size() - n);
-}
-
-// TODO: Dedeup this, also appears in runtime
 template <typename T>
 auto push_value(std::vector<std::byte>& mem, const T& value) -> void
 {
@@ -21,18 +15,17 @@ auto push_value(std::vector<std::byte>& mem, const T& value) -> void
     }
 }
 
-// TODO: Dedeup this, also appears in runtime
 template <typename T>
 auto pop_value(std::vector<std::byte>& mem) -> T
 {
     auto ret = T{};
     std::memcpy(&ret, &mem[mem.size() - sizeof(T)], sizeof(T));
-    pop_n(mem, sizeof(T));
+    mem.resize(mem.size() - sizeof(T));
     return ret;
 }
 
 template <typename Type, template <typename> typename Op>
-auto bin_op_bytes(std::vector<std::byte>& mem) -> void
+auto bin_op(std::vector<std::byte>& mem) -> void
 {
     static constexpr auto op = Op<Type>{};
     const auto rhs = pop_value<Type>(mem);
@@ -47,13 +40,12 @@ auto ptr_addition(std::vector<std::byte>& mem)
     const auto offset = pop_value<std::uint64_t>(mem);
     const auto size = pop_value<std::uint64_t>(mem);
     const auto ptr = pop_value<std::uint64_t>(mem);
-
     push_value(mem, ptr + offset * size);
     push_value(mem, size);
 }
 
 template <typename Type, template <typename> typename Op>
-auto unary_op_sized(std::vector<std::byte>& mem)
+auto unary_op(std::vector<std::byte>& mem)
 {
     static constexpr auto op = Op<Type>{};
     const auto obj = pop_value<Type>(mem);
@@ -80,118 +72,118 @@ auto resolve_binary_op(const binary_op_description& desc) -> std::optional<binar
 
     if (type == i32_type()) {
         if (desc.op == tk_add) {
-            return binary_op_info{ bin_op_bytes<std::int32_t, std::plus>, type };
+            return binary_op_info{ bin_op<std::int32_t, std::plus>, type };
         } else if (desc.op == tk_sub) {
-            return binary_op_info{ bin_op_bytes<std::int32_t, std::minus>, type };
+            return binary_op_info{ bin_op<std::int32_t, std::minus>, type };
         } else if (desc.op == tk_mul) {
-            return binary_op_info{ bin_op_bytes<std::int32_t, std::multiplies>, type };
+            return binary_op_info{ bin_op<std::int32_t, std::multiplies>, type };
         } else if (desc.op == tk_div) {
-            return binary_op_info{ bin_op_bytes<std::int32_t, std::divides>, type };
+            return binary_op_info{ bin_op<std::int32_t, std::divides>, type };
         } else if (desc.op == tk_mod) {
-            return binary_op_info{ bin_op_bytes<std::int32_t, std::modulus>, type };
+            return binary_op_info{ bin_op<std::int32_t, std::modulus>, type };
         } else if (desc.op == tk_lt) {
-            return binary_op_info{ bin_op_bytes<std::int32_t, std::less>, bool_type() };
+            return binary_op_info{ bin_op<std::int32_t, std::less>, bool_type() };
         } else if (desc.op == tk_le) {
-            return binary_op_info{ bin_op_bytes<std::int32_t, std::less_equal>, bool_type() };
+            return binary_op_info{ bin_op<std::int32_t, std::less_equal>, bool_type() };
         } else if (desc.op == tk_gt) {
-            return binary_op_info{ bin_op_bytes<std::int32_t, std::greater>, bool_type() };
+            return binary_op_info{ bin_op<std::int32_t, std::greater>, bool_type() };
         } else if (desc.op == tk_ge) {
-            return binary_op_info{ bin_op_bytes<std::int32_t, std::greater_equal>, bool_type() };
+            return binary_op_info{ bin_op<std::int32_t, std::greater_equal>, bool_type() };
         } else if (desc.op == tk_eq) {
-            return binary_op_info{ bin_op_bytes<std::int32_t, std::equal_to>, bool_type() };
+            return binary_op_info{ bin_op<std::int32_t, std::equal_to>, bool_type() };
         } else if (desc.op == tk_ne) {
-            return binary_op_info{ bin_op_bytes<std::int32_t, std::not_equal_to>, bool_type() };
+            return binary_op_info{ bin_op<std::int32_t, std::not_equal_to>, bool_type() };
         }
     }
     else if (type == i64_type()) {
         if (desc.op == tk_add) {
-            return binary_op_info{ bin_op_bytes<std::int64_t, std::plus>, type };
+            return binary_op_info{ bin_op<std::int64_t, std::plus>, type };
         } else if (desc.op == tk_sub) {
-            return binary_op_info{ bin_op_bytes<std::int64_t, std::minus>, type };
+            return binary_op_info{ bin_op<std::int64_t, std::minus>, type };
         } else if (desc.op == tk_mul) {
-            return binary_op_info{ bin_op_bytes<std::int64_t, std::multiplies>, type };
+            return binary_op_info{ bin_op<std::int64_t, std::multiplies>, type };
         } else if (desc.op == tk_div) {
-            return binary_op_info{ bin_op_bytes<std::int64_t, std::divides>, type };
+            return binary_op_info{ bin_op<std::int64_t, std::divides>, type };
         } else if (desc.op == tk_mod) {
-            return binary_op_info{ bin_op_bytes<std::int64_t, std::modulus>, type };
+            return binary_op_info{ bin_op<std::int64_t, std::modulus>, type };
         } else if (desc.op == tk_lt) {
-            return binary_op_info{ bin_op_bytes<std::int64_t, std::less>, bool_type() };
+            return binary_op_info{ bin_op<std::int64_t, std::less>, bool_type() };
         } else if (desc.op == tk_le) {
-            return binary_op_info{ bin_op_bytes<std::int64_t, std::less_equal>, bool_type() };
+            return binary_op_info{ bin_op<std::int64_t, std::less_equal>, bool_type() };
         } else if (desc.op == tk_gt) {
-            return binary_op_info{ bin_op_bytes<std::int64_t, std::greater>, bool_type() };
+            return binary_op_info{ bin_op<std::int64_t, std::greater>, bool_type() };
         } else if (desc.op == tk_ge) {
-            return binary_op_info{ bin_op_bytes<std::int64_t, std::greater_equal>, bool_type() };
+            return binary_op_info{ bin_op<std::int64_t, std::greater_equal>, bool_type() };
         } else if (desc.op == tk_eq) {
-            return binary_op_info{ bin_op_bytes<std::int64_t, std::equal_to>, bool_type() };
+            return binary_op_info{ bin_op<std::int64_t, std::equal_to>, bool_type() };
         } else if (desc.op == tk_ne) {
-            return binary_op_info{ bin_op_bytes<std::int64_t, std::not_equal_to>, bool_type() };
+            return binary_op_info{ bin_op<std::int64_t, std::not_equal_to>, bool_type() };
         }
     }
     else if (type == u64_type()) {
         if (desc.op == tk_add) {
-            return binary_op_info{ bin_op_bytes<std::uint64_t, std::plus>, type };
+            return binary_op_info{ bin_op<std::uint64_t, std::plus>, type };
         } else if (desc.op == tk_sub) {
-            return binary_op_info{ bin_op_bytes<std::uint64_t, std::minus>, type };
+            return binary_op_info{ bin_op<std::uint64_t, std::minus>, type };
         } else if (desc.op == tk_mul) {
-            return binary_op_info{ bin_op_bytes<std::uint64_t, std::multiplies>, type };
+            return binary_op_info{ bin_op<std::uint64_t, std::multiplies>, type };
         } else if (desc.op == tk_div) {
-            return binary_op_info{ bin_op_bytes<std::uint64_t, std::divides>, type };
+            return binary_op_info{ bin_op<std::uint64_t, std::divides>, type };
         } else if (desc.op == tk_mod) {
-            return binary_op_info{ bin_op_bytes<std::uint64_t, std::modulus>, type };
+            return binary_op_info{ bin_op<std::uint64_t, std::modulus>, type };
         } else if (desc.op == tk_lt) {
-            return binary_op_info{ bin_op_bytes<std::uint64_t, std::less>, bool_type() };
+            return binary_op_info{ bin_op<std::uint64_t, std::less>, bool_type() };
         } else if (desc.op == tk_le) {
-            return binary_op_info{ bin_op_bytes<std::uint64_t, std::less_equal>, bool_type() };
+            return binary_op_info{ bin_op<std::uint64_t, std::less_equal>, bool_type() };
         } else if (desc.op == tk_gt) {
-            return binary_op_info{ bin_op_bytes<std::uint64_t, std::greater>, bool_type() };
+            return binary_op_info{ bin_op<std::uint64_t, std::greater>, bool_type() };
         } else if (desc.op == tk_ge) {
-            return binary_op_info{ bin_op_bytes<std::uint64_t, std::greater_equal>, bool_type() };
+            return binary_op_info{ bin_op<std::uint64_t, std::greater_equal>, bool_type() };
         } else if (desc.op == tk_eq) {
-            return binary_op_info{ bin_op_bytes<std::uint64_t, std::equal_to>, bool_type() };
+            return binary_op_info{ bin_op<std::uint64_t, std::equal_to>, bool_type() };
         } else if (desc.op == tk_ne) {
-            return binary_op_info{ bin_op_bytes<std::uint64_t, std::not_equal_to>, bool_type() };
+            return binary_op_info{ bin_op<std::uint64_t, std::not_equal_to>, bool_type() };
         }
     }
     else if (type == f64_type()) {
         if (desc.op == tk_add) {
-            return binary_op_info{ bin_op_bytes<double, std::plus>, type };
+            return binary_op_info{ bin_op<double, std::plus>, type };
         } else if (desc.op == tk_sub) {
-            return binary_op_info{ bin_op_bytes<double, std::minus>, type };
+            return binary_op_info{ bin_op<double, std::minus>, type };
         } else if (desc.op == tk_mul) {
-            return binary_op_info{ bin_op_bytes<double, std::multiplies>, type };
+            return binary_op_info{ bin_op<double, std::multiplies>, type };
         } else if (desc.op == tk_div) {
-            return binary_op_info{ bin_op_bytes<double, std::divides>, type };
+            return binary_op_info{ bin_op<double, std::divides>, type };
         } else if (desc.op == tk_lt) {
-            return binary_op_info{ bin_op_bytes<double, std::less>, bool_type() };
+            return binary_op_info{ bin_op<double, std::less>, bool_type() };
         } else if (desc.op == tk_le) {
-            return binary_op_info{ bin_op_bytes<double, std::less_equal>, bool_type() };
+            return binary_op_info{ bin_op<double, std::less_equal>, bool_type() };
         } else if (desc.op == tk_gt) {
-            return binary_op_info{ bin_op_bytes<double, std::greater>, bool_type() };
+            return binary_op_info{ bin_op<double, std::greater>, bool_type() };
         } else if (desc.op == tk_ge) {
-            return binary_op_info{ bin_op_bytes<double, std::greater_equal>, bool_type() };
+            return binary_op_info{ bin_op<double, std::greater_equal>, bool_type() };
         } else if (desc.op == tk_eq) {
-            return binary_op_info{ bin_op_bytes<double, std::equal_to>, bool_type() };
+            return binary_op_info{ bin_op<double, std::equal_to>, bool_type() };
         } else if (desc.op == tk_ne) {
-            return binary_op_info{ bin_op_bytes<double, std::not_equal_to>, bool_type() };
+            return binary_op_info{ bin_op<double, std::not_equal_to>, bool_type() };
         }
     }
     else if (type == bool_type()) {
         if (desc.op == tk_and) {
-            return binary_op_info{ bin_op_bytes<bool, std::logical_and>, type };
+            return binary_op_info{ bin_op<bool, std::logical_and>, type };
         } else if (desc.op == tk_or) {
-            return binary_op_info{ bin_op_bytes<bool, std::logical_or>, type };
+            return binary_op_info{ bin_op<bool, std::logical_or>, type };
         } else if (desc.op == tk_eq) {
-            return binary_op_info{ bin_op_bytes<bool, std::equal_to>, bool_type() };
+            return binary_op_info{ bin_op<bool, std::equal_to>, bool_type() };
         } else if (desc.op == tk_ne) {
-            return binary_op_info{ bin_op_bytes<bool, std::not_equal_to>, bool_type() };
+            return binary_op_info{ bin_op<bool, std::not_equal_to>, bool_type() };
         }
     }
     else if (type == char_type()) {
         if (desc.op == tk_eq) {
-            return binary_op_info{ bin_op_bytes<char, std::equal_to>, bool_type() };
+            return binary_op_info{ bin_op<char, std::equal_to>, bool_type() };
         } else if (desc.op == tk_ne) {
-            return binary_op_info{ bin_op_bytes<char, std::equal_to>, bool_type() };
+            return binary_op_info{ bin_op<char, std::equal_to>, bool_type() };
         }
     }
 
@@ -203,22 +195,22 @@ auto resolve_unary_op(const unary_op_description& desc) -> std::optional<unary_o
     const auto& type = desc.type;
     if (type == i32_type()) {
         if (desc.op == tk_sub) {
-            return unary_op_info{ unary_op_sized<std::int32_t, std::negate>, type };
+            return unary_op_info{ unary_op<std::int32_t, std::negate>, type };
         }
     }
     else if (type == i64_type()) {
         if (desc.op == tk_sub) {
-            return unary_op_info{ unary_op_sized<std::int64_t, std::negate>, type };
+            return unary_op_info{ unary_op<std::int64_t, std::negate>, type };
         }
     }
     else if (type == f64_type()) {
         if (desc.op == tk_sub) {
-            return unary_op_info{ unary_op_sized<double, std::negate>, type };
+            return unary_op_info{ unary_op<double, std::negate>, type };
         }
     }
     else if (type == bool_type()) {
         if (desc.op == tk_bang) {
-            return unary_op_info{ unary_op_sized<bool, std::logical_not>, type };
+            return unary_op_info{ unary_op<bool, std::logical_not>, type };
         }
     }
     return std::nullopt;

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -7,93 +7,57 @@
 namespace anzu {
 namespace {
 
-template <typename T>
-auto get_back(std::vector<std::byte>& mem, std::size_t index) -> T&
-{
-    return std::get<std::remove_cvref_t<T>>(mem[mem.size() - index - 1]);
-}
-
 auto pop_n(std::vector<std::byte>& mem, std::size_t n) -> void
 {
     mem.resize(mem.size() - n);
 }
 
+// TODO: Dedeup this, also appears in runtime
+template <typename T>
+auto push_value(std::vector<std::byte>& mem, const T& value) -> void
+{
+    for (const auto& b : std::bit_cast<std::array<std::byte, sizeof(T)>>(value)) {
+        mem.push_back(b);
+    }
+}
+
+// TODO: Dedeup this, also appears in runtime
+template <typename T>
+auto pop_value(std::vector<std::byte>& mem) -> T
+{
+    auto ret = T{};
+    std::memcpy(&ret, &mem[mem.size() - sizeof(T)], sizeof(T));
+    pop_n(mem, sizeof(T));
+    return ret;
+}
+
 template <typename Type, template <typename> typename Op>
 auto bin_op_bytes(std::vector<std::byte>& mem) -> void
 {
-    const auto op = Op<Type>{};
-    auto lhs_bytes = std::vector<std::byte>{};
-    for (std::size_t i = 0; i != sizeof(Type); ++i) {
-        lhs_bytes.push_back(mem[mem.size() - (2 * sizeof(Type)) + i]);
-    }
-    const auto lhs = from_bytes<Type>(lhs_bytes);
-    auto rhs_bytes = std::vector<std::byte>{};
-    for (std::size_t i = 0; i != sizeof(Type); ++i) {
-        rhs_bytes.push_back(mem[mem.size() - sizeof(Type) + i]);
-    }
-    const auto rhs = from_bytes<Type>(rhs_bytes);
-    pop_n(mem, 2 * sizeof(Type));
-    const auto ret = op(lhs, rhs);
-    const auto ret_bytes = std::bit_cast<std::array<std::byte, sizeof(ret)>>(ret);
-    for (const auto& b : ret_bytes) {
-        mem.push_back(b);
-    }
-}
-
-// TODO: Dedeup this, also appears in runtime
-auto push_u64(std::vector<std::byte>& mem, std::uint64_t value) -> void
-{
-    for (const auto& b : std::bit_cast<std::array<std::byte, sizeof(std::uint64_t)>>(value)) {
-        mem.push_back(b);
-    }
-}
-
-// TODO: Dedeup this, also appears in runtime
-auto pop_u64(std::vector<std::byte>& mem) -> std::uint64_t
-{
-    auto bytes = std::array<std::byte, sizeof(std::uint64_t)>{};
-    for (std::size_t i = 0; i != sizeof(std::uint64_t); ++i) {
-        bytes[i] = mem[mem.size() - sizeof(std::uint64_t) + i];
-    }
-    for (std::size_t i = 0; i != sizeof(std::uint64_t); ++i) {
-        mem.pop_back();
-    }
-    return std::bit_cast<std::uint64_t>(bytes);
+    static constexpr auto op = Op<Type>{};
+    const auto rhs = pop_value<Type>(mem);
+    const auto lhs = pop_value<Type>(mem);
+    push_value(mem, op(lhs, rhs));
 }
 
 // Top of stack: [ptr], [size], [offset]
 // offset is popped, size stays the same, ptr is modified
 auto ptr_addition(std::vector<std::byte>& mem)
 {
-    const auto offset = pop_u64(mem);
-    const auto size = pop_u64(mem);
-    const auto ptr = pop_u64(mem);
+    const auto offset = pop_value<std::uint64_t>(mem);
+    const auto size = pop_value<std::uint64_t>(mem);
+    const auto ptr = pop_value<std::uint64_t>(mem);
 
-    push_u64(mem, ptr + offset * size);
-    push_u64(mem, size);
+    push_value(mem, ptr + offset * size);
+    push_value(mem, size);
 }
 
 template <typename Type, template <typename> typename Op>
 auto unary_op_sized(std::vector<std::byte>& mem)
 {
-    const auto op = Op<Type>{};
-    auto obj_bytes = std::vector<std::byte>{};
-    for (std::size_t i = 0; i != sizeof(Type); ++i) {
-        obj_bytes.push_back(mem[mem.size() - (2 * sizeof(Type)) + i]);
-    }
-    const auto obj = from_bytes<Type>(obj_bytes);
-    pop_n(mem, sizeof(Type));
-    const auto ret = op(obj);
-    const auto ret_bytes = std::bit_cast<std::array<std::byte, sizeof(ret)>>(ret);
-    for (const auto& b : ret_bytes) {
-        mem.push_back(b);
-    }
-}
-
-auto bool_negate(std::vector<std::byte>& mem)
-{
-    auto& top = mem.back();
-    top = (top == std::byte{1}) ? std::byte{0} : std::byte{1};
+    static constexpr auto op = Op<Type>{};
+    const auto obj = pop_value<Type>(mem);
+    push_value(mem, op(obj));
 }
 
 }
@@ -254,7 +218,7 @@ auto resolve_unary_op(const unary_op_description& desc) -> std::optional<unary_o
     }
     else if (type == bool_type()) {
         if (desc.op == tk_bang) {
-            return unary_op_info{ bool_negate, type };
+            return unary_op_info{ unary_op_sized<bool, std::logical_not>, type };
         }
     }
     return std::nullopt;

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -24,12 +24,6 @@ auto to_type_name() -> type_name
 }
 
 template <typename T>
-auto as_bytes(const T& value) -> std::array<std::byte, sizeof(T)>
-{
-    return std::bit_cast<std::array<std::byte, sizeof(T)>>(value);
-}
-
-template <typename T>
 auto push_value(std::vector<std::byte>& mem, const T& value) -> void
 {
     for (const auto& b : as_bytes(value)) {
@@ -133,6 +127,7 @@ auto resolve_numerical_binary_op(std::string_view op) -> std::optional<binary_op
             return binary_op_info{ bin_op<T, std::modulus>, to_type_name<T>() };
         }
     }
+    return std::nullopt;
 }
 
 }
@@ -182,7 +177,6 @@ auto resolve_binary_op(const binary_op_description& desc) -> std::optional<binar
             return op.value();
         }
     }
-
     return std::nullopt;
 }
 

--- a/src/operators.cpp
+++ b/src/operators.cpp
@@ -1,5 +1,6 @@
 #include "operators.hpp"
 #include "object.hpp"
+#include "utility/memory.hpp"
 
 #include <algorithm>
 #include <functional>
@@ -21,23 +22,6 @@ auto to_type_name() -> type_name
     } else {
         static_assert(false);
     }
-}
-
-template <typename T>
-auto push_value(std::vector<std::byte>& mem, const T& value) -> void
-{
-    for (const auto& b : as_bytes(value)) {
-        mem.push_back(b);
-    }
-}
-
-template <typename T>
-auto pop_value(std::vector<std::byte>& mem) -> T
-{
-    auto ret = T{};
-    std::memcpy(&ret, &mem[mem.size() - sizeof(T)], sizeof(T));
-    mem.resize(mem.size() - sizeof(T));
-    return ret;
 }
 
 template <typename Type, template <typename> typename Op>

--- a/src/operators.hpp
+++ b/src/operators.hpp
@@ -8,7 +8,7 @@
 
 namespace anzu {
 
-using builtin_mem_op = std::function<void(std::vector<block>& memory)>;
+using builtin_mem_op = std::function<void(std::vector<std::byte>& memory)>;
 
 struct binary_op_description
 {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -106,7 +106,7 @@ auto parse_literal(tokenstream& tokens) -> object
     if (tokens.curr().type == token_type::string) {
         auto ret = object{};
         for (char c : tokens.curr().text) {
-            ret.data.push_back(static_cast<block_byte>(c));
+            ret.data.push_back(static_cast<std::byte>(c));
         }
         ret.type = concrete_list_type(char_type(), tokens.curr().text.size());
         tokens.consume();

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -15,8 +15,8 @@ constexpr auto FORMAT3 = std::string_view{"{:<30} {:<20} {}"};
 auto to_string(const op& op_code) -> std::string
 {
     return std::visit(overloaded {
-        [&](const op_load_literal& op) {
-            return std::format("LOAD_LITERAL({})", op.blk);
+        [&](const op_load_bytes& op) {
+            return std::format("LOAD_BYTES({})", format_comma_separated(op.bytes));
         },
         [&](const op_push_global_addr& op) {
             return std::format("PUSH_GLOBAL_ADDR({}, {})", op.position, op.size);

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -12,9 +12,9 @@
 
 namespace anzu {
 
-struct op_load_literal
+struct op_load_bytes
 {
-    std::byte blk;
+    std::vector<std::byte> bytes;
 };
 
 struct op_push_global_addr
@@ -114,7 +114,7 @@ struct op_return
 };
 
 struct op : std::variant<
-    op_load_literal,
+    op_load_bytes,
     op_push_global_addr,
     op_push_local_addr,
     op_modify_ptr,

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -6,6 +6,7 @@
 #include <variant>
 #include <format>
 #include <vector>
+#include <utility>
 #include <string>
 #include <string_view>
 
@@ -13,7 +14,7 @@ namespace anzu {
 
 struct op_load_literal
 {
-    block blk;
+    std::byte blk;
 };
 
 struct op_push_global_addr

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -164,16 +164,7 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.prog_ptr = op.ptr; // Jump into the function
         },
         [&](const op_builtin_call& op) {
-            auto args = std::vector<std::byte>(op.args_size);
-            for (auto& arg : args | std::views::reverse) {
-                arg = ctx.memory.back();
-                ctx.memory.pop_back();
-            }
-
-            const auto ret = op.ptr(args);
-            for (const auto& b : ret) {
-                ctx.memory.push_back(b);
-            }
+            op.ptr(ctx.memory);
             ++ctx.prog_ptr;
         },
         [&](const op_builtin_mem_op& op) {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -3,13 +3,12 @@
 #include "utility/print.hpp"
 #include "utility/overloaded.hpp"
 #include "utility/scope_timer.hpp"
+#include "utility/memory.hpp"
 
 #include <chrono>
 #include <utility>
 
 namespace anzu {
-
-static constexpr auto SIZE64 = sizeof(std::uint64_t);
 
 template <typename ...Args>
 auto runtime_assert(bool condition, std::string_view msg, Args&&... args)
@@ -18,39 +17,6 @@ auto runtime_assert(bool condition, std::string_view msg, Args&&... args)
         anzu::print(msg, std::forward<Args>(args)...);
         std::exit(1);
     }
-}
-
-template <std::size_t N>
-auto pop_n(std::vector<std::byte>& vec) -> void
-{
-    vec.resize(vec.size() - N);
-}
-
-auto push_u64(std::vector<std::byte>& mem, std::uint64_t value) -> void
-{
-    for (const auto& b : std::bit_cast<std::array<std::byte, SIZE64>>(value)) {
-        mem.push_back(b);
-    }
-}
-
-auto pop_u64(std::vector<std::byte>& mem) -> std::uint64_t
-{
-    auto ret = std::uint64_t{};
-    std::memcpy(&ret, mem.data() + mem.size() - SIZE64, SIZE64);
-    pop_n<SIZE64>(mem);
-    return ret;
-}
-
-auto write_u64(std::vector<std::byte>& mem, std::size_t ptr, std::uint64_t value) -> void
-{
-    std::memcpy(&mem[ptr], &value, SIZE64);
-}
-
-auto read_u64(std::vector<std::byte>& mem, std::size_t ptr) -> std::uint64_t
-{
-    auto ret = std::uint64_t{};
-    std::memcpy(&ret, &mem[ptr], SIZE64);
-    return ret;
 }
 
 auto apply_op(runtime_context& ctx, const op& op_code) -> void

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -9,6 +9,8 @@
 
 namespace anzu {
 
+static constexpr auto SIZE64 = sizeof(std::uint64_t);
+
 template <typename ...Args>
 auto runtime_assert(bool condition, std::string_view msg, Args&&... args)
 {
@@ -18,6 +20,12 @@ auto runtime_assert(bool condition, std::string_view msg, Args&&... args)
     }
 }
 
+template <std::size_t N>
+auto pop_n(std::vector<std::byte>& vec) -> void
+{
+    vec.resize(vec.size() - N);
+}
+
 auto pop_back(std::vector<std::byte>& vec) -> std::byte
 {
     const auto back = vec.back();
@@ -25,39 +33,31 @@ auto pop_back(std::vector<std::byte>& vec) -> std::byte
     return back;   
 }
 
-auto push_u64(runtime_context& ctx, std::uint64_t value) -> void
+auto push_u64(std::vector<std::byte>& mem, std::uint64_t value) -> void
 {
-    for (const auto& b : std::bit_cast<std::array<std::byte, sizeof(std::uint64_t)>>(value)) {
-        ctx.memory.push_back(b);
+    for (const auto& b : std::bit_cast<std::array<std::byte, SIZE64>>(value)) {
+        mem.push_back(b);
     }
 }
 
-auto pop_u64(runtime_context& ctx) -> std::uint64_t
+auto pop_u64(std::vector<std::byte>& mem) -> std::uint64_t
 {
-    auto bytes = std::array<std::byte, sizeof(std::uint64_t)>{};
-    for (std::size_t i = 0; i != sizeof(std::uint64_t); ++i) {
-        bytes[i] = ctx.memory[ctx.memory.size() - sizeof(std::uint64_t) + i];
-    }
-    for (std::size_t i = 0; i != sizeof(std::uint64_t); ++i) {
-        ctx.memory.pop_back();
-    }
+    auto bytes = std::array<std::byte, SIZE64>{};
+    std::memcpy(bytes.data(), mem.data() + mem.size() - SIZE64, SIZE64);
+    pop_n<SIZE64>(mem);
     return std::bit_cast<std::uint64_t>(bytes);
 }
 
-auto write_u64(runtime_context& ctx, std::size_t ptr, std::uint64_t value) -> void
+auto write_u64(std::vector<std::byte>& mem, std::size_t ptr, std::uint64_t value) -> void
 {
-    auto bytes = to_bytes(value);
-    for (std::size_t i = 0; i != sizeof(std::uint64_t); ++i) {
-        ctx.memory[ptr + i] = bytes[i]; 
-    }
+    const auto bytes = std::bit_cast<std::array<std::byte, SIZE64>>(value);
+    std::memcpy(mem.data() + ptr, bytes.data(), SIZE64);
 }
 
-auto read_u64(runtime_context& ctx, std::size_t ptr) -> std::uint64_t
+auto read_u64(std::vector<std::byte>& mem, std::size_t ptr) -> std::uint64_t
 {
-    auto bytes = std::array<std::byte, sizeof(std::uint64_t)>{};
-    for (std::size_t i = 0; i != sizeof(std::uint64_t); ++i) {
-        bytes[i] = ctx.memory[ptr + i];
-    }
+    auto bytes = std::array<std::byte, SIZE64>{};
+    std::memcpy(bytes.data(), mem.data() + ptr, SIZE64);
     return std::bit_cast<std::uint64_t>(bytes);
 }
 
@@ -69,35 +69,35 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ++ctx.prog_ptr;
         },
         [&](const op_push_global_addr& op) {
-            push_u64(ctx, op.position);
-            push_u64(ctx, op.size);
+            push_u64(ctx.memory, op.position);
+            push_u64(ctx.memory, op.size);
             ++ctx.prog_ptr;
         },
         [&](const op_push_local_addr& op) {
-            push_u64(ctx, ctx.base_ptr + op.offset);
-            push_u64(ctx, op.size);
+            push_u64(ctx.memory, ctx.base_ptr + op.offset);
+            push_u64(ctx.memory, op.size);
             ++ctx.prog_ptr;
         },
         [&](op_modify_ptr) {
-            const auto new_size = pop_u64(ctx);
-            const auto offset = pop_u64(ctx);
-            pop_u64(ctx); // Old size
-            const auto ptr = pop_u64(ctx);
-            push_u64(ctx, ptr + offset);
-            push_u64(ctx, new_size);
+            const auto new_size = pop_u64(ctx.memory);
+            const auto offset = pop_u64(ctx.memory);
+            pop_u64(ctx.memory); // Old size
+            const auto ptr = pop_u64(ctx.memory);
+            push_u64(ctx.memory, ptr + offset);
+            push_u64(ctx.memory, new_size);
             ++ctx.prog_ptr;
         },
         [&](op_load) {
-            const auto size = pop_u64(ctx);
-            const auto ptr = pop_u64(ctx);
+            const auto size = pop_u64(ctx.memory);
+            const auto ptr = pop_u64(ctx.memory);
             for (std::size_t i = 0; i != size; ++i) {
                 ctx.memory.push_back(ctx.memory[ptr + i]);
             }
             ++ctx.prog_ptr;
         },
         [&](op_save) {
-            const auto size = pop_u64(ctx);
-            const auto ptr = pop_u64(ctx);
+            const auto size = pop_u64(ctx.memory);
+            const auto ptr = pop_u64(ctx.memory);
             runtime_assert(ptr + size <= ctx.memory.size(), "tried to access invalid memory address {}", ptr);
             if (ptr + size < ctx.memory.size()) {
                 for (const auto i : std::views::iota(ptr, ptr + size) | std::views::reverse) {
@@ -145,9 +145,9 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             ctx.prog_ptr = op.jump;
         },
         [&](op_return) {
-            const auto prev_base_ptr = read_u64(ctx, ctx.base_ptr);
-            const auto prev_prog_ptr = read_u64(ctx, ctx.base_ptr + sizeof(std::uint64_t));
-            const auto return_size = read_u64(ctx, ctx.base_ptr + 2*sizeof(std::uint64_t));
+            const auto prev_base_ptr = read_u64(ctx.memory, ctx.base_ptr);
+            const auto prev_prog_ptr = read_u64(ctx.memory, ctx.base_ptr + sizeof(std::uint64_t));
+            const auto return_size = read_u64(ctx.memory, ctx.base_ptr + 2*sizeof(std::uint64_t));
             
             for (std::size_t i = 0; i != return_size; ++i) {
                 ctx.memory[ctx.base_ptr + i] = ctx.memory[ctx.memory.size() - return_size + i];
@@ -163,8 +163,8 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             // the function. Note that the return size is stored at new_base_ptr + 2 but and has
             // already been written in.
             const auto new_base_ptr = ctx.memory.size() - op.args_size;
-            write_u64(ctx, new_base_ptr, ctx.base_ptr);
-            write_u64(ctx, new_base_ptr + sizeof(std::uint64_t), ctx.prog_ptr + 1); // Pos after function call
+            write_u64(ctx.memory, new_base_ptr, ctx.base_ptr);
+            write_u64(ctx.memory, new_base_ptr + sizeof(std::uint64_t), ctx.prog_ptr + 1); // Pos after function call
             
             ctx.base_ptr = new_base_ptr;
             ctx.prog_ptr = op.ptr; // Jump into the function

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -35,30 +35,31 @@ auto push_u64(std::vector<std::byte>& mem, std::uint64_t value) -> void
 
 auto pop_u64(std::vector<std::byte>& mem) -> std::uint64_t
 {
-    auto bytes = std::array<std::byte, SIZE64>{};
-    std::memcpy(bytes.data(), mem.data() + mem.size() - SIZE64, SIZE64);
+    auto ret = std::uint64_t{};
+    std::memcpy(&ret, mem.data() + mem.size() - SIZE64, SIZE64);
     pop_n<SIZE64>(mem);
-    return std::bit_cast<std::uint64_t>(bytes);
+    return ret;
 }
 
 auto write_u64(std::vector<std::byte>& mem, std::size_t ptr, std::uint64_t value) -> void
 {
-    const auto bytes = std::bit_cast<std::array<std::byte, SIZE64>>(value);
-    std::memcpy(mem.data() + ptr, bytes.data(), SIZE64);
+    std::memcpy(&mem[ptr], &value, SIZE64);
 }
 
 auto read_u64(std::vector<std::byte>& mem, std::size_t ptr) -> std::uint64_t
 {
-    auto bytes = std::array<std::byte, SIZE64>{};
-    std::memcpy(bytes.data(), mem.data() + ptr, SIZE64);
-    return std::bit_cast<std::uint64_t>(bytes);
+    auto ret = std::uint64_t{};
+    std::memcpy(&ret, &mem[ptr], SIZE64);
+    return ret;
 }
 
 auto apply_op(runtime_context& ctx, const op& op_code) -> void
 {
     std::visit(overloaded {
-        [&](const op_load_literal& op) {
-            ctx.memory.push_back(op.blk);
+        [&](const op_load_bytes& op) {
+            for (const auto byte : op.bytes) {
+                ctx.memory.push_back(byte);
+            }
             ++ctx.prog_ptr;
         },
         [&](const op_push_global_addr& op) {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -26,13 +26,6 @@ auto pop_n(std::vector<std::byte>& vec) -> void
     vec.resize(vec.size() - N);
 }
 
-auto pop_back(std::vector<std::byte>& vec) -> std::byte
-{
-    const auto back = vec.back();
-    vec.pop_back();
-    return back;   
-}
-
 auto push_u64(std::vector<std::byte>& mem, std::uint64_t value) -> void
 {
     for (const auto& b : std::bit_cast<std::array<std::byte, SIZE64>>(value)) {
@@ -101,7 +94,8 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             runtime_assert(ptr + size <= ctx.memory.size(), "tried to access invalid memory address {}", ptr);
             if (ptr + size < ctx.memory.size()) {
                 for (const auto i : std::views::iota(ptr, ptr + size) | std::views::reverse) {
-                    ctx.memory[i] = pop_back(ctx.memory);
+                    ctx.memory[i] = ctx.memory.back();
+                    ctx.memory.pop_back();
                 }
             }
             ++ctx.prog_ptr;
@@ -172,7 +166,8 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
         [&](const op_builtin_call& op) {
             auto args = std::vector<std::byte>(op.args_size);
             for (auto& arg : args | std::views::reverse) {
-                arg = pop_back(ctx.memory);
+                arg = ctx.memory.back();
+                ctx.memory.pop_back();
             }
 
             const auto ret = op.ptr(args);

--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -1,8 +1,8 @@
 #pragma once
-#include "object.hpp"
 #include "program.hpp"
 
 #include <vector>
+#include <utility>
 
 namespace anzu {
 
@@ -10,7 +10,7 @@ struct runtime_context
 {
     std::size_t prog_ptr = 0;
     std::size_t base_ptr = 0;
-    std::vector<block> memory;
+    std::vector<std::byte> memory;
 };
 
 auto run_program(const program& prog) -> void;

--- a/src/utility/memory.hpp
+++ b/src/utility/memory.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include <array>
+#include <vector>
+#include <utility>
+#include <cstdint>
+#include <cstring>
+
+namespace anzu {
+
+inline static constexpr auto SIZE64 = sizeof(std::uint64_t);
+
+template <std::size_t N>
+auto pop_n(std::vector<std::byte>& vec) -> void
+{
+    vec.resize(vec.size() - N);
+}
+
+auto push_u64(std::vector<std::byte>& mem, std::uint64_t value) -> void
+{
+    for (const auto& b : std::bit_cast<std::array<std::byte, SIZE64>>(value)) {
+        mem.push_back(b);
+    }
+}
+
+auto pop_u64(std::vector<std::byte>& mem) -> std::uint64_t
+{
+    auto ret = std::uint64_t{};
+    std::memcpy(&ret, mem.data() + mem.size() - SIZE64, SIZE64);
+    pop_n<SIZE64>(mem);
+    return ret;
+}
+
+auto write_u64(std::vector<std::byte>& mem, std::size_t ptr, std::uint64_t value) -> void
+{
+    std::memcpy(&mem[ptr], &value, SIZE64);
+}
+
+auto read_u64(std::vector<std::byte>& mem, std::size_t ptr) -> std::uint64_t
+{
+    auto ret = std::uint64_t{};
+    std::memcpy(&ret, &mem[ptr], SIZE64);
+    return ret;
+}
+
+}

--- a/src/utility/memory.hpp
+++ b/src/utility/memory.hpp
@@ -7,38 +7,39 @@
 
 namespace anzu {
 
-inline static constexpr auto SIZE64 = sizeof(std::uint64_t);
-
-template <std::size_t N>
-auto pop_n(std::vector<std::byte>& vec) -> void
+inline auto pop_n(std::vector<std::byte>& vec, std::size_t count) -> void
 {
-    vec.resize(vec.size() - N);
+    vec.resize(vec.size() - count);
 }
 
-auto push_u64(std::vector<std::byte>& mem, std::uint64_t value) -> void
+template <typename T>
+auto push_value(std::vector<std::byte>& mem, const T& value) -> void
 {
-    for (const auto& b : std::bit_cast<std::array<std::byte, SIZE64>>(value)) {
+    for (const auto& b : as_bytes(value)) {
         mem.push_back(b);
     }
 }
 
-auto pop_u64(std::vector<std::byte>& mem) -> std::uint64_t
+template <typename T>
+auto pop_value(std::vector<std::byte>& mem) -> T
 {
-    auto ret = std::uint64_t{};
-    std::memcpy(&ret, mem.data() + mem.size() - SIZE64, SIZE64);
-    pop_n<SIZE64>(mem);
+    auto ret = T{};
+    std::memcpy(&ret, &mem[mem.size() - sizeof(T)], sizeof(T));
+    mem.resize(mem.size() - sizeof(T));
     return ret;
 }
 
-auto write_u64(std::vector<std::byte>& mem, std::size_t ptr, std::uint64_t value) -> void
+template <typename T>
+auto write_value(std::vector<std::byte>& mem, std::size_t ptr, const T& value) -> void
 {
-    std::memcpy(&mem[ptr], &value, SIZE64);
+    std::memcpy(&mem[ptr], &value, sizeof(T));
 }
 
-auto read_u64(std::vector<std::byte>& mem, std::size_t ptr) -> std::uint64_t
+template <typename T>
+auto read_value(std::vector<std::byte>& mem, std::size_t ptr) -> T
 {
-    auto ret = std::uint64_t{};
-    std::memcpy(&ret, &mem[ptr], SIZE64);
+    auto ret = T{};
+    std::memcpy(&ret, &mem[ptr], sizeof(T));
     return ret;
 }
 


### PR DESCRIPTION
* No more block variant, data is represented in the runtime as `std::byte`.
* Refactored builtin functions and bin op resolutions.
* Builtin functions are now the same a mem op functions to reduce the number of redundant allocations.
* Replace `op_load_literal` with `op_load_bytes`.
* The runtime now just stores two `uint64_t`s and a `std::vector<std::byte>`.