### PR TITLE
Destructors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/src/Debug/anzu.exe",
-            "args": ["${workspaceFolder}/examples/vector.az", "run"],
+            "args": ["${workspaceFolder}/examples/test.az", "run"],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,10 +1,10 @@
 
-while true {
-    x := 5;
-    {
-        y := 6;
-    }
-    z := 7;
-    break;
-    u := 6;
+fn foo() -> null
+{
+    x := 6;
+    return; 
+    y := 8;
 }
+
+foo();
+foo();

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,10 +1,35 @@
 
-fn foo() -> null
+struct managed_int
 {
-    x := 6;
-    return; 
-    y := 8;
+    val: &i64;
+
+    fn move(self: &managed_int, other: &managed_int) -> null
+    {
+
+    }
+
+    fn copy(self: &managed_int, other: &managed_int) -> null
+    {
+
+    }
+
+    fn drop(self: &managed_int) -> null
+    {
+        println("deleting int");
+        delete self->val;
+    }
 }
 
-foo();
-foo();
+fn make_int(val: i64) -> managed_int
+{
+    ret := managed_int(new i64);
+    *(ret.val) = val;
+    return ret;
+}
+
+{
+    f := make_int(6);
+    println("here i am");
+}
+
+println("end");

--- a/examples/test.az
+++ b/examples/test.az
@@ -3,16 +3,6 @@ struct managed_int
 {
     val: &i64;
 
-    fn move(self: &managed_int, other: &managed_int) -> null
-    {
-
-    }
-
-    fn copy(self: &managed_int, other: &managed_int) -> null
-    {
-
-    }
-
     fn drop(self: &managed_int) -> null
     {
         println("deleting int");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,22 +1,5 @@
 
-num := 0;
-while num < 10 {
-    v := 5;
-    num = num + 1;
-    {
-        println("start inner scope");
-        b := 6;
-        if num > 3 {
-            println("breaking");
-            break;
-        }
-        c := 0;
-        println("end inner scope");
-    }
-
-    g := 5;
-    println("end of loop");
+while true {
+    x := 5;
+    continue;
 }
-
-
-# jj, g, y, x, h, t

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,8 @@
 
-x := new i64;
-*(x + 0u) = 5;
-
-println(*x);
+println("before scope");
+{
+    x := 5;
+    y := true;
+    println("in scope");
+}
+println("after scope");

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,5 +1,10 @@
 
 while true {
     x := 5;
-    continue;
+    {
+        y := 6;
+    }
+    z := 7;
+    break;
+    u := 6;
 }

--- a/examples/test.az
+++ b/examples/test.az
@@ -5,7 +5,8 @@ struct managed_int
 
     fn drop(self: &managed_int) -> null
     {
-        println("deleting int");
+        print("deleting int: ");
+        println(*(self->val));
         delete self->val;
     }
 }
@@ -18,7 +19,10 @@ fn make_int(val: i64) -> managed_int
 }
 
 {
-    f := make_int(6);
+    b := "hello";
+    a := 1;
+    f := make_int(60);
+    c := 5;
     println("here i am");
 }
 

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,4 +1,5 @@
 
+t := 1;
 println("before scope");
 {
     x := 5;
@@ -6,3 +7,4 @@ println("before scope");
     println("in scope");
 }
 println("after scope");
+h := 2;

--- a/examples/test.az
+++ b/examples/test.az
@@ -1,10 +1,22 @@
 
-t := 1;
-println("before scope");
-{
-    x := 5;
-    y := true;
-    println("in scope");
+num := 0;
+while num < 10 {
+    v := 5;
+    num = num + 1;
+    {
+        println("start inner scope");
+        b := 6;
+        if num > 3 {
+            println("breaking");
+            break;
+        }
+        c := 0;
+        println("end inner scope");
+    }
+
+    g := 5;
+    println("end of loop");
 }
-println("after scope");
-h := 2;
+
+
+# jj, g, y, x, h, t

--- a/examples/vector.az
+++ b/examples/vector.az
@@ -49,19 +49,17 @@ struct vector
     {
         return self->capacity;
     }
+
+    fn drop(self: &vector) -> null
+    {
+        delete self->data;
+    }
 }
 
 fn new_vector() -> vector
 {
     # We don't have nullptr yet, so we must allocate some space here for now
     return vector(new i64, 0u, 1u);
-}
-
-fn delete_vector(v: vector) -> null
-{
-    delete v.data;
-    v.size = 0u;
-    v.capacity = 0u;
 }
 
 v := new_vector();
@@ -73,5 +71,3 @@ v.push(8);
 println(v.pop());
 println(v.pop());
 println(v.pop());
-
-delete_vector(v);

--- a/examples/vector.az
+++ b/examples/vector.az
@@ -68,6 +68,8 @@ v.push(4);
 v.push(7);
 v.push(8);
 
-println(v.pop());
-println(v.pop());
-println(v.pop());
+idx := 0u;
+while idx != v.size() {
+    println(v.at(idx));
+    idx = idx + 1u;
+}

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -330,12 +330,11 @@ auto call_destructor(compiler& com, const std::string& var, const type_name& typ
     func_key.args = { concrete_ptr_type(type) };
     if (auto it = com.functions.find(func_key); it != com.functions.end()) {
         const auto& [sig, ptr] = it->second;
-        com.program.emplace_back(op_debug{std::format("destructing {}: {}\n", var, type)});
 
         // Push the args to the stack
         push_literal(com, std::uint64_t{0}); // base ptr
         push_literal(com, std::uint64_t{0}); // prog ptr
-        push_literal(com, std::uint64_t{0}); // TODO: PUSH POINTER TO INSTANCE
+        push_var_addr(com, token{}, var);
 
         com.program.emplace_back(op_function_call{
             .name=destructor_name,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -198,7 +198,9 @@ auto append_op(compiler& com, T&& op) -> std::size_t
 // Registers the given name in the current scope
 void declare_var(compiler& com, const token& tok, const std::string& name, const type_name& type)
 {
-    current_vars(com).declare(name, type, com.types.size_of(type));
+    if (!current_vars(com).declare(name, type, com.types.size_of(type))) {
+        compiler_error(tok, "name already in use: '{}'", name);
+    }
 }
 
 auto get_var_type(const compiler& com, const token& tok, const std::string& name) -> type_name

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -673,7 +673,9 @@ void compile_stmt(compiler& com, const node_sequence_stmt& node)
         compile_stmt(com, *seq_node);
     }
     const auto scope_size = current_vars(com).pop_scope();
-    com.program.emplace_back(op_pop{scope_size});
+    if (scope_size > 0) {
+        com.program.emplace_back(op_pop{scope_size});
+    }
 }
 
 void compile_stmt(compiler& com, const node_while_stmt& node)
@@ -703,7 +705,9 @@ void compile_stmt(compiler& com, const node_while_stmt& node)
     com.control_flow.pop();
 
     const auto scope_size = current_vars(com).pop_scope();
-    com.program.emplace_back(op_pop{scope_size});
+    if (scope_size > 0) {
+        com.program.emplace_back(op_pop{scope_size});
+    }
 }
 
 void compile_stmt(compiler& com, const node_if_stmt& node)
@@ -817,7 +821,6 @@ void compile_stmt(compiler& com, const node_function_def_stmt& node)
         compiler_error(node.token, "'{}' cannot be a function name, it is a type def", node.name);
     }
     com.function_names.insert(node.name);
-
     compile_function_body(com, node.token, node.name, node.sig, node.body);
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -682,7 +682,9 @@ void compile_stmt(compiler& com, const node_sequence_stmt& node)
     {
         auto& scope = current_vars(com).current_scope();
         for (const auto& [name, info] : scope.vars | std::views::reverse) {
-            
+            com.program.emplace_back(op_debug{
+                .message = std::format("destructing {}: {}\n", name, info.type)
+            });
         }
     }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -99,6 +99,11 @@ public:
         d_next -= scope_size;
         return scope_size;
     }
+
+    auto current_scope() -> var_scope&
+    {
+        return d_scopes.back();
+    }
 };
 
 struct function_key
