### PR TITLE
Slim Pointers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/test.az", "run"],
+            "args": ["${workspaceFolder}/examples/feature_test.az", "run"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/examples/test.az
+++ b/examples/test.az
@@ -13,8 +13,18 @@ fn println(v: vec2) -> null
     println("}")
 }
 
+l := [vec2(1, 2), vec2(3, 4), vec2(5, 6)]
 
-l := [vec2(1, 2), vec2(3, 4)]
 p := &l[0u]
+size := size_of(l) / size_of(l[0])
+idx := 0u
 
+while idx != size {
+    println(*(p + idx))
+    println(idx)
+    idx = idx + 1u
+}
+
+println(*(p + 0u))
 println(*(p + 1u))
+println(*(p + 2u))

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -208,14 +208,14 @@ auto save_variable(compiler& com, const token& tok, const std::string& name) -> 
 {
     const auto type = find_variable(com, tok, name);
     const auto size = com.types.size_of(type);
-    com.program.emplace_back(anzu::op_save{ .count=size });
+    com.program.emplace_back(anzu::op_save{ .size=size });
 }
 
 auto load_variable(compiler& com, const token& tok, const std::string& name) -> void
 {
     const auto type = find_variable(com, tok, name);
     const auto size = com.types.size_of(type);
-    com.program.emplace_back(anzu::op_load{ .count=size });
+    com.program.emplace_back(anzu::op_load{ .size=size });
 }
 
 auto signature_args_size(const compiler& com, const signature& sig) -> std::size_t
@@ -661,7 +661,7 @@ auto compile_expr_val(compiler& com, const auto& node) -> type_name
 {
     const auto type = compile_expr_ptr(com, node);
     const auto size = com.types.size_of(type);
-    com.program.emplace_back(op_load{ .count=size });
+    com.program.emplace_back(op_load{ .size=size });
     return type;
 }
 
@@ -758,7 +758,7 @@ void compile_stmt(compiler& com, const node_assignment_stmt& node)
     const auto lhs = compile_expr_ptr(com, *node.position);
     const auto size = com.types.size_of(lhs);
     compiler_assert(lhs == rhs, node.token, "cannot assign a {} to a {}\n", rhs, lhs);
-    com.program.emplace_back(op_save{ .count=size });
+    com.program.emplace_back(op_save{ .size=size });
 }
 
 void compile_stmt(compiler& com, const node_function_def_stmt& node)
@@ -871,7 +871,7 @@ void compile_stmt(compiler& com, const node_return_stmt& node)
 void compile_stmt(compiler& com, const node_expression_stmt& node)
 {
     const auto type = compile_expr_val(com, *node.expr);
-    com.program.emplace_back(anzu::op_pop{ .count=com.types.size_of(type) });
+    com.program.emplace_back(anzu::op_pop{ .size=com.types.size_of(type) });
 }
 
 auto compile_expr_val(compiler& com, const node_expr& expr) -> type_name

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -210,14 +210,16 @@ auto find_variable(compiler& com, const token& tok, const std::string& name) -> 
 
 auto save_variable(compiler& com, const token& tok, const std::string& name) -> void
 {
-    find_variable(com, tok, name);
-    com.program.emplace_back(anzu::op_save{});
+    const auto type = find_variable(com, tok, name);
+    const auto size = com.types.size_of(type);
+    com.program.emplace_back(anzu::op_save{ .count=size });
 }
 
 auto load_variable(compiler& com, const token& tok, const std::string& name) -> void
 {
-    find_variable(com, tok, name);
-    com.program.emplace_back(anzu::op_load{});
+    const auto type = find_variable(com, tok, name);
+    const auto size = com.types.size_of(type);
+    com.program.emplace_back(anzu::op_load{ .count=size });
 }
 
 auto signature_args_size(const compiler& com, const signature& sig) -> std::size_t
@@ -229,13 +231,6 @@ auto signature_args_size(const compiler& com, const signature& sig) -> std::size
         args_size += com.types.size_of(arg.type);
     }
     return args_size;
-}
-
-auto modify_ptr(compiler& com, std::size_t offset, std::size_t size) -> void
-{
-    push_literal(com, offset);
-    push_literal(com, size);
-    com.program.emplace_back(op_modify_ptr{});
 }
 
 // Given a type and field name, and assuming that the top of the stack at runtime is a pointer
@@ -260,7 +255,8 @@ auto compile_ptr_to_field(
     }
     
     compiler_assert(size != 0, tok, "type {} has no field '{}'\n", type, field_name);
-    modify_ptr(com, offset, size);
+    push_literal(com, offset);
+    com.program.emplace_back(op_modify_ptr{});
     return field_type;
 }
 
@@ -342,7 +338,7 @@ auto type_of_expr(const compiler& com, const node_expr& node) -> type_name
                 .lhs=type_of_expr(com, *expr.lhs),
                 .rhs=type_of_expr(com, *expr.rhs)
             };