@@ -672,6 +677,16 @@ void compile_stmt(compiler& com, const node_sequence_stmt& node)
     for (const auto& seq_node : node.sequence) {
         compile_stmt(com, *seq_node);
     }
+
+    // First, destruct all variables in the current scope
+    {
+        auto& scope = current_vars(com).current_scope();
+        for (const auto& [name, info] : scope.vars | std::views::reverse) {
+            
+        }
+    }
+
+    // Then, clean up the memory
     const auto scope_size = current_vars(com).pop_scope();
     if (scope_size > 0) {
         com.program.emplace_back(op_pop{scope_size});

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -17,7 +17,7 @@ using line_iterator = peekstream<std::string>;
 
 auto is_int(std::string_view token) -> bool
 {
-    return std::ranges::all_of(token, [](char c) { return std::isdigit(c); });
+    return !token.empty() && std::ranges::all_of(token, [](char c) { return std::isdigit(c); });
 }
 
 auto is_i32(std::string_view token) -> bool

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -63,6 +63,9 @@ auto to_string(const op& op_code) -> std::string
         },
         [&](const op_builtin_call& op) {
             return std::format("BUILTIN_CALL({})", op.name);
+        },
+        [](const op_debug& op) {
+            return std::format("DEBUG({})", op.message);
         }
     }, op_code);
 }

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -91,6 +91,11 @@ struct op_return
     std::size_t size;
 };
 
+struct op_debug
+{
+    std::string message;
+};
+
 struct op : std::variant<
     op_load_bytes,
     op_push_global_addr,
@@ -106,7 +111,8 @@ struct op : std::variant<
     op_function,
     op_return,
     op_function_call,
-    op_builtin_call
+    op_builtin_call,
+    op_debug
 >
 {};
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -153,6 +153,10 @@ auto apply_op(runtime_context& ctx, const op& op_code) -> void
         [&](const op_builtin_call& op) {
             op.ptr(ctx.stack);
             ++ctx.prog_ptr;
+        },
+        [&](const op_debug& op) {
+            print(op.message);
+            ++ctx.prog_ptr;
         }
     }, op_code);
 }


### PR DESCRIPTION
* Almost fully implemented destructors.
* Worked out at compile time which objects get destructed at the end of scopes as well as at `break`, `continue` and `return` statements.
* Added scopes around `while` loops when when a `break` or `continue` occurs, we can destruct objects within the scope. Will also make it trivial to allow things like `while (x := 0, x != 10) {}` where the `x` is within the `while` scope but not in the braces scope. Currently the while scope is always empty and only within the scope stack so that we know how far up the stack we need to destruct objects.
* If an class `T` has a function called `drop`, it is called when the object goes out of scope. The signature must be `(&T) -> null`, however this is not currently checked.
* There will be problems with this when binary operators are allowed for custom types.
* Copying objects can currently cause problems.
* Arrays do not call destructors.
* Member variable destructors are not called.
* Basically there are a load of holes in this system, but it somewhat works.
* Improved the `vector` example to include a destructor.