-            const auto r = resolve_binary_op(desc);
+            const auto r = resolve_binary_op(com.types, desc);
             if (!r.has_value()) {
                 compiler_error(
                     expr.token, "could not find op '{} {} {}'",
@@ -473,14 +469,12 @@ auto compile_expr_ptr(compiler& com, const node_subscript_expr& expr) -> type_na
     compiler_assert(itype == u64_type(), expr.token, "subscript argument must be a 'u64', got '{}'", itype);
 
     push_literal(com, etype_size);
-    const auto info = resolve_binary_op({ .op="*", .lhs=itype, .rhs=itype });
+    const auto info = resolve_binary_op(com.types, { .op="*", .lhs=itype, .rhs=itype });
     com.program.emplace_back(op_builtin_mem_op{
         .name = "uint * uint",
         .ptr = info->operator_func
     });
 
-    // Push the size
-    push_literal(com, etype_size);
     com.program.emplace_back(op_modify_ptr{});
     return etype;
 }
@@ -507,7 +501,7 @@ auto compile_expr_val(compiler& com, const node_binary_op_expr& node) -> type_na
     const auto rhs = compile_expr_val(com, *node.rhs);
     const auto op = node.token.text;
 
-    const auto info = resolve_binary_op({ .op=op, .lhs=lhs, .rhs=rhs });
+    const auto info = resolve_binary_op(com.types, { .op=op, .lhs=lhs, .rhs=rhs });
     compiler_assert(info.has_value(), node.token, "could not evaluate '{} {} {}'", lhs, op, rhs);
 
     com.program.emplace_back(op_builtin_mem_op{
@@ -670,7 +664,8 @@ auto compile_expr_val(compiler& com, const node_sizeof_expr& node) -> type_name
 auto compile_expr_val(compiler& com, const auto& node) -> type_name
 {
     const auto type = compile_expr_ptr(com, node);
-    com.program.emplace_back(op_load{});
+    const auto size = com.types.size_of(type);
+    com.program.emplace_back(op_load{ .count=size });
     return type;
 }
 
@@ -765,8 +760,9 @@ void compile_stmt(compiler& com, const node_assignment_stmt& node)
 {
     const auto rhs = compile_expr_val(com, *node.expr);
     const auto lhs = compile_expr_ptr(com, *node.position);
+    const auto size = com.types.size_of(lhs);
     compiler_assert(lhs == rhs, node.token, "cannot assign a {} to a {}\n", rhs, lhs);
-    com.program.emplace_back(op_save{});
+    com.program.emplace_back(op_save{ .count=size });
 }
 
 void compile_stmt(compiler& com, const node_function_def_stmt& node)
@@ -879,7 +875,7 @@ void compile_stmt(compiler& com, const node_return_stmt& node)
 void compile_stmt(compiler& com, const node_expression_stmt& node)
 {
     const auto type = compile_expr_val(com, *node.expr);
-    com.program.emplace_back(anzu::op_pop{ .size=com.types.size_of(type) });
+    com.program.emplace_back(anzu::op_pop{ .count=com.types.size_of(type) });
 }
 
 auto compile_expr_val(compiler& com, const node_expr& expr) -> type_name

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -190,18 +190,14 @@ auto find_variable(compiler& com, const token& tok, const std::string& name) -> 
     if (com.current_func) {
         auto& locals = com.current_func->vars;
         if (const auto info = locals.find(name); info.has_value()) {
-            com.program.emplace_back(op_push_local_addr{
-                .offset=info->location, .size=info->type_size
-            });
+            com.program.emplace_back(op_push_local_addr{ .offset=info->location });
             return info->type;
         }
     }
 
     auto& globals = com.globals;
     if (const auto info = globals.find(name); info.has_value()) {
-        com.program.emplace_back(op_push_global_addr{
-            .position=info->location, .size=info->type_size
-        });
+        com.program.emplace_back(op_push_global_addr{ .position=info->location });
         return info->type;
     }
 

--- a/src/operators.hpp
+++ b/src/operators.hpp
@@ -23,7 +23,9 @@ struct binary_op_info
     type_name      result_type;
 };
 
-auto resolve_binary_op(const binary_op_description& desc) -> std::optional<binary_op_info>;
+auto resolve_binary_op(
+    const type_store& types, const binary_op_description& desc
+) -> std::optional<binary_op_info>;
 
 struct unary_op_description
 {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -19,10 +19,10 @@ auto to_string(const op& op_code) -> std::string
             return std::format("LOAD_BYTES({})", format_comma_separated(op.bytes));
         },
         [&](const op_push_global_addr& op) {
-            return std::format("PUSH_GLOBAL_ADDR({}, {})", op.position, op.size);
+            return std::format("PUSH_GLOBAL_ADDR({})", op.position);
         },
         [&](const op_push_local_addr& op) {
-            return std::format("PUSH_LOCAL_ADDR(+{}, {})", op.offset, op.size);
+            return std::format("PUSH_LOCAL_ADDR(+{})", op.offset);
         },
         [&](const op_modify_ptr& op) {
             return std::string{"MODIFY_PTR"};

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -28,13 +28,13 @@ auto to_string(const op& op_code) -> std::string
             return std::string{"MODIFY_PTR"};
         },
         [&](const op_load& op) {
-            return std::format("LOAD({})", op.count);
+            return std::format("LOAD({})", op.size);
         },
         [&](const op_save& op) {
-            return std::format("SAVE({})", op.count);
+            return std::format("SAVE({})", op.size);
         },
         [&](const op_pop& op) {
-            return std::format("POP({})", op.count);
+            return std::format("POP({})", op.size);
         },
         [&](const op_if& op) {
             return std::string{"IF"};

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -27,14 +27,14 @@ auto to_string(const op& op_code) -> std::string
         [&](const op_modify_ptr& op) {
             return std::string{"MODIFY_PTR"};
         },
-        [&](const op_load&) {
-            return std::string{"LOAD"};
+        [&](const op_load& op) {
+            return std::format("LOAD({})", op.count);
         },
         [&](const op_save& op) {
-            return std::string{"SAVE"};
+            return std::format("SAVE({})", op.count);
         },
         [&](const op_pop& op) {
-            return std::format("POP({})", op.size);
+            return std::format("POP({})", op.count);
         },
         [&](const op_if& op) {
             return std::string{"IF"};

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -20,13 +20,11 @@ struct op_load_bytes
 struct op_push_global_addr
 {
     std::size_t position;
-    std::size_t size;
 };
 
 struct op_push_local_addr
 {
     std::size_t offset;
-    std::size_t size;
 };
 
 struct op_modify_ptr

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -35,15 +35,17 @@ struct op_modify_ptr
 
 struct op_load
 {
+    std::size_t count;
 };
 
 struct op_save
 {
+    std::size_t count;
 };
 
 struct op_pop
 {
-    std::size_t size;
+    std::size_t count;
 };
 
 struct op_if

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -27,23 +27,24 @@ struct op_push_local_addr
     std::size_t offset;
 };
 
+// This is just integer addition now
 struct op_modify_ptr
 {
 };
 
 struct op_load
 {
-    std::size_t count;
+    std::size_t size;
 };
 
 struct op_save
 {
-    std::size_t count;
+    std::size_t size;
 };
 
 struct op_pop
 {
-    std::size_t count;
+    std::size_t size;
 };
 
 struct op_if

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -28,11 +28,11 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
             }
             ++ctx.prog_ptr;
         },
-        [&](const op_push_global_addr& op) {
+        [&](op_push_global_addr op) {
             push_value(ctx.memory, op.position);
             ++ctx.prog_ptr;
         },
-        [&](const op_push_local_addr& op) {
+        [&](op_push_local_addr op) {
             push_value(ctx.memory, ctx.base_ptr + op.offset);
             ++ctx.prog_ptr;
         },

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -52,7 +52,10 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
         [&](op_save op) {
             const auto ptr = pop_value<std::uint64_t>(ctx.memory);
             runtime_assert(ptr + op.size <= ctx.memory.size(), "tried to access invalid memory address {}", ptr);
-            std::memcpy(&ctx.memory[ptr], &ctx.memory[ctx.memory.size() - op.size], op.size);
+            if (ptr + op.size < ctx.memory.size()) {
+                std::memcpy(&ctx.memory[ptr], &ctx.memory[ctx.memory.size() - op.size], op.size);
+                ctx.memory.resize(ctx.memory.size() - op.size);
+            }
             ++ctx.prog_ptr;
         },
         [&](op_pop op) {

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -183,7 +183,7 @@ auto type_store::size_of(const type_name& type) const -> std::size_t
     }
 
     if (is_ptr_type(type)) {
-        return 16; // Two unsigned ints, ptr and size
+        return 8; // Two unsigned ints, ptr and size
     }
 
     if (type == i32_type()) {


### PR DESCRIPTION
* Until now, anzu has had "fat" pointers, which store a size as well as a location. This is actually an overcomplication since all types are known at compile time and so sizes are known.
* The sizes are now stored in the `op_save`, `op_load` and `op_pop` op codes, and pointers are just locations now.
* This simplifies a few things, for example, `op_modify_ptr` just modifies the location of the pointer, the size of the type does not have to be considered at all. This works because when we eventually make use of it to load or save, the size is already in the op code.
* Sadly, the pointer addition operation requires us to pass the type store again since we cannot fetch the size from the stack.